### PR TITLE
[Reviewer: Matt] Add rendezvous hashing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "modules/sas-client"]
 	path = modules/sas-client
 	url = git@github.com:Metaswitch/sas-client.git
+[submodule "modules/gmock"]
+	path = modules/gmock
+	url = git@github.com:Metaswitch/gmock-upstream.git

--- a/Makefile
+++ b/Makefile
@@ -8,22 +8,36 @@ PREFIX ?= ${ROOT}/build/usr
 INSTALL_DIR ?= ${PREFIX}
 MODULE_DIR := ${ROOT}/modules
 
+GTEST_DIR := $(ROOT)/modules/gmock/gtest
+GMOCK_DIR := $(ROOT)/modules/gmock
+
 TARGET := chronos
 TARGET_TEST := chronos_test
 TARGET_SOURCES_BUILD := src/main/main.cpp
 TARGET_SOURCES_TEST := $(wildcard src/test/*.cpp) test_interposer.cpp fakelogger.cpp mock_sas.cpp fakecurl.cpp
 TARGET_SOURCES := $(filter-out $(TARGET_SOURCES_BUILD) $(TARGET_SOURCES_TEST), $(wildcard src/main/*.cpp) $(wildcard src/main/**/*.cpp))
 TARGET_SOURCES += log.cpp logger.cpp unique.cpp signalhandler.cpp alarm.cpp httpstack.cpp httpstack_utils.cpp accesslogger.cpp utils.cpp health_checker.cpp exception_handler.cpp httpconnection.cpp statistic.cpp baseresolver.cpp dnscachedresolver.cpp dnsparser.cpp zmq_lvc.cpp httpresolver.cpp
-TARGET_EXTRA_OBJS_TEST :=
+TARGET_EXTRA_OBJS_TEST := gmock-all.o gtest-all.o
 INCLUDE_DIR := ${ROOT}/src/include
 LIB_DIR := ${INSTALL_DIR}/lib
 CPPFLAGS := -ggdb -I${INCLUDE_DIR} -I${ROOT}/modules/cpp-common/include -I${ROOT}/modules/rapidjson/include -I${ROOT}/modules/sas-client/include -std=c++0x -I${INSTALL_DIR}/include -Werror
 CPPFLAGS_BUILD := -O0
-CPPFLAGS_TEST := -O0 -fprofile-arcs -ftest-coverage -DUNITTEST -I${ROOT}/src/test/ -I${ROOT}/modules/cpp-common/test_utils/ -fno-access-control
+CPPFLAGS_TEST := -O0 -fprofile-arcs -ftest-coverage -DUNITTEST -I${ROOT}/src/test/ -I${ROOT}/modules/cpp-common/test_utils/ -fno-access-control -I$(GTEST_DIR)/include -I$(GMOCK_DIR)/include
 LDFLAGS := -L${INSTALL_DIR}/lib -lrt -lpthread -lcurl -levent -lboost_program_options -lboost_regex -lzmq -lc -lboost_filesystem -lboost_system -levhtp \
            -levent_pthreads -lcares
 LDFLAGS_BUILD := -lsas
