### PR TITLE
Reviewer Rob - Monotonic timers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ EXTRA_CLEANS += $(TEST_XML) \
                 $(OBJ_DIR_TEST)/*.gcno \
                 $(OBJ_DIR_TEST)/*.gcda \
                 *.gcov \
-		${OBJ_DIR_TEST}/chronos.memcheck
+                ${OBJ_DIR_TEST}/chronos.memcheck
 
 # Now the GMock / GTest boilerplate.
 GTEST_HEADERS := $(GTEST_DIR)/include/gtest/*.h \
@@ -126,21 +126,6 @@ valgrind: ${TARGET_BIN_TEST}
 	valgrind ${VG_OPTS} ${TARGET_BIN_TEST}
 
 .PHONY: coverage
-coverage: ${TARGET_BIN_TEST}
-	-rm ${OBJ_DIR_TEST}/src/main/*.gcda 2> /dev/null
-	@mkdir -p gcov
-	${TARGET_BIN_TEST}
-	gcov -o ${OBJ_DIR_TEST}/src/main/ ${OBJ_DIR_TEST}/src/main/*.o > gcov/synopsis
-	@for gcov in *.gcov;                                                         \
-	do                                                                           \
-	  source=$$(basename $$gcov .gcov);                                          \
-		found=$$(find src -name $$source | wc -l);                           \
-	  if [[ $$found != 1 ]];                                                     \
-	  then                                                                       \
-	    rm $$gcov;                                                               \
-	  fi                                                                         \
-	done
-	@mv *.gcov gcov/
 coverage: | run_test
 	$(GCOVR) $(COVERAGEFLAGS) --xml > $(COVERAGE_XML)
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -109,7 +109,7 @@ During a net-split, the timer may pop multiple times, once on each partition.  O
 
 ## Internal API
 
-Chronos nodes in a cluster communicate through an internal API that forms a superset of the public API and is documented here for developers.  This API is designed to be extensible to allow the API to change from release to release without breaking backwards compatibility.
+Chronos nodes in a cluster communicate through an internal API which is documented here for developers.  This API is designed to be extensible to allow the API to change from release to release without breaking backwards compatibility.
 
 ### Mainline Uses
 
@@ -151,7 +151,7 @@ Each of the attributes that overlap with the public API are used in the same way
 
 #### Replicating a Timer Pop
 
-When one Chronos instance pops a timer it informs all other replicas of the timer by sending a PUT message (same JSON body as above) with the appropriate `sequnence-number` set.  The receiving nodes should prepare to pop the timer at the next interval (if appropriate).
+When one Chronos instance pops a timer it informs all other replicas that it did by sending a PUT message (same JSON body as above) with the appropriate `start-time-delta` and `sequence-number` set.  The receiving nodes should prepare to pop the timer at the end of the next interval.
 
 #### Replicating a Timer Deletion
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -6,7 +6,7 @@ This document covers the external interface exposed by the Chronos network timer
 
 The timer service runs like a timer heap: clients request a timer to pop after a certain interval, or to pop regularly at a given rate over a given interval, and the timer service notifies the client (through a client-supplied callback) when the timer pops.
 
-## API Definition
+## Public API Definition
 
 ### Adding and modifying timers
 
@@ -105,13 +105,61 @@ Always a `201 OK` assuming the request was valid.  A `400 Bad Request` otherwise
 
 The timer pop is guaranteed to occur **after** the interval specified, but is not guaranteed to occur exactly on the interval (due to scheduling considerations, implementation details of the redundancy model and network latency).
 
-The accuracy of the timer service is only as good as the accuracy of the system clock on the timer nodes themselves.  If the system clock are skewed by a large amount (&gt;&gt; 1 second) then multiple timer nodes may pop for the same sequence number of the same timer.  To prevent this, we recommend running a time-synchronizing service on each of your timer nodes (NTPd/PTPd) to keep their clocks in sync.
-
 During a net-split, the timer may pop multiple times, once on each partition.  Once the net-split is healed, the next timer pop will resolve the multi-headed-ness and from then on the timer will only pop once per interval.
+
+## Internal API
+
+Chronos nodes in a cluster communicate through an internal API that forms a superset of the public API and is documented here for developers.  This API is designed to be extensible to allow the API to change from release to release without breaking backwards compatibility.
+
+### Mainline Uses
+
+The only request type sent over the API in mainline cases is a PUT which is used for three purposes:
+
+ * Telling the receiving node that it has been chosen as a replica for the given timer.
+ * Telling the receiving node that the given timer has been popped by an earlier replica.
+ * Telling the receiving node that the given timer has been deleted and should not be popped.
+
+#### Replicating a Timer Creation
+
+As with the public API, the URL shall be `/timers/<timer-id>` and the body shall be a JSON block:
+
+    {
+      "timing": {
+        "interval": <ms>,
+        "repeat-for": <ms>
+        "start-time-delta": <ms>
+        "sequence-number": <int>
+      },
+      "callback": {
+        "http": {
+          "uri": <callback-uri>,
+          "opaque": <opaque-data>
+        }
+      },
+      "reliability": {
+        "cluster-view-id": <cluster-view-id>,
+        "replicas": [<replica-1>, ...]
+      }
+    }
+
+Each of the attributes that overlap with the public API are used in the same way, the new attributes are used as followed:
+
+ * `timing/start-time-delta` - The delta to apply to the current time to compensate for time that the timer was programmed on the sending node.
+ * `timing/sequence-number` - The instance of the timer that is next to pop (always 0 for one-shot timers)
+ * `reliability/cluster-view-id` - The ID of the current cluster topology (used for error-checking and to spot inconsistencies in the cluster)
+ * `reliability/replicas` - The ordered list of the replicas for the timer, the receiving node can use this to work out when it should pop the timer.
+
+#### Replicating a Timer Pop
+
+When one Chronos instance pops a timer it informs all other replicas of the timer by sending a PUT message (same JSON body as above) with the appropriate `sequnence-number` set.  The receiving nodes should prepare to pop the timer at the next interval (if appropriate).
+
+#### Replicating a Timer Deletion
+
+When a timer is deleted by a client or after the final timer pop, the handling node sends a PUT to the replicas for that timer specifying an empty `callback` section (indicating that this is a tombstone record) and with an appropriate `start-time-delta` and `sequence-number`.  A tombstone should be stored for one more `interval` of time to prevent out-of-date replication requests from re-creating deleted timers.
 
 ### Resynchronization requests
 
-The timer service supports two types of request to allow Chronos nodes to resynchronize timers. 
+The timer service supports two types of request to allow Chronos nodes to resynchronize timers.
 
 Resynchronizing timers between nodes is carried out by each Chronos node sending a series of GETs and DELETEs to all the other Chronos nodes in the Chronos cluster. The resynchronization process is described in more detail [here](doc/scaling.md).
 
@@ -119,13 +167,13 @@ Resynchronizing timers between nodes is carried out by each Chronos node sending
 
     GET /timers
 
-This URL requests information about timers that are on the receiving node that the requesting node will be a replica for under new cluster configuration. 
- 
+This URL requests information about timers that are on the receiving node that the requesting node will be a replica for under new cluster configuration.
+
 It takes three mandatory parameters
 
 * `node-for-replicas=<address>` - The address of the node to check for replica status (typically the requesting node). This must match a node in the Chronos cluster
-* `sync-mode=<sync-mode>` - The synchronization mode. The only currently supported value is SCALE. 
-* `cluster-view-id=<cluster-view-id>` - The requesting node's view of the current cluster configuration. 
+* `sync-mode=<sync-mode>` - The synchronization mode. The only currently supported value is SCALE.
+* `cluster-view-id=<cluster-view-id>` - The requesting node's view of the current cluster configuration.
 
 The request should also include a `Range` header, holding how many timers should be returned in one response, e.g.:
 
@@ -164,13 +212,13 @@ The JSON body in the response has the format:
                ]
     }
 
-This JSON body contains enough information for the requesting node to add the timer to their timer wheel, and to optionally replicate the timer to other nodes. The `Timer` object contains the information to recreate the timer on the node, the `TimerID` holds the timer's ID, and the `OldReplicas` list holds where the replicas for the timer were under the old cluster configuration. 
+This JSON body contains enough information for the requesting node to add the timer to their timer wheel, and to optionally replicate the timer to other nodes. The `Timer` object contains the information to recreate the timer on the node, the `TimerID` holds the timer's ID, and the `OldReplicas` list holds where the replicas for the timer were under the old cluster configuration.
 
 #### Request (DELETE)
 
     DELETE /timers/references
 
-This URL requests that the receiving node delete their references to a set of timers. 
+This URL requests that the receiving node delete their references to a set of timers.
 
 The DELETE body consists of the IDs of all the timers the node has just processed, paired with the replica number of the node for each timer. It has the format:
 
@@ -180,7 +228,7 @@ The DELETE body consists of the IDs of all the timers the node has just processe
             ]
     }
 
-The `ReplicaIndex` is the index of the timer in the replica list (where 0 represents the primary). The `ID` is the timer ID. 
+The `ReplicaIndex` is the index of the timer in the replica list (where 0 represents the primary). The `ID` is the timer ID.
 
 #### Response (DELETE)
 

--- a/mk/platform.mk
+++ b/mk/platform.mk
@@ -86,7 +86,7 @@ TARGET_OBJS_TEST := $(patsubst %.cpp, ${OBJ_DIR_TEST}/%.o, ${TARGET_SOURCES} ${T
                     $(patsubst %,     ${OBJ_DIR_TEST}/%, $(TARGET_EXTRA_OBJS_TEST))
 
 # The dependencies
-DEPS := $(patsubst %.o, %.depends, $(patsubst %.so, %.depends, ${TARGET_OBJS} ${TARGET_OBJS_TEST}))
+DEPS := $(patsubst %.o, %.d, $(patsubst %.so, %.depends, ${TARGET_OBJS} ${TARGET_OBJS_TEST}))
 
 # Buld the test binary.
 .PHONY: build_test
@@ -109,26 +109,14 @@ ${TARGET_BIN_TEST}: ${TARGET_OBJS_TEST}
 
 ${OBJ_DIR}/%.o: %.cpp
 	@mkdir -p $(@D)
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(CPPFLAGS_BUILD) $(TARGET_ARCH) -c -o $@ $<
+	$(CXX) -MMD $(CXXFLAGS) $(CPPFLAGS) $(CPPFLAGS_BUILD) $(TARGET_ARCH) -c -o $@ $<
 
 ${OBJ_DIR_TEST}/%.o: %.cpp
 	@mkdir -p $(@D)
 	-rm $(patsubst %o, %gcno, $@)
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(CPPFLAGS_TEST) $(TARGET_ARCH) -c -o $@ $<
+	$(CXX) -MMD $(CXXFLAGS) $(CPPFLAGS) $(CPPFLAGS_TEST) $(TARGET_ARCH) -c -o $@ $<
 
 ${OBJ_DIR_TEST}/%.o: $(UT_DIR)/%.cpp
-	$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(CPPFLAGS_TEST) $(TARGET_ARCH) -c -o $@ $<
-
-${OBJ_DIR}/%.depends: %.cpp
-	@mkdir -p $(@D)
-	@$(CXX) -M -MQ ${OBJ_DIR}/$*.o -MQ $@ $(CXXFLAGS) $(CPPFLAGS) $(CPPFLAGS_BUILD) $(TARGET_ARCH) -c -o $@ $<
-
-${OBJ_DIR_TEST}/%.depends: %.cpp
-	@mkdir -p $(@D)
-	@$(CXX) -M -MQ ${OBJ_DIR_TEST}/$*.o -MQ $@ $(CXXFLAGS) $(CPPFLAGS) $(CPPFLAGS_TEST) $(TARGET_ARCH) -c -o $@ $<
-
-${OBJ_DIR_TEST}/%.depends: $(UT_DIR)/%.cpp
-	@mkdir -p $(@D)
-	@$(CXX) -M -MQ ${OBJ_DIR_TEST}/$*.o -MQ $@ $(CXXFLAGS) $(CPPFLAGS) $(CPPFLAGS_TEST) $(TARGET_ARCH) -c -o $@ $<
+	$(CXX) -MMD $(CXXFLAGS) $(CPPFLAGS) $(CPPFLAGS_TEST) $(TARGET_ARCH) -c -o $@ $<
 
 -include $(DEPS)

--- a/src/include/timer.h
+++ b/src/include/timer.h
@@ -115,7 +115,7 @@ public:
   // Member variables (mostly public since this is pretty much a struct with utility
   // functions, rather than a full-blown object).
   TimerID id;
-  uint64_t start_time;
+  uint64_t start_time_mono_ms;
   uint32_t interval;
   uint32_t repeat_for;
   uint32_t sequence_number;

--- a/src/include/timer_store.h
+++ b/src/include/timer_store.h
@@ -167,8 +167,8 @@ private:
   // a multiple of SHORT_WHEEL_RESOLUTION_MS.
   uint64_t _tick_timestamp;
 
-  // Return the current wall time in ms.
-  static uint64_t wall_time_ms();
+  // Return the current timestamp in ms.
+  static uint64_t timestamp_ms();
 
   // Utility functions to locate a Timer's correct home in the store's timer
   // wheels.

--- a/src/main/timer.cpp
+++ b/src/main/timer.cpp
@@ -50,6 +50,7 @@
 #include <boost/format.hpp>
 #include <map>
 #include <atomic>
+#include <time.h>
 
 uint32_t Hasher::do_hash(TimerID data, uint32_t seed)
 {
@@ -79,7 +80,7 @@ Timer::Timer(TimerID id, uint32_t interval, uint32_t repeat_for) :
   // Get the cluster view ID from global configuration
   std::string global_cluster_view_id;
   __globals->get_cluster_view_id(global_cluster_view_id);
-  cluster_view_id = global_cluster_view_id; 
+  cluster_view_id = global_cluster_view_id;
 }
 
 Timer::~Timer()
@@ -93,8 +94,8 @@ uint64_t Timer::next_pop_time()
   int replica_index = 0;
   __globals->get_cluster_local_ip(localhost);
 
-  for (std::vector<std::string>::iterator it = replicas.begin(); 
-                                          it != replicas.end(); 
+  for (std::vector<std::string>::iterator it = replicas.begin();
+                                          it != replicas.end();
                                           ++it, ++replica_index)
   {
     if (*it == localhost)
@@ -126,15 +127,15 @@ std::string Timer::url(std::string host)
 
     ss << "http://" << address << ":" << port;
   }
-  
+
   ss << "/timers/";
   ss << std::setfill('0') << std::setw(16) << std::hex << id;
   uint64_t hash = 0;
   std::map<std::string, uint64_t> cluster_bloom_filters;
   __globals->get_cluster_bloom_filters(cluster_bloom_filters);
 
-  for (std::vector<std::string>::iterator it = replicas.begin(); 
-                                          it != replicas.end(); 
+  for (std::vector<std::string>::iterator it = replicas.begin();
+                                          it != replicas.end();
                                           ++it)
   {
     hash |= cluster_bloom_filters[*it];
@@ -148,7 +149,8 @@ std::string Timer::url(std::string host)
 // The JSON should take the form:
 // {
 //     "timing": {
-//         "start-time": Int64,
+//         "start-time": UInt64, // Wall-time in milliseconds - Deprecated in favor of "start-time-delta"
+//         "start-time-delta": Int32, // Millisecond offset from current time
 //         "sequence-number": Int,
 //         "interval": Int,
 //         "repeat-for": Int
@@ -178,6 +180,13 @@ std::string Timer::to_json()
   return body;
 }
 
+inline uint64_t clock_gettime_ms(int clock_id)
+{
+  struct timespec time;
+  clock_gettime(clock_id, &time);
+  return ((time.tv_sec * 1000) + (time.tv_nsec / 1000));
+}
+
 void Timer::to_json_obj(rapidjson::Writer<rapidjson::StringBuffer>* writer)
 {
   writer->StartObject();
@@ -185,8 +194,13 @@ void Timer::to_json_obj(rapidjson::Writer<rapidjson::StringBuffer>* writer)
     writer->String("timing");
     writer->StartObject();
     {
+      uint64_t realtime = clock_gettime_ms(CLOCK_REALTIME);
+      uint64_t monotime = clock_gettime_ms(CLOCK_MONOTONIC);
+      int32_t delta = start_time_mono_ms - monotime;
       writer->String("start-time");
-      writer->Int64(start_time);
+      writer->Int64(realtime + delta);
+      writer->String("start-time-delta");
+      writer->Int64(delta);
       writer->String("sequence-number");
       writer->Int(sequence_number);
       writer->String("interval");
@@ -305,7 +319,7 @@ static void calculate_rendezvous_hash(std::vector<std::string> cluster,
     // and (30, 3), so the ordered list is A, C, B, D. Effectively, the
     // first entry in the original list consistently wins.
     //
-    // This doesn't work perfectly in the edge case 
+    // This doesn't work perfectly in the edge case
     // If I have servers A, B, C, D which cause this
     // timer to hash to 10, 11, 10, 11:
     // hash_to_idx[10] = 0 (A's index)
@@ -327,7 +341,7 @@ static void calculate_rendezvous_hash(std::vector<std::string> cluster,
       hash++;
       // LCOV_EXCL_STOP
     }
-    
+
     hash_to_idx[hash] = ii;
   }
 
@@ -338,10 +352,10 @@ static void calculate_rendezvous_hash(std::vector<std::string> cluster,
   {
     ordered_cluster.push_back(cluster[ii->second]);
   }
-  
+
   replicas.push_back(ordered_cluster.front());
 
-  // Pick the (N-1) highest hash values as the backup replicas.  
+  // Pick the (N-1) highest hash values as the backup replicas.
   replication_factor = replication_factor > ordered_cluster.size() ?
                        ordered_cluster.size() : replication_factor;
 
@@ -408,8 +422,8 @@ void Timer::calculate_replicas(TimerID id,
   }
 
   TRC_DEBUG("Replicas calculated:");
-  for (std::vector<std::string>::iterator it = replicas.begin(); 
-                                          it != replicas.end(); 
+  for (std::vector<std::string>::iterator it = replicas.begin();
+                                          it != replicas.end();
                                           ++it)
   {
     TRC_DEBUG(" - %s", it->c_str());
@@ -420,7 +434,7 @@ void Timer::calculate_replicas(uint64_t replica_hash)
 {
   std::map<std::string, uint64_t> cluster_bloom_filters;
   __globals->get_cluster_bloom_filters(cluster_bloom_filters);
-  
+
   std::vector<std::string> cluster;
   __globals->get_cluster_addresses(cluster);
 
@@ -472,10 +486,10 @@ Timer* Timer::create_tombstone(TimerID id, uint64_t replica_hash)
 // @param json - The JSON representation of the timer.
 // @param error - This will be populated with a descriptive error string if required.
 // @param replicated - This will be set to true if this is a replica of a timer.
-Timer* Timer::from_json(TimerID id, 
-                        uint64_t replica_hash, 
-                        std::string json, 
-                        std::string& error, 
+Timer* Timer::from_json(TimerID id,
+                        uint64_t replica_hash,
+                        std::string json,
+                        std::string& error,
                         bool& replicated)
 {
   rapidjson::Document doc;
@@ -488,13 +502,13 @@ Timer* Timer::from_json(TimerID id,
     return NULL;
   }
 
-  return from_json_obj(id, replica_hash, error, replicated, doc);  
+  return from_json_obj(id, replica_hash, error, replicated, doc);
 }
 
-Timer* Timer::from_json_obj(TimerID id, 
-                            uint64_t replica_hash, 
-                            std::string& error, 
-                            bool& replicated, 
+Timer* Timer::from_json_obj(TimerID id,
+                            uint64_t replica_hash,
+                            std::string& error,
+                            bool& replicated,
                             rapidjson::Value& doc)
 {
   Timer* timer = NULL;
@@ -526,18 +540,30 @@ Timer* Timer::from_json_obj(TimerID id,
 
     if ((interval.GetInt() == 0) && (repeat_for_int != 0))
     {
-      // If the interval time is 0 and the repeat_for_int isn't then reject the timer. 
-      error = "Can't have a zero interval time with a non-zero (%s) repeat-for time", 
+      // If the interval time is 0 and the repeat_for_int isn't then reject the timer.
+      error = "Can't have a zero interval time with a non-zero (%s) repeat-for time",
               std::to_string(repeat_for_int);
       return NULL;
     }
 
     timer = new Timer(id, (interval.GetInt() * 1000), (repeat_for_int * 1000));
 
-    if (timing.HasMember("start-time"))
+    if (timing.HasMember("start-time-delta"))
+    {
+      // Timer JSON specified a time offset, use that to determine the true
+      // start time.
+      uint64_t start_time_delta;
+      JSON_GET_INT_64_MEMBER(timing, "start-time-delta", start_time_delta);
+      timer->start_time_mono_ms = clock_gettime_ms(CLOCK_MONOTONIC) + start_time_delta;
+    }
+    else if (timing.HasMember("start-time"))
     {
       // Timer JSON specifies a start-time, use that instead of now.
-      JSON_GET_INT_64_MEMBER(timing, "start-time", timer->start_time);
+      uint64_t real_start_time;
+      JSON_GET_INT_64_MEMBER(timing, "start-time", real_start_time);
+      uint64_t real_time = clock_gettime_ms(CLOCK_REALTIME);
+      uint64_t mono_time = clock_gettime_ms(CLOCK_MONOTONIC);
+      timer->start_time_mono_ms = mono_time + (real_start_time - real_time);
     }
 
     if (timing.HasMember("sequence-number"))
@@ -564,8 +590,8 @@ Timer* Timer::from_json_obj(TimerID id,
 
       if (reliability.HasMember("cluster-view-id"))
       {
-        JSON_GET_STRING_MEMBER(reliability, 
-                               "cluster-view-id", 
+        JSON_GET_STRING_MEMBER(reliability,
+                               "cluster-view-id",
                                timer->cluster_view_id);
       }
 
@@ -583,8 +609,8 @@ Timer* Timer::from_json_obj(TimerID id,
 
         timer->_replication_factor = replicas.Size();
 
-        for (rapidjson::Value::ConstValueIterator it = replicas.Begin(); 
-                                                  it != replicas.End(); 
+        for (rapidjson::Value::ConstValueIterator it = replicas.Begin();
+                                                  it != replicas.End();
                                                   ++it)
         {
           JSON_ASSERT_STRING(*it);
@@ -655,7 +681,7 @@ void Timer::update_cluster_information()
   replicas.clear();
   calculate_replicas(0);
 
-  // Update the cluster view ID 
+  // Update the cluster view ID
   std::string global_cluster_view_id;
   __globals->get_cluster_view_id(global_cluster_view_id);
  cluster_view_id = global_cluster_view_id;

--- a/src/main/timer.cpp
+++ b/src/main/timer.cpp
@@ -61,6 +61,13 @@ uint32_t Hasher::do_hash(TimerID data, uint32_t seed)
 
 static Hasher hasher;
 
+inline uint64_t clock_gettime_ms(int clock_id)
+{
+  struct timespec time;
+  clock_gettime(clock_id, &time);
+  return ((time.tv_sec * 1000) + (time.tv_nsec / 1000000));
+}
+
 Timer::Timer(TimerID id, uint32_t interval, uint32_t repeat_for) :
   id(id),
   interval(interval),
@@ -73,9 +80,7 @@ Timer::Timer(TimerID id, uint32_t interval, uint32_t repeat_for) :
   _replica_tracker(0)
 {
   // Set the start time to now
-  struct timespec ts;
-  clock_gettime(CLOCK_MONOTONIC, &ts);
-  start_time_mono_ms = (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
+  start_time_mono_ms = clock_gettime_ms(CLOCK_MONOTONIC);
 
   // Get the cluster view ID from global configuration
   std::string global_cluster_view_id;
@@ -178,13 +183,6 @@ std::string Timer::to_json()
   TRC_DEBUG("Built replication body: %s", body.c_str());
 
   return body;
-}
-
-inline uint64_t clock_gettime_ms(int clock_id)
-{
-  struct timespec time;
-  clock_gettime(clock_id, &time);
-  return ((time.tv_sec * 1000) + (time.tv_nsec / 1000));
 }
 
 void Timer::to_json_obj(rapidjson::Writer<rapidjson::StringBuffer>* writer)

--- a/src/main/timer.cpp
+++ b/src/main/timer.cpp
@@ -71,10 +71,10 @@ Timer::Timer(TimerID id, uint32_t interval, uint32_t repeat_for) :
   _replication_factor(0),
   _replica_tracker(0)
 {
-  // Set the start time to now (using REALTIME)
+  // Set the start time to now
   struct timespec ts;
-  clock_gettime(CLOCK_REALTIME, &ts);
-  start_time = (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  start_time_mono_ms = (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
 
   // Get the cluster view ID from global configuration
   std::string global_cluster_view_id;
@@ -103,7 +103,7 @@ uint64_t Timer::next_pop_time()
     }
   }
 
-  return start_time + ((sequence_number + 1) * interval) + (replica_index * 2 * 1000);
+  return start_time_mono_ms + ((sequence_number + 1) * interval) + (replica_index * 2 * 1000);
 }
 
 // Create the timer's URL from a given hostname

--- a/src/test/test_timer.cpp
+++ b/src/test/test_timer.cpp
@@ -1,42 +1,39 @@
-/**
- * @file test_timer.cpp
+/** @file test_timer.cpp
  *
- * Project Clearwater - IMS in the Cloud
- * Copyright (C) 2013  Metaswitch Networks Ltd
+ * Project Clearwater - IMS in the Cloud Copyright (C) 2013  Metaswitch
+ * Networks Ltd
  *
  * This program is free software: you can redistribute it and/or modify it
- * under the terms of the GNU General Public License as published by the
- * Free Software Foundation, either version 3 of the License, or (at your
- * option) any later version, along with the "Special Exception" for use of
- * the program along with SSL, set forth below. This program is distributed
- * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
- * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
- * A PARTICULAR PURPOSE.  See the GNU General Public License for more
- * details. You should have received a copy of the GNU General Public
- * License along with this program.  If not, see
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation, either version 3 of the License, or (at your option)
+ * any later version, along with the "Special Exception" for use of the program
+ * along with SSL, set forth below. This program is distributed in the hope
+ * that it will be useful, but WITHOUT ANY WARRANTY; without even the implied
+ * warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details. You should have received a copy
+ * of the GNU General Public License along with this program.  If not, see
  * <http://www.gnu.org/licenses/>.
  *
- * The author can be reached by email at clearwater@metaswitch.com or by
- * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ * The author can be reached by email at clearwater@metaswitch.com or by post
+ * at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
  *
- * Special Exception
- * Metaswitch Networks Ltd  grants you permission to copy, modify,
- * propagate, and distribute a work formed by combining OpenSSL with The
- * Software, or a work derivative of such a combination, even if such
- * copying, modification, propagation, or distribution would otherwise
- * violate the terms of the GPL. You must comply with the GPL in all
- * respects for all of the code used other than OpenSSL.
- * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
- * Project and licensed under the OpenSSL Licenses, or a work based on such
- * software and licensed under the OpenSSL Licenses.
- * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
- * under which the OpenSSL Project distributes the OpenSSL toolkit software,
- * as those licenses appear in the file LICENSE-OPENSSL.
+ * Special Exception Metaswitch Networks Ltd  grants you permission to copy,
+ * modify, propagate, and distribute a work formed by combining OpenSSL with
+ * The Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise violate
+ * the terms of the GPL. You must comply with the GPL in all respects for all
+ * of the code used other than OpenSSL.  "OpenSSL" means OpenSSL toolkit
+ * software distributed by the OpenSSL Project and licensed under the OpenSSL
+ * Licenses, or a work based on such software and licensed under the OpenSSL
+ * Licenses.  "OpenSSL Licenses" means the OpenSSL License and Original SSLeay
+ * License under which the OpenSSL Project distributes the OpenSSL toolkit
+ * software, as those licenses appear in the file LICENSE-OPENSSL.
  */
 
 #include "timer.h"
 #include "globals.h"
 #include "base.h"
