### PR TITLE
[No reviewer] Don't use timer after it's been deleted

### DIFF
--- a/src/main/timer_handler.cpp
+++ b/src/main/timer_handler.cpp
@@ -63,8 +63,8 @@ void TimerHandler::add_timer(Timer* timer)
 {
   LOG_DEBUG("Adding timer:  %lu", timer->id);
   pthread_mutex_lock(&_mutex);
-  _store->add_timer(timer);
   signal_new_timer(timer->next_pop_time());
+  _store->add_timer(timer);
   pthread_mutex_unlock(&_mutex);
 }
 


### PR DESCRIPTION
Don't try and use the timer after it's been added to the store, as it may have been deleted
