### PR TITLE
No review required - Slice timestamps to uint32_t size

### DIFF
--- a/src/include/timer.h
+++ b/src/include/timer.h
@@ -115,7 +115,7 @@ public:
   // Member variables (mostly public since this is pretty much a struct with utility
   // functions, rather than a full-blown object).
   TimerID id;
-  uint64_t start_time_mono_ms;
+  uint32_t start_time_mono_ms;
   uint32_t interval;
   uint32_t repeat_for;
   uint32_t sequence_number;

--- a/src/main/timer.cpp
+++ b/src/main/timer.cpp
@@ -552,7 +552,9 @@ Timer* Timer::from_json_obj(TimerID id,
       // start time.
       uint64_t start_time_delta;
       JSON_GET_INT_64_MEMBER(timing, "start-time-delta", start_time_delta);
-      timer->start_time_mono_ms = clock_gettime_ms(CLOCK_MONOTONIC) + start_time_delta;
+
+      // This cast is safe as this sum is deliberately designed to wrap over UINT_MAX.
+      timer->start_time_mono_ms = (uint32_t)(clock_gettime_ms(CLOCK_MONOTONIC) + start_time_delta);
     }
     else if (timing.HasMember("start-time"))
     {
@@ -561,7 +563,9 @@ Timer* Timer::from_json_obj(TimerID id,
       JSON_GET_INT_64_MEMBER(timing, "start-time", real_start_time);
       uint64_t real_time = clock_gettime_ms(CLOCK_REALTIME);
       uint64_t mono_time = clock_gettime_ms(CLOCK_MONOTONIC);
-      timer->start_time_mono_ms = mono_time + (real_start_time - real_time);
+
+      // This cast is safe as this sum is deliberately designed to wrap over UINT_MAX.
+      timer->start_time_mono_ms = (uint32_t)(mono_time + real_start_time - real_time);
     }
 
     if (timing.HasMember("sequence-number"))


### PR DESCRIPTION
Fixes the ToJSON test when the monotonic clock is close to wrapping.