-LDFLAGS_TEST := -lgtest -lgmock
+LDFLAGS_TEST := -ldl
+
+# Now the GMock / GTest boilerplate.
+GTEST_HEADERS := $(GTEST_DIR)/include/gtest/*.h \
+                 $(GTEST_DIR)/include/gtest/internal/*.h
+GMOCK_HEADERS := $(GMOCK_DIR)/include/gmock/*.h \
+                 $(GMOCK_DIR)/include/gmock/internal/*.h \
+                 $(GTEST_HEADERS)
+
+GTEST_SRCS_ := $(GTEST_DIR)/src/*.cc $(GTEST_DIR)/src/*.h $(GTEST_HEADERS)
+GMOCK_SRCS_ := $(GMOCK_DIR)/src/*.cc $(GMOCK_HEADERS)
+# End of boilerplate
 
 VPATH := ${ROOT}/modules/cpp-common/src:${ROOT}/modules/cpp-common/test_utils
 
@@ -89,10 +103,20 @@ coverage: ${TARGET_BIN_TEST}
 	@for gcov in *.gcov;                                                         \
 	do                                                                           \
 	  source=$$(basename $$gcov .gcov);                                          \
-		found=$$(find src -name $$source | wc -l);                                 \
+		found=$$(find src -name $$source | wc -l);                           \
 	  if [[ $$found != 1 ]];                                                     \
 	  then                                                                       \
 	    rm $$gcov;                                                               \
 	  fi                                                                         \
 	done
 	@mv *.gcov gcov/
+
+# Build rules for GMock/GTest library.
+$(OBJ_DIR_TEST)/gtest-all.o : $(GTEST_SRCS_)
+	$(CXX) $(CPPFLAGS) -I$(GTEST_DIR) -I$(GTEST_DIR)/include -I$(GMOCK_DIR) -I$(GMOCK_DIR)/include \
+            -DGTEST_USE_OWN_TR1_TUPLE=0 -c $(GTEST_DIR)/src/gtest-all.cc -o $@
+
+$(OBJ_DIR_TEST)/gmock-all.o : $(GMOCK_SRCS_)
+	$(CXX) $(CPPFLAGS) -I$(GTEST_DIR) -I$(GTEST_DIR)/include -I$(GMOCK_DIR) -I$(GMOCK_DIR)/include \
+            -c $(GMOCK_DIR)/src/gmock-all.cc -o $@
+

--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,18 @@ deb: build deb-only
 .PHONY: build
 build: ${SUBMODULES} ${TARGET_BIN}
 
+# Define JUSTTEST=<testname> to test just that test.  Easier than
+# passing the --gtest_filter in EXTRA_TEST_ARGS.
+ifdef JUSTTEST
+  EXTRA_TEST_ARGS ?= --gtest_filter=$(JUSTTEST)
+endif
+
 .PHONY: test
-test: ${SUBMODULES} ${TARGET_BIN_TEST}
-	${TARGET_BIN_TEST}
+test: ${SUBMODULES} ${TARGET_BIN_TEST} run_test
+
+.PHONY: run_test
+run_test: ${TARGET_BIN_TEST}
+	${TARGET_BIN_TEST} $(EXTRA_TEST_ARGS)
 
 .PHONY: debug
 debug: ${TARGET_BIN_TEST}

--- a/doc/design/hashing.md
+++ b/doc/design/hashing.md
@@ -1,0 +1,72 @@
+The goal of Chronos' hashing algorithm is to move as few timers as possible on scale-up or scale-down. For example, if we go from "A, B, C" to "A, B, C, D", the best way to do this is just to move 25% of timers from A, B and C onto D.
+
+We ensure this through rendezvous hashing. http://en.wikipedia.org/wiki/Rendezvous_hashing talks about this method at a high level, and its benefits, but to understand how it works in Chronos, the best way is probably a worked example.
+
+## Worked example ##
+
+Assume we start with the cluster A, B, C, and are trying to choose a primary and a backup for a timer with ID 100.
+
+- At start-of, day, we hash "A", "B" and "C". These might hash to the values 1000, 2000 and 3000.
+- When considering the timer with ID 100, we hash the value 100 three times:
+    - once with the seed 1000 (server A's hash), resulting in e.g. 7777
+    - once with the seed 2000 (server B's hash), resulting in e.g. 9999
+    - once with the seed 3000 (server C's hash), resulting in e.g. 8888
+-  We then reorder the servers by those hashes - A/7777, C/8888, B/9999
+-  A would therefore be the primary replica (as the lowest hash), and B the first backup replica (as the highest hash).
+-  If we had a replication-factor of 3 rather than 2, C (with the second-highest hash) would be second backup replica.
+
+- We then scale up to the cluster "A, B, C, D". We hash "A", "B", "C" and "D". "A", "B" and "C" hash to the same values as before (1000, 2000 and 3000). "D" might hash to 4000,
+- When considering the timer with ID 100, we hash the value 100 four times:
+    - once with the seed 1000 (server A's hash), resulting in 7777 as before
+    - once with the seed 2000 (server B's hash), resulting in 9999 as before
+    - once with the seed 3000 (server C's hash), resulting in 8888 as before
+    - once with the seed 4000 (server D's hash), resulting in e.g. 6666
+-  We then reorder the servers by those hashes - D/6666, A/7777, C/8888, B/9999
+-  D would therefore be the primary replica (as the lowest hash), and B the first backup replica (as the highest hash).
+-  If we had a replication-factor of 3 rather than 2, C (with the second-highest hash) would be second backup replica.
+-  This means that ownership of the timer (as primary) moves from D to A, but B remains the backup.
+-  Because A, B and C's relative positions are unchanged by this hashing, timers cannot move between them - only on to D.
+
+## Hash collision handling ##
+
+Collisions are very rare: our hash function has 4.3 billion possible outputs, and most of our values are similar (timer IDs are sequential, server names will generally be IP addresses in the same subnet), which should mean their hashes are different. However, we do cope with the very rare case of hash collisions as follows: 
+
+### Collision between server hashes ###
+
+Assume we start with the cluster A1, A2, B, C, and are trying to choose a primary and a backup for a timer with ID 100.
+
+- At start-of day, we hash "A1", "A2", "B" and "C". These might hash to the values 1000, 1000, 2000 and 3000. We resolve the clash between A1 and A2's hashes by incrementing the second hash until it is unique - so in this case, it would become 1000, 1001, 2000 and 3000. 
+- When considering the timer with ID 100, we hash the value 100 four times:
+    - once with the seed 1000 (server A1's hash), resulting in e.g. 7777
+    - once with the seed 1001 (server A2's hash), resulting in e.g. 9000
+    - once with the seed 2000 (server B's hash), resulting in e.g. 9999
+    - once with the seed 3000 (server C's hash), resulting in e.g. 8888
+-  We then reorder the servers by those hashes - A1/7777, C/8888, A2/9000, C/8888, B/9999
+-  A1 would therefore be the primary replica (as the lowest hash), and B the first backup replica (as the highest hash).
+-  If we had a replication-factor of 3 rather than 2, A2 (with the second-highest hash) would be second backup replica.
+
+
+- We then scale-down, removing A1. We hash "A2", "B" and "C". These hash to the values 1000, 2000 and 3000. We no longer have clashing hashes, so don't increment A2's hash - it is now 1000 instead of 1001.
+- When considering the timer with ID 100, we hash the value 100 three times:
+    - once with the seed 1000 (server A2's new hash), resulting in e.g. 7777
+    - once with the seed 2000 (server B's hash), resulting in e.g. 9999
+    - once with the seed 3000 (server C's hash), resulting in e.g. 8888
+-  We then reorder the servers by those hashes - A2/7777, C/8888, C/8888, B/9999
+-  A2 would therefore be the primary replica (as the lowest hash), and B the first backup replica (as the highest hash).
+-  If we had a replication-factor of 3 rather than 2, c (with the second-highest hash) would be second backup replica.
+-  Note that this means that A2 has gone from being the second backup to being primary. This does not happen under normal circumstances - it only happens here because of the collision, which means A2 stays in the cluster but changes its hash.  
+
+### Collision between timer hashes ###
+
+Assume we start with the cluster A, B, C, and are trying to choose a primary and a backup for a timer with ID 200.
+
+- At start-of day, we hash "A", "B" and "C". These might hash to the values 1000, 2000 and 3000. 
+- When considering the timer with ID 200, we hash the value 200 three times:
+    - once with the seed 1000 (server A's hash), resulting in e.g. 800
+    - once with the seed 2000 (server B's hash), resulting in e.g. 800
+    - once with the seed 3000 (server C's hash), resulting in e.g. 900
+-  We resolve the collision (two values of 800) by incrementing the clashing value until it is unique. This effectively means that, in the case of a clash, the server first in the original list wins.
+-  We then reorder the servers by those hashes - A/100, B/801, C/900
+-  A would therefore be the primary replica (as the lowest hash), and C the first backup replica (as the highest hash).
+-  If we had a replication-factor of 3 rather than 2, B (with the second-highest hash) would be second backup replica.
+

--- a/readme.md
+++ b/readme.md
@@ -22,15 +22,7 @@ To develop on Chronos, you'll need to install a few dependencies first.
 
 On Ubuntu most of these can be installed with:
 
-    sudo apt-get install git build-essential devscripts debhelper libcurl4-gnutls-dev libboost-program-options-dev libboost-regex-dev libevent-dev google-mock
-
-The only part that doesn't install is the actual `gtest` library, it does however install the library code to `/usr/src`.  You can build this into the correct library with:
-
-    sudo apt-get install cmake
-    cd /usr/src/gtest
-    sudo cmake -f CMakeCache.txt
-    sudo make
-    sudo mv libgtest.a libgtest_main.a /usr/lib/
+    sudo apt-get install git build-essential devscripts debhelper libcurl4-gnutls-dev libboost-program-options-dev libboost-regex-dev libevent-dev
 
 ### Building
 

--- a/src/include/globals.h
+++ b/src/include/globals.h
@@ -37,7 +37,7 @@ public:
   GLOBAL(bind_address, std::string);
   GLOBAL(bind_port, int);
   GLOBAL(cluster_local_ip, std::string);
-  GLOBAL(cluster_hashes, std::map<std::string, uint64_t>);
+  GLOBAL(cluster_bloom_filters, std::map<std::string, uint64_t>);
   GLOBAL(cluster_addresses, std::vector<std::string>);
   GLOBAL(cluster_leaving_addresses, std::vector<std::string>);
   GLOBAL(alarms_enabled, bool);
@@ -50,7 +50,7 @@ public:
   void unlock() { pthread_rwlock_unlock(&_lock); }
 
 private:
-  uint64_t generate_hash(std::string);
+  uint64_t generate_bloom_filter(std::string);
 
   std::string _config_file;
   pthread_rwlock_t _lock; 

--- a/src/include/globals.h
+++ b/src/include/globals.h
@@ -39,6 +39,7 @@ public:
   GLOBAL(cluster_local_ip, std::string);
   GLOBAL(cluster_bloom_filters, std::map<std::string, uint64_t>);
   GLOBAL(cluster_addresses, std::vector<std::string>);
+  GLOBAL(cluster_hashes, std::vector<uint32_t>);
   GLOBAL(cluster_leaving_addresses, std::vector<std::string>);
   GLOBAL(alarms_enabled, bool);
   GLOBAL(threads, int);
@@ -51,6 +52,7 @@ public:
 
 private:
   uint64_t generate_bloom_filter(std::string);
+  std::vector<uint32_t> generate_hashes(std::vector<std::string>);
 
   std::string _config_file;
   pthread_rwlock_t _lock; 

--- a/src/include/timer.h
+++ b/src/include/timer.h
@@ -9,6 +9,13 @@
 
 typedef uint64_t TimerID;
 
+class Hasher
+{
+public:
+  virtual uint32_t do_hash(TimerID data, uint32_t seed);
+  virtual uint32_t do_hash(std::string data, uint32_t seed);
+};
+
 class Timer
 {
 public:
@@ -49,7 +56,8 @@ public:
                                  std::vector<std::string> cluster,
                                  uint32_t replication_factor,
                                  std::vector<std::string>& replicas,
-                                 std::vector<std::string>& extra_replicas);
+                                 std::vector<std::string>& extra_replicas,
+                                 Hasher* hasher);
 
   // Mark which replicas have been informed about the timer 
   int update_replica_tracker(int replica_index);

--- a/src/include/timer.h
+++ b/src/include/timer.h
@@ -2,6 +2,7 @@
 #define TIMER_H__
 
 #include <vector>
+#include <map>
 #include <string>
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
@@ -41,6 +42,14 @@ public:
 
   // Calculate/Guess at the replicas for this timer (using the replica hash if present)
   void calculate_replicas(uint64_t);
+
+  static void calculate_replicas(TimerID id,
+                                 uint64_t replica_hash,
+                                 std::map<std::string, uint64_t> cluster_hashes,
+                                 std::vector<std::string> cluster,
+                                 uint32_t replication_factor,
+                                 std::vector<std::string>& replicas,
+                                 std::vector<std::string>& extra_replicas);
 
   // Mark which replicas have been informed about the timer 
   int update_replica_tracker(int replica_index);

--- a/src/include/timer.h
+++ b/src/include/timer.h
@@ -9,6 +9,9 @@
 
 typedef uint64_t TimerID;
 
+// Separate class implementing the hash approach for rendezvous hashing -
+// allows the hashing to be changed in UT (e.g. to force collisions).
+
 class Hasher
 {
 public:
@@ -50,6 +53,7 @@ public:
   // Calculate/Guess at the replicas for this timer (using the replica hash if present)
   void calculate_replicas(uint64_t);
 
+  // Class method for calculating replicas, for easy UT.
   static void calculate_replicas(TimerID id,
                                  uint64_t replica_hash,
                                  std::map<std::string, uint64_t> cluster_hashes,

--- a/src/include/timer.h
+++ b/src/include/timer.h
@@ -54,6 +54,7 @@ public:
                                  uint64_t replica_hash,
                                  std::map<std::string, uint64_t> cluster_hashes,
                                  std::vector<std::string> cluster,
+                                 std::vector<uint32_t> cluster_rendezvous_hashes,
                                  uint32_t replication_factor,
                                  std::vector<std::string>& replicas,
                                  std::vector<std::string>& extra_replicas,

--- a/src/include/timer_handler.h
+++ b/src/include/timer_handler.h
@@ -16,7 +16,7 @@ class TimerHandler
 {
 public:
   TimerHandler(TimerStore*, Callback*);
-  ~TimerHandler();
+  virtual ~TimerHandler();
   virtual void add_timer(Timer*);
   virtual void update_replica_tracker_for_timer(TimerID id,
                                                 int replica_index);

--- a/src/main/globals.cpp
+++ b/src/main/globals.cpp
@@ -86,6 +86,9 @@ void Globals::update_config()
   }
   set_cluster_bloom_filters(cluster_bloom_filters);
 
+  std::vector<uint32_t> cluster_rendezvous_hashes = generate_hashes(cluster_addresses);
+  set_cluster_hashes(cluster_rendezvous_hashes);
+
   std::vector<std::string> cluster_leaving_addresses = conf_map["cluster.leaving"].as<std::vector<std::string>>();
   set_cluster_leaving_addresses(cluster_leaving_addresses);
 
@@ -125,3 +128,20 @@ uint64_t Globals::generate_bloom_filter(std::string data)
 
   return rc;
 }
+
+std::vector<uint32_t> Globals::generate_hashes(std::vector<std::string> data)
+{
+  std::vector<uint32_t> ret;
+  for (size_t ii = 0; ii < data.size(); ++ii)
+  {
+    uint32_t hash;
+    MurmurHash3_x86_32(data[ii].c_str(), data[ii].length(), 0, &hash);
+    while (std::find(ret.begin(), ret.end(), hash) != ret.end()) {
+      hash--;
+    }
+    ret.push_back(hash);
+  }
+
+  return ret;
+}
+

--- a/src/main/globals.cpp
+++ b/src/main/globals.cpp
@@ -74,7 +74,7 @@ void Globals::update_config()
 
   std::vector<std::string> cluster_addresses = conf_map["cluster.node"].as<std::vector<std::string>>();
   set_cluster_addresses(cluster_addresses);
-  std::map<std::string, uint64_t> cluster_hashes;
+  std::map<std::string, uint64_t> cluster_bloom_filters;
   LOG_STATUS("Cluster nodes:");
 
   for (std::vector<std::string>::iterator it = cluster_addresses.begin();
@@ -82,9 +82,9 @@ void Globals::update_config()
                                           ++it)
   {
     LOG_STATUS(" - %s", it->c_str());
-    cluster_hashes[*it] = generate_hash(*it);
+    cluster_bloom_filters[*it] = generate_bloom_filter(*it);
   }
-  set_cluster_hashes(cluster_hashes);
+  set_cluster_bloom_filters(cluster_bloom_filters);
 
   std::vector<std::string> cluster_leaving_addresses = conf_map["cluster.leaving"].as<std::vector<std::string>>();
   set_cluster_leaving_addresses(cluster_leaving_addresses);
@@ -109,7 +109,7 @@ void Globals::update_config()
 // Create 3 128-bit hashes, modulo each half down to 0..63 and set those
 // bits in the returned value.  In general this will set ~6 bits in the
 // returned hash.
-uint64_t Globals::generate_hash(std::string data)
+uint64_t Globals::generate_bloom_filter(std::string data)
 {
   uint64_t hash[2];
   uint64_t rc = 0;

--- a/src/main/globals.cpp
+++ b/src/main/globals.cpp
@@ -136,6 +136,9 @@ std::vector<uint32_t> Globals::generate_hashes(std::vector<std::string> data)
   {
     uint32_t hash;
     MurmurHash3_x86_32(data[ii].c_str(), data[ii].length(), 0, &hash);
+
+    // If we have hash collisions, modify the hash (we decrement it,
+    // but any arbitrary modification is valid) until it is unique.
     while (std::find(ret.begin(), ret.end(), hash) != ret.end()) {
       hash--;
     }

--- a/src/main/timer.cpp
+++ b/src/main/timer.cpp
@@ -207,25 +207,6 @@ void Timer::become_tombstone()
   repeat_for = interval * (sequence_number + 1);
 }
 
-static void calculate_standard_hash(std::vector<std::string> cluster,
-                                    TimerID id,
-                                    uint32_t replication_factor,
-                                    std::vector<std::string>& replicas)
-{
-  // Pick replication-factor replicas from the cluster, using a hash of the ID
-  // to balance the choices.
-  uint32_t hash;
-  MurmurHash3_x86_32(&id, sizeof(TimerID), 0x0, &hash);
-  unsigned int first_replica = hash % cluster.size();
-  for (unsigned int ii = 0;
-       ii < replication_factor && ii < cluster.size();
-       ++ii)
-  {
-    replicas.push_back(cluster[(first_replica + ii) % cluster.size()]);
-  }
-}
-
-
 static void calculate_rendezvous_hash(std::vector<std::string> cluster,
                                       TimerID id,
                                       uint32_t replication_factor,
@@ -339,8 +320,7 @@ void Timer::calculate_replicas(TimerID id,
   }
 
   // Pick replication-factor replicas from the cluster.
-  calculate_standard_hash(cluster, id, replication_factor, replicas);
-  //calculate_rendezvous_hash(cluster, id, replication_factor, replicas);
+  calculate_rendezvous_hash(cluster, id, replication_factor, replicas);
 
   if (replica_hash)
   {

--- a/src/test/base.cpp
+++ b/src/test/base.cpp
@@ -22,6 +22,9 @@ void Base::SetUp()
   cluster_bloom_filters["10.0.0.2:9999"] = 0x10001000001000;
   cluster_bloom_filters["10.0.0.3:9999"] = 0x01000100000100;
   __globals->set_cluster_bloom_filters(cluster_bloom_filters);
+  std::vector<uint32_t> cluster_rendezvous_hashes = __globals->generate_hashes(cluster_addresses);
+  __globals->set_cluster_hashes(cluster_rendezvous_hashes);
+
   int bind_port = 9999;
   __globals->set_bind_port(bind_port);
   __globals->unlock();

--- a/src/test/base.cpp
+++ b/src/test/base.cpp
@@ -17,11 +17,11 @@ void Base::SetUp()
   cluster_addresses.push_back("10.0.0.2:9999");
   cluster_addresses.push_back("10.0.0.3:9999");
   __globals->set_cluster_addresses(cluster_addresses);
-  std::map<std::string, uint64_t> cluster_hashes;
-  cluster_hashes["10.0.0.1:9999"] = 0x00010000010001;
-  cluster_hashes["10.0.0.2:9999"] = 0x10001000001000;
-  cluster_hashes["10.0.0.3:9999"] = 0x01000100000100;
-  __globals->set_cluster_hashes(cluster_hashes);
+  std::map<std::string, uint64_t> cluster_bloom_filters;
+  cluster_bloom_filters["10.0.0.1:9999"] = 0x00010000010001;
+  cluster_bloom_filters["10.0.0.2:9999"] = 0x10001000001000;
+  cluster_bloom_filters["10.0.0.3:9999"] = 0x01000100000100;
+  __globals->set_cluster_bloom_filters(cluster_bloom_filters);
   int bind_port = 9999;
   __globals->set_bind_port(bind_port);
   __globals->unlock();

--- a/src/test/test_timer_replica_choosing.cpp
+++ b/src/test/test_timer_replica_choosing.cpp
@@ -262,6 +262,13 @@ TEST_F(TestTimerReplicaChoosingWithCollision, MinimumTimersMovePrimary)
     
     if ((old_replicas[0] != new_replicas[0]))
     {
+
+      // Timers should only move off the removed server to the server whose
+      // hash has replaced it, or off the server whose hash has changed to any
+      // remaining server
+      
+      ASSERT_TRUE(((old_replicas[0] == "10.0.0.1:7253") && (new_replicas[0] == "10.0.0.2:7253")) ||
+                  ((old_replicas[0] == "10.0.0.2:7253") && (new_replicas[0] != "10.0.0.1:7253")));
       different++;
     }
   }

--- a/src/test/test_timer_replica_choosing.cpp
+++ b/src/test/test_timer_replica_choosing.cpp
@@ -122,7 +122,7 @@ TEST_F(TestTimerReplicaChoosing, MinimumTimersMovePrimary)
   }
 
   // To balance the cluster when we moved from N replicas to N+1, approximately
-  // 1/N+1th of existing timers should have moved. Allow a 15% difference to account for randomness.
+  // 1/N+1th of existing timers should have moved. Allow a 5% difference to account for randomness.
   EXPECT_THAT(different, ::testing::Lt((MAX_TIMERS / new_cluster.size()) * 1.05));
 }
 
@@ -148,7 +148,7 @@ TEST_F(TestTimerReplicaChoosing, MinimumTimersMoveBackup)
 
 
   // To balance the cluster when we moved from N replicas to N+1, approximately
-  // 1/N+1th of existing timers should have moved. Allow a 15% difference to account for randomness.
+  // 1/N+1th of existing timers should have moved. Allow a 5% difference to account for randomness.
   EXPECT_THAT(different, ::testing::Lt((MAX_TIMERS / new_cluster.size()) * 1.05));
 }
 
@@ -241,15 +241,14 @@ TEST_F(TestTimerReplicaChoosingWithCollision, MinimumTimersMovePrimary)
     }
   }
 
-  //printf("%d of %d timers changed primary replica on scale-up (expected around %ld, won't accept more than %ld)\n", different, MAX_TIMERS, MAX_TIMERS / new_cluster.size(), (uint32_t)((MAX_TIMERS / new_cluster.size()) * 1.05));
-
   // If we have a cluster of size N shringing to size M, we remove A, and that resolves a hash collision so B's hash changes:
   //  - B's hash is now A's former hash, so all A's timers (1/N) move to B
   //  - B's hash has disappeared, so all B's timers (1/N) get rehashed
   //  - Of those 1/N timers, M-1/M move to other nodes, and 1/M stay on B
   //  - Overall, 1/N + (M-1/MN) of the total timers movetimers move = (M/MN + M-1/MN) = 2M-1/MN
-  //
   int expected_to_move = MAX_TIMERS * ((2 * new_cluster.size()) - 1) / (new_cluster.size() * cluster.size());
+
+  // Allow a 5% deviation from the expected value (as our subset of timers won't necessarily be perfectly distributed).
   EXPECT_THAT(different, ::testing::Lt(expected_to_move * 1.05));
 }
 

--- a/src/test/test_timer_replica_choosing.cpp
+++ b/src/test/test_timer_replica_choosing.cpp
@@ -1,0 +1,110 @@
+#include "timer.h"
+#include "globals.h"
+#include "base.h"
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <map>
+
+/*****************************************************************************/
+/* Test fixture                                                              */
+/*****************************************************************************/
+
+class TestTimerReplicaChoosing : public Base
+{
+protected:
+  virtual void SetUp()
+  {
+    Base::SetUp();
+    id = (TimerID)7;
+  }
+
+  virtual void TearDown()
+  {
+    Base::TearDown();
+  }
+
+  TimerID id;
+};
+
+/*****************************************************************************/
+/* Class functions                                                           */
+/*****************************************************************************/
+
+TEST_F(TestTimerReplicaChoosing, UnderHalfOfTimersMove)
+{
+  std::map<std::string, uint64_t> cluster_hashes;
+  std::vector<std::string> cluster = {"A", "B", "C"};
+  std::vector<std::string> cluster2 = {"A", "B", "C", "D"};
+
+  std::vector<std::string> replicas;
+  std::vector<std::string> replicas2;
+  std::vector<std::string> extra_replicas;
+  int different = 0;
+  int max_timers = 65536;
+  for (TimerID id = (TimerID)1;
+       id < (TimerID)max_timers;
+       id++)
+  {
+    replicas.clear();
+    replicas2.clear();
+    Timer::calculate_replicas(id,
+                              0u,
+                              cluster_hashes,
+                              cluster,
+                              2u,
+                              replicas,
+                              extra_replicas);
+
+    Timer::calculate_replicas(id,
+                              0u,
+                              cluster_hashes,
+                              cluster2,
+                              2u,
+                              replicas2,
+                              extra_replicas);
+    if ((replicas[0] != replicas2[0]) ||
+        (replicas[1] != replicas2[1]))
+    {
+      different++;
+    }
+  }
+  printf("%d of %d timers changed replica on scale-up\n", different, max_timers);
+  EXPECT_THAT(different, ::testing::Lt(max_timers / 2));
+}
+
+TEST_F(TestTimerReplicaChoosing, NoPrimaryBackupSwap)
+{
+  std::map<std::string, uint64_t> cluster_hashes;
+  std::vector<std::string> cluster = {"A", "B", "C"};
+  std::vector<std::string> cluster2 = {"A", "B", "C", "D"};
+
+  std::vector<std::string> replicas;
+  std::vector<std::string> replicas2;
+  std::vector<std::string> extra_replicas;
+  int max_timers = 65536;
+  for (TimerID id = (TimerID)1;
+       id < (TimerID)max_timers;
+       id++)
+  {
+    replicas.clear();
+    replicas2.clear();
+    Timer::calculate_replicas(id,
+                              0u,
+                              cluster_hashes,
+                              cluster,
+                              2u,
+                              replicas,
+                              extra_replicas);
+
+    Timer::calculate_replicas(id,
+                              0u,
+                              cluster_hashes,
+                              cluster2,
+                              2u,
+                              replicas2,
+                              extra_replicas);
+    ASSERT_NE(replicas[0], replicas2[1]);
+    ASSERT_THAT(replicas[1], ::testing::Ne(replicas2[0]));
+  }
+}