+#include "test_interposer.hpp"
 
 #include <gtest/gtest.h>
 #include <map>
@@ -51,6 +48,7 @@ protected:
   virtual void SetUp()
   {
     Base::SetUp();
+
     std::vector<std::string> replicas;
     replicas.push_back("10.0.0.1:9999");
     replicas.push_back("10.0.0.2:9999");
@@ -74,7 +72,10 @@ protected:
   }
 
   // Helper function to access timer private variables
-  int get_replication_factor(Timer* t) { return t->_replication_factor; }
+  int get_replication_factor(Timer* t)
+  {
+    return t->_replication_factor;
+  }
 
   Timer* t1;
 };
@@ -85,52 +86,62 @@ protected:
 
 TEST_F(TestTimer, FromJSONTests)
 {
+  // The following tests depend on the current time, so install the shim
+  cwtest_completely_control_time();
+
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  uint64_t mono_time = (ts.tv_sec * 1000) + (ts.tv_nsec / 1000);
+  clock_gettime(CLOCK_REALTIME, &ts);
+  uint64_t real_time = (ts.tv_sec * 1000) + (ts.tv_nsec / 1000);
+
   std::vector<std::string> failing_test_data;
-  failing_test_data.push_back(
-      "{}");
-  failing_test_data.push_back(
-      "{\"timing\"}");
-  failing_test_data.push_back(
-      "{\"timing\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": [], \"callback\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": [], \"callback\": [], \"reliability\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": {}, \"callback\": [], \"reliability\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": \"hello\" }, \"callback\": [], \"reliability\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": \"hello\", \"repeat-for\": \"hello\" }, \"callback\": [], \"reliability\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": 100, \"repeat-for\": \"hello\" }, \"callback\": [], \"reliability\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": [], \"reliability\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": {}, \"reliability\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": []}, \"reliability\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": {}}, \"reliability\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": [] }}, \"reliability\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": [], \"opaque\": [] }}, \"reliability\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": [] }}, \"reliability\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": []}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replication-factor\": \"hello\" }}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [] }}");
-  failing_test_data.push_back(
-      "{\"timing\": { \"interval\": 0, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}}");
+
+  failing_test_data.push_back("{}");
+
+  failing_test_data.push_back("{\"timing\"}");
+
+  failing_test_data.push_back("{\"timing\": []}");
+
+  failing_test_data.push_back("{\"timing\": [], \"callback\": []}");
+
+  failing_test_data.push_back("{\"timing\": [], \"callback\": [], \"reliability\": []}");
+
+  failing_test_data.push_back("{\"timing\": {}, \"callback\": [], \"reliability\": []}");
+
+  failing_test_data.push_back("{\"timing\": { \"interval\": \"hello\" }, \"callback\": [], \"reliability\": []}");
+
+  failing_test_data.push_back("{\"timing\": { \"interval\": \"hello\", \"repeat-for\": \"hello\" }, \"callback\": [], \"reliability\": []}");
+
+  failing_test_data.push_back("{\"timing\": { \"interval\": 100, \"repeat-for\": \"hello\" }, \"callback\": [], \"reliability\": []}");
+
+  failing_test_data.push_back("{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": [], \"reliability\": []}");
+
+  failing_test_data.push_back("{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": {}, \"reliability\": []}");
+
+  failing_test_data.push_back("{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": []}, \"reliability\": []}");
+
+  failing_test_data.push_back("{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": {}}, \"reliability\": []}");
+
+  failing_test_data.push_back("{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": [] }}, \"reliability\": []}");
+
+  failing_test_data.push_back("{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": [], \"opaque\": [] }}, \"reliability\": []}");
+
+  failing_test_data.push_back("{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": [] }}, \"reliability\": []}");
+
+  failing_test_data.push_back( "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": []}");
+
+  failing_test_data.push_back( "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replication-factor\": \"hello\" }}");
+
+  failing_test_data.push_back("{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [] }}");
+
+  failing_test_data.push_back( "{\"timing\": { \"interval\": 0, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}}");
 
   // Reliability can be ignored by the client to use default replication.
   std::string default_repl_factor = "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}}";
 
