### PR TITLE
Change the boost dependencies to get sprout to dynamically link correctly on Ubuntu 14.04.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ CPPFLAGS_BUILD := -O0
 CPPFLAGS_TEST := -O0 -fprofile-arcs -ftest-coverage -DUNITTEST -I${ROOT}/src/test/ -I${ROOT}/modules/cpp-common/test_utils/
 LDFLAGS := -L${INSTALL_DIR}/lib -lrt -lpthread -lcurl -levent -lboost_program_options -lboost_regex -lzmq -lc -lboost_filesystem -lboost_system
 LDFLAGS_BUILD :=
-LDFLAGS_TEST := -lgtest -lgmock
+LDFLAGS_TEST := -lgtest -lgmock -ldl
 VPATH := ${ROOT}/modules/cpp-common/src:${ROOT}/modules/cpp-common/test_utils
 
 .PHONY: default

--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: chronos
 Section: network
 Priority: optional
 Maintainer: Project Clearwater Maintainers <maintainers@projectclearwater.org>
-Build-Depends: debhelper (>= 8.0.0), devscripts, build-essential, libboost-program-options-dev, libcurl4-gnutls-dev, libevent-dev, google-mock, libboost-regex1.46-dev, libboost-filesystem-dev
+Build-Depends: debhelper (>= 8.0.0), devscripts, build-essential, libboost-program-options-dev, libcurl4-gnutls-dev, libevent-dev, google-mock
 Standards-Version: 3.9.2
 Homepage: http://github.com/Metaswitch/chronos
 
 Package: chronos
 Architecture: any
-Depends: clearwater-infrastructure, libboost-program-options1.46.1, libboost-regex1.46.1, libboost-filesystem1.46.1
+Depends: clearwater-infrastructure, libboost-program-options-dev ( >= 1.46.1), libboost-regex-dev ( >= 1.46.1), libboost-filesystem-dev ( >= 1.46.1)
 Description: Distributed, redundant network timer service.
 
 Package: chronos-dbg


### PR DESCRIPTION
The boost dependencies are too specific to Ubuntu 12.04 so I modified them so as to be compatible with later versions of boost; specifically the version that's part of Ubuntu 14.04. These dependency changes have been incorporated into a build and have been run through system test's regression suite.

Also, the unit tests would not run on Ubuntu 14.04 with specifically linking against libdl, so that has been added to the unit test ld flags. With this option the unit tests run as expected and has no deleterious affect in an Ubuntu 12.04 build environment.