--- a/src/test/test_timer_replica_choosing.cpp
+++ b/src/test/test_timer_replica_choosing.cpp
@@ -12,6 +12,7 @@
 
 static uint32_t REPLICATION_FACTOR = 2u;
 static int MAX_TIMERS = 4096;
+static Hasher normal_hasher;
 
 class TestTimerReplicaChoosing : public Base
 {
@@ -40,7 +41,8 @@ protected:
                               cluster,
                               REPLICATION_FACTOR,
                               old_replicas,
-                              extra_replicas);
+                              extra_replicas,
+                              &normal_hasher);
 
     Timer::calculate_replicas(id,
                               0u,
@@ -48,7 +50,8 @@ protected:
                               new_cluster,
                               REPLICATION_FACTOR,
                               new_replicas,
-                              extra_replicas);
+                              extra_replicas,
+                              &normal_hasher);
   }
 
   std::vector<std::string> cluster;
@@ -150,3 +153,5 @@ TEST_F(TestTimerReplicaChoosing, NoPrimaryBackupSwap)
     ASSERT_TRUE((old_replicas[1] != new_replicas[0]));
   }
 }
+
+

--- a/src/test/test_timer_replica_choosing.cpp
+++ b/src/test/test_timer_replica_choosing.cpp
@@ -32,13 +32,16 @@ protected:
 
   void calculate_timers_for_id(TimerID id)
   {
-    std::map<std::string, uint64_t> cluster_hashes;
+    std::map<std::string, uint64_t> cluster_bloom_filters;
+    std::vector<uint32_t> cluster_rendezvous_hashes = __globals->generate_hashes(cluster);
+    std::vector<uint32_t> new_cluster_rendezvous_hashes = __globals->generate_hashes(new_cluster);
     old_replicas.clear();
     new_replicas.clear();
     Timer::calculate_replicas(id,
                               0u,
-                              cluster_hashes,
+                              cluster_bloom_filters,
                               cluster,
+                              cluster_rendezvous_hashes,
                               REPLICATION_FACTOR,
                               old_replicas,
                               extra_replicas,
@@ -46,8 +49,9 @@ protected:
 
     Timer::calculate_replicas(id,
                               0u,
-                              cluster_hashes,
+                              cluster_bloom_filters,
                               new_cluster,
+                              new_cluster_rendezvous_hashes,
                               REPLICATION_FACTOR,
                               new_replicas,
                               extra_replicas,
@@ -61,6 +65,7 @@ protected:
   std::vector<std::string> new_replicas;
   std::vector<std::string> extra_replicas;
 };
+
 
 /*****************************************************************************/
 /* Class functions                                                           */
@@ -154,4 +159,117 @@ TEST_F(TestTimerReplicaChoosing, NoPrimaryBackupSwap)
   }
 }
 