-  // Reliability can be specified as empty by the client to use default replication.
+  // Reliability can be specified as empty by the client to use default
+  // replication.
   std::string default_repl_factor2 = "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": {}}";
 
   // Or you can pass a custom replication factor.
@@ -142,20 +153,26 @@ TEST_F(TestTimer, FromJSONTests)
   // You can skip the `repeat-for` to set up a one-shot timer.
   std::string no_repeat_for = "{\"timing\": { \"interval\": 100 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replication-factor\": 3 }}";
 
+  // You can (should) specify start time by relative delta, not absolute
+  // timestamp, the relative number should be preferred.
+  std::string delta_start_time = "{\"timing\": { \"start-time\": 100, \"start-time-delta\":-200, \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": {}}";
+
+  // For backwards compatibility, we have to be accepting of nodes that don't
+  // include "start-time-delta" in their JSON.
+  std::ostringstream absolute_start_time_s; absolute_start_time_s << "{\"timing\": { \"start-time\":" << real_time - 300 << ", \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": {}}";
+  std::string absolute_start_time = absolute_start_time_s.str();
+
   // Each of the failing json blocks should not parse to a timer.
-  for (std::vector<std::string>::iterator it = failing_test_data.begin(); 
-                                          it != failing_test_data.end(); 
-                                          ++it)
+  for (std::vector<std::string>::iterator it = failing_test_data.begin();
+       it != failing_test_data.end();
+       ++it)
   {
-    std::string err;
-    bool replicated;
+    std::string err; bool replicated;
     EXPECT_EQ((void*)NULL, Timer::from_json(1, 0, *it, err, replicated)) << *it;
     EXPECT_NE("", err);
   }
 
