### PR TITLE
[Reviewer: Andy][From: Alex] Fix valgrind errors.

### DIFF
--- a/src/test/test_timer_handler.cpp
+++ b/src/test/test_timer_handler.cpp
@@ -320,6 +320,7 @@ TEST_F(TestTimerHandler, FutureTimerLeakTest)
 
   _th = new TimerHandler(_store, _replicator, _callback);
   _cond()->block_till_waiting();
+  delete timer; timer = NULL;
 }
 
 TEST_F(TestTimerHandler, FutureTimerPop)

--- a/src/test/test_timer_store.cpp
+++ b/src/test/test_timer_store.cpp
@@ -54,6 +54,7 @@ protected:
   // must clear up the timer instances.
   virtual void TearDown()
   {
+    delete ts; ts = NULL;
     cwtest_reset_time();
     Base::TearDown();
   }
@@ -308,10 +309,11 @@ TEST_F(TestTimerStore, ReallyLongTimer)
 
 TEST_F(TestTimerStore, DeleteNearTimer)
 {
+  uint64_t interval = timers[0]->interval;
   ts->add_timer(timers[0]);
   ts->delete_timer(1);
   std::unordered_set<Timer*> next_timers;
-  cwtest_advance_time_ms(timers[0]->interval + TIMER_GRANULARITY_MS);
+  cwtest_advance_time_ms(interval + TIMER_GRANULARITY_MS);
   ts->get_next_timers(next_timers);
   EXPECT_TRUE(next_timers.empty());
   delete timers[1];
@@ -321,10 +323,11 @@ TEST_F(TestTimerStore, DeleteNearTimer)
 
 TEST_F(TestTimerStore, DeleteMidTimer)
 {
+  uint64_t interval = timers[2]->interval;
   ts->add_timer(timers[1]);
   ts->delete_timer(2);
   std::unordered_set<Timer*> next_timers;
-  cwtest_advance_time_ms(timers[1]->interval + TIMER_GRANULARITY_MS);
+  cwtest_advance_time_ms(interval + TIMER_GRANULARITY_MS);
   ts->get_next_timers(next_timers);
   EXPECT_TRUE(next_timers.empty());
   delete timers[0];
@@ -334,9 +337,10 @@ TEST_F(TestTimerStore, DeleteMidTimer)
 
 TEST_F(TestTimerStore, DeleteLongTimer)
 {
+  uint64_t interval = timers[2]->interval;
   ts->add_timer(timers[2]);
   ts->delete_timer(3);
-  cwtest_advance_time_ms(timers[2]->interval + TIMER_GRANULARITY_MS);
+  cwtest_advance_time_ms(interval + TIMER_GRANULARITY_MS);
   std::unordered_set<Timer*> next_timers;
   ts->get_next_timers(next_timers);
   EXPECT_TRUE(next_timers.empty());
@@ -584,6 +588,11 @@ TEST_F(TestTimerStore, MixtureOfTimerLengths)
   ts->get_next_timers(next_timers);
   EXPECT_EQ(3, next_timers.size());
   next_timers.clear();
+
+  delete timers[0];
+  delete timers[1];
+  delete timers[2];
+  delete tombstone;
 }
 
 TEST_F(TestTimerStore, TimerPopsOnTheHour)
@@ -602,4 +611,9 @@ TEST_F(TestTimerStore, TimerPopsOnTheHour)
   ts->get_next_timers(next_timers);
   EXPECT_EQ(1, next_timers.size());
   next_timers.clear();
+
+  delete timers[0];
+  delete timers[1];
+  delete timers[2];
+  delete tombstone;
 }


### PR DESCRIPTION
Andy please can you review some fixes to make chronos tests run cleanly under valgrind (which I didn't spot because `make test` does not use valgrind).