+class TestTimerReplicaChoosingWithCollision : public Base
+{
+protected:
+  virtual void SetUp()
+  {
+    Base::SetUp();
+    cluster = {"10.0.0.1:7253", "10.0.0.2:7253", "10.0.0.3:7253", "10.0.0.4:7253"};
+    new_cluster = {"10.0.0.2:7253", "10.0.0.3:7253", "10.0.0.4:7253"};
+    cluster_rendezvous_hashes = {100, 99, 4, 5};
+    new_cluster_rendezvous_hashes = {100, 4, 5};
+  }
 
+  virtual void TearDown()
+  {
+    Base::TearDown();
+  }
+
+  void calculate_timers_for_id(TimerID id)
+  {
+    std::map<std::string, uint64_t> cluster_bloom_filters;
+    old_replicas.clear();
+    new_replicas.clear();
+    Timer::calculate_replicas(id,
+                              0u,
+                              cluster_bloom_filters,
+                              cluster,
+                              cluster_rendezvous_hashes,
+                              REPLICATION_FACTOR,
+                              old_replicas,
+                              extra_replicas,
+                              &normal_hasher);
+
+    Timer::calculate_replicas(id,
+                              0u,
+                              cluster_bloom_filters,
+                              new_cluster,
+                              new_cluster_rendezvous_hashes,
+                              REPLICATION_FACTOR,
+                              new_replicas,
+                              extra_replicas,
+                              &normal_hasher);
+  }
+
+  std::vector<std::string> cluster;
+  std::vector<std::string> new_cluster;
+  
+  std::vector<uint32_t> cluster_rendezvous_hashes;
+  std::vector<uint32_t> new_cluster_rendezvous_hashes;
+  
+  std::vector<std::string> old_replicas;
+  std::vector<std::string> new_replicas;
+  std::vector<std::string> extra_replicas;
+};
+
+
+TEST_F(TestTimerReplicaChoosingWithCollision, ClusteringIsBalanced)
+{
+  std::map<std::string, uint32_t> cluster_counts;
+
+  for (TimerID id = (TimerID)0;
+       id < (TimerID)MAX_TIMERS;
+       id++)
+  {
+    calculate_timers_for_id(id);
+    cluster_counts[old_replicas[0]]++;
+  }
+
+  uint32_t expected_max = MAX_TIMERS / (cluster.size() - 1);
+  uint32_t expected_min = MAX_TIMERS / (cluster.size() + 1);
+  
+  for (std::vector<std::string>::iterator ii = cluster.begin();
+      ii != cluster.end();
+      ii++)
+  {
+    EXPECT_GT(cluster_counts[*ii], expected_min);
+    EXPECT_LT(cluster_counts[*ii], expected_max);
+  }
+}
+
+TEST_F(TestTimerReplicaChoosingWithCollision, MinimumTimersMovePrimary)
+{
+  int different = 0;
+  for (TimerID id = (TimerID)0;
+       id < (TimerID)MAX_TIMERS;
+       id++)
+  {
+    calculate_timers_for_id(id);
+    
+    if ((old_replicas[0] != new_replicas[0]))
+    {
+      different++;
+    }
+  }
+
+  //printf("%d of %d timers changed primary replica on scale-up (expected around %ld, won't accept more than %ld)\n", different, MAX_TIMERS, MAX_TIMERS / new_cluster.size(), (uint32_t)((MAX_TIMERS / new_cluster.size()) * 1.15));
+
+  // If we have a cluster of size N shringing to size M, we remove A, and that resolves a hash collision so B's hash changes:
+  //  - B's hash is now A's former hash, so all A's timers (1/N) move to B
+  //  - B's hash has disappeared, so all B's timers (1/N) get rehashed
+  //  - Of those 1/N timers, M-1/M move to other nodes, and 1/M stay on B
+  //  - Overall, 1/N + (M-1/MN) of the total timers movetimers move = (M/MN + M-1/MN) = 2M-1/MN
+  //
+  int expected_to_move = MAX_TIMERS * ((2 * new_cluster.size()) - 1) / (new_cluster.size() * cluster.size());
+  EXPECT_THAT(different, ::testing::Lt(expected_to_move * 1.15));
+}
+
+
+TEST_F(TestTimerReplicaChoosingWithCollision, ServerHashesDontCollide)
+{
+  std::vector<std::string> cluster_with_duplicate = {"A", "A", "B"};
+  std::vector<uint32_t> hashes = __globals->generate_hashes(cluster_with_duplicate);
+
+  ASSERT_NE(hashes[0], hashes[1]);
+}