-  std::string err;
-  bool replicated;
-  Timer* timer;
+  std::string err; bool replicated; Timer* timer;
 
   // If you don't specify a replication-factor, use 2.
   timer = Timer::from_json(1, 0, default_repl_factor, err, replicated);
@@ -165,6 +182,7 @@ TEST_F(TestTimer, FromJSONTests)
   EXPECT_EQ(2, get_replication_factor(timer));
   EXPECT_EQ(2u, timer->replicas.size());
   delete timer;
+
   timer = Timer::from_json(1, 0, default_repl_factor2, err, replicated);
   EXPECT_NE((void*)NULL, timer);
   EXPECT_EQ("", err);
@@ -175,11 +193,9 @@ TEST_F(TestTimer, FromJSONTests)
 
   // If you do specify a replication-factor, use that.
   timer = Timer::from_json(1, 0, custom_repl_factor, err, replicated);
-  EXPECT_NE((void*)NULL, timer);
-  EXPECT_EQ("", err);
-  EXPECT_FALSE(replicated);
-  EXPECT_EQ(3, get_replication_factor(timer));
-  EXPECT_EQ(3u, timer->replicas.size());
+  EXPECT_NE((void*)NULL, timer); EXPECT_EQ("", err); EXPECT_FALSE(replicated);
+  EXPECT_EQ(3, get_replication_factor(timer)); EXPECT_EQ(3u,
+                                                         timer->replicas.size());
   delete timer;
 
   // Get the replicas from the bloom filter if given
