### PR TITLE
[Reviewer: Ellie] Use 14.04's Boost version as a dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,13 +2,13 @@ Source: chronos
 Section: network
 Priority: optional
 Maintainer: Project Clearwater Maintainers <maintainers@projectclearwater.org>
-Build-Depends: debhelper (>= 8.0.0), devscripts, build-essential, libboost-program-options-dev, libcurl4-gnutls-dev, libevent-dev, google-mock, libboost-regex1.46-dev, libboost-filesystem-dev
+Build-Depends: debhelper (>= 8.0.0), devscripts, build-essential, libboost-program-options-dev, libcurl4-gnutls-dev, libevent-dev, libboost-regex-dev, libboost-filesystem-dev
 Standards-Version: 3.9.2
 Homepage: http://github.com/Metaswitch/chronos
 
 Package: chronos
 Architecture: any
-Depends: clearwater-infrastructure, libboost-program-options1.46.1, libboost-regex1.46.1, libboost-filesystem1.46.1, libevent-pthreads-2.0-5
+Depends: clearwater-infrastructure, libboost-program-options1.54.0, libboost-regex1.54.0, libboost-filesystem1.54.0, libevent-pthreads-2.0-5
 Description: Distributed, redundant network timer service.
 
 Package: chronos-dbg

--- a/debian/rules
+++ b/debian/rules
@@ -13,7 +13,7 @@ override_dh_auto_install:
 	mkdir debian/tmp
  
 override_dh_installinit:
-	dh_installinit -u"defaults 70 30"
+	dh_installinit --no-start -u"defaults 70 30"
 
 override_dh_shlibdeps:
 override_dh_strip:


### PR DESCRIPTION
This fixes up debian/control to:
* allow building without google-mock installed, because we now have the submodule
* allow you to install on a 14.04 system, by using Boost 1.54.0 as the dependency, not 1.46.1.

(It's possible to allow you to install on both 12.04 and 14.04 with the syntax `libboost-program-options1.46.1 | libboost-program-options1.54.0`, but that's not a requirement here.)