--- a/src/test/test_timer_replica_choosing.cpp
+++ b/src/test/test_timer_replica_choosing.cpp
@@ -119,7 +119,7 @@ TEST_F(TestTimerReplicaChoosing, MinimumTimersMovePrimary)
 
   // To balance the cluster when we moved from N replicas to N+1, approximately
   // 1/N+1th of existing timers should have moved. Allow a 15% difference to account for randomness.
-  EXPECT_THAT(different, ::testing::Lt((MAX_TIMERS / new_cluster.size()) * 1.15));
+  EXPECT_THAT(different, ::testing::Lt((MAX_TIMERS / new_cluster.size()) * 1.05));
 }
 
 // Same logic as previous test, but checking backup instead of primary.
@@ -145,7 +145,7 @@ TEST_F(TestTimerReplicaChoosing, MinimumTimersMoveBackup)
 
   // To balance the cluster when we moved from N replicas to N+1, approximately
   // 1/N+1th of existing timers should have moved. Allow a 15% difference to account for randomness.
-  EXPECT_THAT(different, ::testing::Lt((MAX_TIMERS / new_cluster.size()) * 1.15));
+  EXPECT_THAT(different, ::testing::Lt((MAX_TIMERS / new_cluster.size()) * 1.05));
 }
 
 // The algorithm used to distribute timers should ensure that no primary nodes