@@ -197,20 +213,40 @@ TEST_F(TestTimer, FromJSONTests)
   EXPECT_EQ(3, get_replication_factor(timer));
   delete timer;
 
-  // If specifc replicas are specified, use them (regardless of presence of bloom hash).
+  // If specific replicas are specified, use them (regardless of presence of
+  // bloom hash).
   timer = Timer::from_json(1, 0x11011100011101, specific_replicas, err, replicated);
   EXPECT_NE((void*)NULL, timer);
   EXPECT_EQ("", err);
   EXPECT_TRUE(replicated);
   EXPECT_EQ(2, get_replication_factor(timer));
   delete timer;
-  
+
   // If no repeat for was specifed, use the interval
   timer = Timer::from_json(1, 0x11011100011101, no_repeat_for, err, replicated);
   EXPECT_NE((void*)NULL, timer);
   EXPECT_EQ("", err);
   EXPECT_EQ(timer->interval, timer->repeat_for);
   delete timer;
+
+  // If delta-start-time was provided, use that
+  timer = Timer::from_json(1, 0x11011100011101, delta_start_time, err, replicated);
+  EXPECT_NE((void*)NULL, timer);
+  EXPECT_EQ("", err); EXPECT_EQ(mono_time - 200, timer->start_time_mono_ms);
+  delete timer;
+
+  // If absolute start time was proved (and no delta-time), use that.
+  timer = Timer::from_json(1, 0x11011100011101, absolute_start_time, err, replicated);
+  EXPECT_NE((void*)NULL, timer);
+  EXPECT_EQ("", err);
+
+  // Note that this compares to monotonic time (but the offest is the same as
+  // the offset to realtime when we made the JSON string).
+  EXPECT_EQ(mono_time - 300, timer->start_time_mono_ms);
+  delete timer;
+
+  // Restore real time
+  cwtest_reset_time();
 }
 
 // Utility thread function to test thread-safeness of the unique generation
