### PR TITLE
Reviewer Mike - Unlock the store lock when we're popping timers

### DIFF
--- a/src/main/timer_handler.cpp
+++ b/src/main/timer_handler.cpp
@@ -86,7 +86,9 @@ void TimerHandler::run() {
     if (!next_timers.empty())
     {
       LOG_DEBUG("Have a timer to pop");
+      pthread_mutex_unlock(&_mutex);
       pop(next_timers);
+      pthread_mutex_lock(&_mutex);
     }
     else
     {


### PR DESCRIPTION
Mike,

As discussed this helps resolve the deadlocking issues you were seeing in Chronos + Sprout earlier.  Basically, don't hold the store's lock while popping timers (as the pop might take a while is Sprout's running slow).

There's a second piece of work needed to pop the timers asynchronously so we don't fall behind if Sprout is slow but I've not got around to that yet.

Tested with existing UTs.
