### PR TITLE
[Reviewer: Matt] Add poll_chronos script

### DIFF
--- a/usr/share/chronos/chronos.monit
+++ b/usr/share/chronos/chronos.monit
@@ -1,6 +1,11 @@
 # Monitor the service's PID file and public interface. Issue an alarm for
 # any restart, clear after the process has run for 30s.
 
+check program poll_chronos with path "/usr/share/clearwater/bin/poll_chronos.sh"
+
+  if status != 0 for 2 cycles
+     then exec "/etc/init.d/chronos abort"
+
 check process chronos with pidfile /var/run/chronos.pid
 
   start program = "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 3000.4; /etc/init.d/chronos start'"

--- a/usr/share/clearwater/bin/poll_chronos.sh
+++ b/usr/share/clearwater/bin/poll_chronos.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+# @file poll_chronos.sh
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2015  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+# This script uses HTTP to poll a chronos process and check whether it is healthy.
+
+. /etc/clearwater/config
+
+# In case chronos has only just restarted, give it a few seconds to come up.
+sleep 5
+
+# Grab our configuration - we just use the local IP address.
+. /etc/clearwater/config
+
+# For HTTP, we need to wrap IPv6 addresses in square brackets.
+http_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip):7253
+
+/usr/share/clearwater/bin/poll-http $http_ip
+exit $rc

--- a/usr/share/clearwater/bin/poll_chronos.sh
+++ b/usr/share/clearwater/bin/poll_chronos.sh
@@ -37,10 +37,6 @@
 # In case chronos has only just restarted, give it a few seconds to come up.
 sleep 5
 
-# Grab our configuration - we just use the local IP address.
 . /etc/clearwater/config
-
-# For HTTP, we need to wrap IPv6 addresses in square brackets.
-http_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip):7253
-/usr/share/clearwater/bin/poll-http $http_ip
-exit $rc
+/usr/share/clearwater/bin/poll-http $chronos_hostname
+exit $?

--- a/usr/share/clearwater/bin/poll_chronos.sh
+++ b/usr/share/clearwater/bin/poll_chronos.sh
@@ -34,10 +34,6 @@
 # under which the OpenSSL Project distributes the OpenSSL toolkit software,
 # as those licenses appear in the file LICENSE-OPENSSL.
 
-# This script uses HTTP to poll a chronos process and check whether it is healthy.
-
-. /etc/clearwater/config
-
 # In case chronos has only just restarted, give it a few seconds to come up.
 sleep 5
 
@@ -46,6 +42,5 @@ sleep 5
 
 # For HTTP, we need to wrap IPv6 addresses in square brackets.
 http_ip=$(/usr/share/clearwater/bin/bracket_ipv6_address.py $local_ip):7253
-
 /usr/share/clearwater/bin/poll-http $http_ip
 exit $rc


### PR DESCRIPTION
Matt, can you review this change to add a poll_chronos script. This uses a generic poll-http script (taken from poll_homestead) that runs in the correct namespace. 

I've tested against a normal Chronos node and a multiple networks one
Fixes #97 