@@ -276,8 +312,13 @@ TEST_F(TestTimer, URL)
 
 TEST_F(TestTimer, ToJSON)
 {
-  // Test this by rendering as JSON, then parsing back to a timer
-  // and comparing.
+  // Test this by rendering as JSON, then parsing back to a timer and
+  // comparing.
+
+  // Need to completely control time here (as we encode the time as a
+  // delta against "now" in the JSON and need that to come back the same
+  // afterwards).
+  cwtest_completely_control_time();
 
   // We need to use a new timer here, because the values we use in
   // testing (100ms and 200ms) are too short to be specified on the
@@ -292,10 +333,14 @@ TEST_F(TestTimer, ToJSON)
   t2->callback_url = "http://localhost:80/callback";
   t2->callback_body = "{\"stuff\": \"stuff\"}";
   t2->cluster_view_id = "cluster-view-id";
+
+  // Move time forward a bit, to check this this is correctly
+  // compensated for by the start-time-delta.
+  cwtest_advance_time_ms(1000);
   std::string json = t2->to_json();
+
   std::string err;
   bool replicated;
-
   Timer* t3 = Timer::from_json(2, 0, json, err, replicated);
   EXPECT_EQ(err, "");
   EXPECT_TRUE(replicated);
@@ -312,6 +357,8 @@ TEST_F(TestTimer, ToJSON)
   EXPECT_EQ("{\"stuff\": \"stuff\"}", t3->callback_body) << json;
   delete t2;
   delete t3;
+
+  cwtest_reset_time();
 }
 
 TEST_F(TestTimer, IsLocal)