@@ -266,7 +266,7 @@ TEST_F(TestTimerReplicaChoosingWithCollision, MinimumTimersMovePrimary)
     }
   }
 
-  //printf("%d of %d timers changed primary replica on scale-up (expected around %ld, won't accept more than %ld)\n", different, MAX_TIMERS, MAX_TIMERS / new_cluster.size(), (uint32_t)((MAX_TIMERS / new_cluster.size()) * 1.15));
+  //printf("%d of %d timers changed primary replica on scale-up (expected around %ld, won't accept more than %ld)\n", different, MAX_TIMERS, MAX_TIMERS / new_cluster.size(), (uint32_t)((MAX_TIMERS / new_cluster.size()) * 1.05));
 
   // If we have a cluster of size N shringing to size M, we remove A, and that resolves a hash collision so B's hash changes:
   //  - B's hash is now A's former hash, so all A's timers (1/N) move to B
@@ -275,7 +275,7 @@ TEST_F(TestTimerReplicaChoosingWithCollision, MinimumTimersMovePrimary)
   //  - Overall, 1/N + (M-1/MN) of the total timers movetimers move = (M/MN + M-1/MN) = 2M-1/MN
   //
   int expected_to_move = MAX_TIMERS * ((2 * new_cluster.size()) - 1) / (new_cluster.size() * cluster.size());
-  EXPECT_THAT(different, ::testing::Lt(expected_to_move * 1.15));
+  EXPECT_THAT(different, ::testing::Lt(expected_to_move * 1.05));
 }
 
 

--- a/src/test/test_timer_store.cpp
+++ b/src/test/test_timer_store.cpp
@@ -674,7 +674,7 @@ TEST_F(TestTimerStore, UpdateReplicaTrackerValue)
   ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size());
   timers[0] = *next_timers.begin();
-  ASSERT_EQ(7, timers[0]->_replica_tracker);
+  ASSERT_EQ(7u, timers[0]->_replica_tracker);
 
   delete timers[0];
   delete timers[1];


### PR DESCRIPTION
This PR adds rendezvous hashing to Chronos, and UTs it to check that it behaves like we expect it to. The main points of interest are `Timer::calculate_rendezvous_hash` and the new tests.

Alongside that change, I've also:
* pulled in the gmock submodule from https://github.com/Metaswitch/chronos/pull/105 so I didn't have to build google-mock separately
* added a run_test Makefile target that honours JUSTTEST, to speed up my test-and-fix cycle