### PR TITLE
[Reviewer: Andy] Ensure process name passed to openlog() lasts for duration of program

### DIFF
--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -133,7 +133,10 @@ int main(int argc, char** argv)
   __globals->update_config();
 
   boost::filesystem::path p = argv[0];
-  openlog(p.filename().c_str(), PDLOG_PID, PDLOG_LOCAL6);
+  // Copy the filename to a string so that we can be sure of its lifespan -
+  // the value passed to openlog must be valid for the duration of the program.
+  std::string filename = p.filename().c_str();
+  openlog(filename.c_str(), PDLOG_PID, PDLOG_LOCAL6);
   CL_CHRONOS_STARTED.log();
 
   // Log the PID, this is useful for debugging if monit restarts chronos.


### PR DESCRIPTION
Fixes Metaswitch/sprout#973 (partly)