--- a/src/test/test_timer.cpp
+++ b/src/test/test_timer.cpp
@@ -1,7 +1,8 @@
-/** @file test_timer.cpp
+/**
+ * @file test_timer.cpp
  *
- * Project Clearwater - IMS in the Cloud Copyright (C) 2013  Metaswitch
- * Networks Ltd
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2013  Metaswitch Networks Ltd
  *
  * This program is free software: you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free

--- a/src/test/test_timer.cpp
+++ b/src/test/test_timer.cpp
@@ -59,7 +59,7 @@ protected:
     uint32_t repeat_for = 200;
 
     t1 = new Timer(id, interval, repeat_for);
-    t1->start_time = 1000000;
+    t1->start_time_mono_ms = 1000000;
     t1->sequence_number = 0;
     t1->replicas = replicas;
     t1->callback_url = "http://localhost:80/callback";
@@ -286,7 +286,7 @@ TEST_F(TestTimer, ToJSON)
   uint32_t repeat_for = 2000;
 
   Timer* t2 = new Timer(1, interval, repeat_for);
-  t2->start_time = 1000000;
+  t2->start_time_mono_ms = 1000000;
   t2->sequence_number = 0;
   t2->replicas = t1->replicas;
   t2->callback_url = "http://localhost:80/callback";
@@ -302,7 +302,7 @@ TEST_F(TestTimer, ToJSON)
   ASSERT_NE((void*)NULL, t2);
 
   EXPECT_EQ(2u, t3->id) << json;
-  EXPECT_EQ(1000000u, t3->start_time) << json;
+  EXPECT_EQ(1000000u, t3->start_time_mono_ms) << json;
   EXPECT_EQ(t2->interval, t3->interval) << json;
   EXPECT_EQ(t2->repeat_for, t3->repeat_for) << json;
   EXPECT_EQ(2, get_replication_factor(t3)) << json;
@@ -324,7 +324,7 @@ TEST_F(TestTimer, IsLocal)
 TEST_F(TestTimer, IsTombstone)
 {
   Timer* t2 = Timer::create_tombstone(100, 0);
-  EXPECT_NE(0u, t2->start_time);
+  EXPECT_NE(0u, t2->start_time_mono_ms);
   EXPECT_TRUE(t2->is_tombstone());
   delete t2;
 }
@@ -334,7 +334,7 @@ TEST_F(TestTimer, BecomeTombstone)
   EXPECT_FALSE(t1->is_tombstone());
   t1->become_tombstone();
   EXPECT_TRUE(t1->is_tombstone());
-  EXPECT_EQ(1000000u, t1->start_time);
+  EXPECT_EQ(1000000u, t1->start_time_mono_ms);
   EXPECT_EQ(100u, t1->interval);
   EXPECT_EQ(100u, t1->repeat_for);
 }

--- a/src/test/test_timer_handler.cpp
+++ b/src/test/test_timer_handler.cpp
@@ -286,8 +286,8 @@ TEST_F(TestTimerHandler, FutureTimerPop)
 
   // Start the timer right now.
   struct timespec ts;
-  clock_gettime(CLOCK_REALTIME, &ts);
-  timer->start_time = (ts.tv_sec * 1000) + (ts.tv_nsec / (1000 * 1000));
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  timer->start_time_mono_ms = (ts.tv_sec * 1000) + (ts.tv_nsec / (1000 * 1000));
 
   // Since we only allocates timers on millisecond intervals, round the
   // time down to a millisecond.

--- a/src/test/timer_helper.cpp
+++ b/src/test/timer_helper.cpp
@@ -39,7 +39,7 @@
 Timer* default_timer(TimerID id)
 {
   Timer* timer = new Timer(id, 100, 100);
-  timer->start_time = 1000000;
+  timer->start_time_mono_ms = 1000000;
   timer->sequence_number = 0;
   timer->replicas = std::vector<std::string>(1, "10.0.0.1:9999");
   timer->callback_url = "localhost:80/callback" + std::to_string(id);


### PR DESCRIPTION
Fixes https://github.com/Metaswitch/chronos/issues/85.

The approach is that Chronos always talks in terms of offsets from the current time (the `start-time-delta` field in the JSON) this means we can translate from the monotonic clock on one Chronos instance to the monotonic clock on another Chronos with no loss of accuracy.

For back compatibility, Chronos also adds `start-time` based on it's local wall clock and handles receiving JSON without `start-time-delta` from old nodes.  Some future version might remove the old API.