### PR TITLE
No review required - Log the correct-sized variable

### DIFF
--- a/src/main/timer_store.cpp
+++ b/src/main/timer_store.cpp
@@ -48,7 +48,7 @@
 
 // Macros to help log timer details.
 #define TIMER_LOG_FMT "ID:       %lu\n"                                        \
-                      "Start:    %lu\n"                                        \
+                      "Start:    %u\n"                                         \
                       "Interval: %u\n"                                         \
                       "Repeat:   %u\n"                                         \
                       "Seq:      %u\n"                                         \


### PR DESCRIPTION
Fix up valgrind warning about printing a `uint32_t` as a `uint64_t`.