### PR TITLE
Reviewer: Matt] - Added stateful statistics and replaced existing LVC model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,12 @@ TARGET_TEST := chronos_test
 TARGET_SOURCES_BUILD := src/main/main.cpp
 TARGET_SOURCES_TEST := $(wildcard src/test/*.cpp) test_interposer.cpp fakelogger.cpp mock_sas.cpp fakecurl.cpp pthread_cond_var_helper.cpp
 TARGET_SOURCES := $(filter-out $(TARGET_SOURCES_BUILD) $(TARGET_SOURCES_TEST), $(wildcard src/main/*.cpp) $(wildcard src/main/**/*.cpp))
-TARGET_SOURCES += log.cpp logger.cpp unique.cpp signalhandler.cpp alarm.cpp httpstack.cpp httpstack_utils.cpp accesslogger.cpp utils.cpp health_checker.cpp exception_handler.cpp httpconnection.cpp statistic.cpp baseresolver.cpp dnscachedresolver.cpp dnsparser.cpp zmq_lvc.cpp httpresolver.cpp counter.cpp
+
+TARGET_SOURCES += log.cpp logger.cpp unique.cpp signalhandler.cpp alarm.cpp httpstack.cpp httpstack_utils.cpp accesslogger.cpp utils.cpp health_checker.cpp exception_handler.cpp httpconnection.cpp statistic.cpp baseresolver.cpp dnscachedresolver.cpp dnsparser.cpp zmq_lvc.cpp httpresolver.cpp counter.cpp snmp_continuous_accumulator_table.cpp snmp_scalar.cpp snmp_agent.cpp snmp_row.cpp snmp_counter_table.cpp
 TARGET_EXTRA_OBJS_TEST := gmock-all.o gtest-all.o
 INCLUDE_DIR := ${ROOT}/src/include
 LIB_DIR := ${INSTALL_DIR}/lib
-CPPFLAGS := -ggdb -I${INCLUDE_DIR} -I${ROOT}/modules/cpp-common/include -I${ROOT}/modules/rapidjson/include -I${ROOT}/modules/sas-client/include -std=c++0x -I${INSTALL_DIR}/include -Werror 
+CPPFLAGS := -ggdb -I${INCLUDE_DIR} -I${ROOT}/modules/cpp-common/include -I${ROOT}/modules/rapidjson/include -I${ROOT}/modules/sas-client/include -std=c++0x -I${INSTALL_DIR}/include -Werror
 CPPFLAGS_BUILD := -O0
 CPPFLAGS_TEST := -O0 -fprofile-arcs -ftest-coverage -DUNIT_TEST -I${ROOT}/src/test/ -I${ROOT}/modules/cpp-common/test_utils/ -fno-access-control -I$(GTEST_DIR)/include -I$(GMOCK_DIR)/include
 LDFLAGS := -L${INSTALL_DIR}/lib -lrt -lpthread -lcurl -levent -lboost_program_options -lboost_regex -lzmq -lc -lboost_filesystem -lboost_system -levhtp \
@@ -84,7 +85,7 @@ ifdef JUSTTEST
   EXTRA_TEST_ARGS ?= --gtest_filter=$(JUSTTEST)
 endif
 
-.PHONY: test 
+.PHONY: test
 test: ${SUBMODULES} ${TARGET_BIN_TEST} run_test coverage coverage-check
 
 .PHONY: run_test

--- a/src/include/chronos_internal_connection.h
+++ b/src/include/chronos_internal_connection.h
@@ -44,15 +44,19 @@
 #include "updater.h"
 #include "statistic.h"
 #include "counter.h"
+#include "snmp_counter_table.h"
+#include "snmp_scalar.h"
 
 /// @class ChronosInternalConnection
 class ChronosInternalConnection
 {
 public:
   ChronosInternalConnection(HttpResolver* resolver,
-                            TimerHandler* handler, 
+                            TimerHandler* handler,
                             Replicator* replicator,
-                            LastValueCache* lvc,
+                            SNMP::U32Scalar* _remaining_nodes_scalar,
+                            SNMP::CounterTable* _timers_processed_table,
+                            SNMP::CounterTable* _invalid_timers_processed_table,
                             Alarm* alarm);
   virtual ~ChronosInternalConnection();
 
@@ -65,9 +69,9 @@ private:
   TimerHandler* _handler;
   Replicator* _replicator;
   Alarm* _alarm;
-  Statistic* _nodes_to_query_stat;
-  StatisticCounter* _timers_processed_stat;
-  StatisticCounter* _invalid_timers_processed_stat;
+  SNMP::U32Scalar* _remaining_nodes_scalar;
+  SNMP::CounterTable* _timers_processed_table;
+  SNMP::CounterTable* _invalid_timers_processed_table;
   Updater<void, ChronosInternalConnection>* _updater;
 
   // Creates the body to use in a delete request. This is a JSON
@@ -100,9 +104,9 @@ private:
                             std::string& response);
 
   // Resynchronises with a single Chronos node (used in scale
-  // operations). 
+  // operations).
   virtual HTTPCode resynchronise_with_single_node(
-                            const std::string server_to_sync, 
+                            const std::string server_to_sync,
                             std::vector<std::string> cluster_nodes,
                             std::string localhost);
 };

--- a/src/include/chronos_internal_connection.h
+++ b/src/include/chronos_internal_connection.h
@@ -54,10 +54,10 @@ public:
   ChronosInternalConnection(HttpResolver* resolver,
                             TimerHandler* handler,
                             Replicator* replicator,
-                            SNMP::U32Scalar* _remaining_nodes_scalar,
-                            SNMP::CounterTable* _timers_processed_table,
-                            SNMP::CounterTable* _invalid_timers_processed_table,
-                            Alarm* alarm);
+                            Alarm* alarm,
+                            SNMP::U32Scalar* _remaining_nodes_scalar = NULL,
+                            SNMP::CounterTable* _timers_processed_table = NULL,
+                            SNMP::CounterTable* _invalid_timers_processed_table = NULL);
   virtual ~ChronosInternalConnection();
 
   // Performs a scale-up/down operation by resynchronising

--- a/src/include/timer_handler.h
+++ b/src/include/timer_handler.h
@@ -47,11 +47,13 @@
 
 #include "timer_store.h"
 #include "callback.h"
+#include "snmp_continuous_accumulator_table.h"
+#include "snmp_scalar.h"
 
 class TimerHandler
 {
 public:
-  TimerHandler(TimerStore*, Callback*);
+  TimerHandler(TimerStore*, Callback*, SNMP::ContinuousAccumulatorTable*, SNMP::U32Scalar*);
   virtual ~TimerHandler();
   virtual void add_timer(Timer*);
   virtual void update_replica_tracker_for_timer(TimerID id,
@@ -72,11 +74,15 @@ private:
   void pop(std::unordered_set<Timer*>&);
   void pop(Timer*);
   void signal_new_timer(unsigned int);
+  void update_statistics(uint32_t);
 
   TimerStore* _store;
   Callback* _callback;
+  SNMP::ContinuousAccumulatorTable* _total_timers_table;
+  SNMP::U32Scalar* _current_timers_scalar;
 
   pthread_t _handler_thread;
+  uint32_t _timer_count;
   volatile bool _terminate;
   volatile unsigned int _nearest_new_timer;
   pthread_mutex_t _mutex;

--- a/src/main/chronos_internal_connection.cpp
+++ b/src/main/chronos_internal_connection.cpp
@@ -55,10 +55,10 @@
 ChronosInternalConnection::ChronosInternalConnection(HttpResolver* resolver,
                                                      TimerHandler* handler,
                                                      Replicator* replicator,
-                                                     SNMP::U32Scalar* _remaining_nodes_scalar,
-                                                     SNMP::CounterTable* _timers_processed_table,
-                                                     SNMP::CounterTable* _invalid_timers_processed_table,
-                                                     Alarm* alarm) :
+                                                     Alarm* alarm,
+                                                     SNMP::U32Scalar* remaining_nodes_scalar,
+                                                     SNMP::CounterTable* timers_processed_table,
+                                                     SNMP::CounterTable* invalid_timers_processed_table) :
   _http(new HttpConnection("",
                            false,
                            resolver,
@@ -67,9 +67,9 @@ ChronosInternalConnection::ChronosInternalConnection(HttpResolver* resolver,
   _handler(handler),
   _replicator(replicator),
   _alarm(alarm),
-  _remaining_nodes_scalar(_remaining_nodes_scalar),
-  _timers_processed_table(_timers_processed_table),
-  _invalid_timers_processed_table(_invalid_timers_processed_table)
+  _remaining_nodes_scalar(remaining_nodes_scalar),
+  _timers_processed_table(timers_processed_table),
+  _invalid_timers_processed_table(invalid_timers_processed_table)
 {
   // Create an updater to control when Chronos should resynchronise. This uses
   // SIGUSR1 rather than the default SIGHUP, and we shouldn't resynchronise

--- a/src/main/chronos_internal_connection.cpp
+++ b/src/main/chronos_internal_connection.cpp
@@ -52,10 +52,12 @@
 #include "globals.h"
 #include "chronos_pd_definitions.h"
 
-ChronosInternalConnection::ChronosInternalConnection(HttpResolver* resolver, 
-                                                     TimerHandler* handler, 
+ChronosInternalConnection::ChronosInternalConnection(HttpResolver* resolver,
+                                                     TimerHandler* handler,
                                                      Replicator* replicator,
-                                                     LastValueCache* lvc,
+                                                     SNMP::U32Scalar* _remaining_nodes_scalar,
+                                                     SNMP::CounterTable* _timers_processed_table,
+                                                     SNMP::CounterTable* _invalid_timers_processed_table,
                                                      Alarm* alarm) :
   _http(new HttpConnection("",
                            false,
@@ -65,31 +67,29 @@ ChronosInternalConnection::ChronosInternalConnection(HttpResolver* resolver,
   _handler(handler),
   _replicator(replicator),
   _alarm(alarm),
-  _nodes_to_query_stat(new Statistic("chronos_scale_nodes_to_query", lvc)),
-  _timers_processed_stat(new StatisticCounter("chronos_scale_timers_processed", lvc)),
-  _invalid_timers_processed_stat(new StatisticCounter("chronos_scale_invalid_timers_processed", lvc))
+  _remaining_nodes_scalar(_remaining_nodes_scalar),
+  _timers_processed_table(_timers_processed_table),
+  _invalid_timers_processed_table(_invalid_timers_processed_table)
 {
-  // Create an updater to control when Chronos should resynchronise. This uses 
+  // Create an updater to control when Chronos should resynchronise. This uses
   // SIGUSR1 rather than the default SIGHUP, and we shouldn't resynchronise
   // on start up (note this may change in future work)
   _updater = new Updater<void, ChronosInternalConnection>
-                   (this, 
-                   std::mem_fun(&ChronosInternalConnection::resynchronize), 
-                   &_sigusr1_handler, 
+                   (this,
+                   std::mem_fun(&ChronosInternalConnection::resynchronize),
+                   &_sigusr1_handler,
                    false);
-  
+
   // Zero the statistic to start with
-  std::vector<std::string> no_stats;
-  no_stats.push_back(std::to_string(0));
-  _nodes_to_query_stat->report_change(no_stats);
+  if (_remaining_nodes_scalar != NULL)
+  {
+    _remaining_nodes_scalar->value = 0;
+  }
 }
 
 ChronosInternalConnection::~ChronosInternalConnection()
 {
   delete _updater; _updater = NULL;
-  delete _invalid_timers_processed_stat; _invalid_timers_processed_stat = NULL;
-  delete _timers_processed_stat; _timers_processed_stat = NULL;
-  delete _nodes_to_query_stat; _nodes_to_query_stat = NULL;
   delete _http; _http = NULL;
 }
 
@@ -103,15 +103,15 @@ void ChronosInternalConnection::resynchronize()
 
   if (leaving_nodes.size() > 0)
   {
-    cluster_nodes.insert(cluster_nodes.end(), 
-                         leaving_nodes.begin(), 
+    cluster_nodes.insert(cluster_nodes.end(),
+                         leaving_nodes.begin(),
                          leaving_nodes.end());
   }
 
   // Shuffle the lists (so the same Chronos node doesn't get queried by
   // all the other nodes at the same time) and remove the local node
   srand(time(NULL));
-  std::random_shuffle(cluster_nodes.begin(), cluster_nodes.end()); 
+  std::random_shuffle(cluster_nodes.begin(), cluster_nodes.end());
   std::string localhost;
   __globals->get_cluster_local_ip(localhost);
   cluster_nodes.erase(std::remove(cluster_nodes.begin(),
@@ -135,10 +135,10 @@ void ChronosInternalConnection::resynchronize()
                                           ++it, --nodes_remaining)
   {
     // Update the number of nodes to query
-    std::vector<std::string> updated_values;
-    updated_values.push_back(std::to_string(nodes_remaining));
-    _nodes_to_query_stat->report_change(updated_values);
-    updated_values.clear();
+    if (_remaining_nodes_scalar != NULL)
+    {
+      _remaining_nodes_scalar->value = nodes_remaining;
+    }
 
     std::string address;
     int port;
@@ -150,15 +150,15 @@ void ChronosInternalConnection::resynchronize()
       __globals->get_bind_port(port);
       // LCOV_EXCL_STOP
     }
-    
+
     std::string server_to_sync = address + ":" + std::to_string(port);
-    HTTPCode rc = resynchronise_with_single_node(server_to_sync, 
+    HTTPCode rc = resynchronise_with_single_node(server_to_sync,
                                                  cluster_nodes,
                                                  localhost);
     if (rc != HTTP_OK)
     {
       TRC_WARNING("Resynchronisation with node %s failed with rc %d",
-                  server_to_sync.c_str(), 
+                  server_to_sync.c_str(),
                   rc);
       CL_CHRONOS_RESYNC_ERROR.log(server_to_sync.c_str());
     }
@@ -174,9 +174,10 @@ void ChronosInternalConnection::resynchronize()
     _alarm->clear();   // LCOV_EXCL_LINE - No alarms in UT
   }
 
-  std::vector<std::string> finished_value;
-  finished_value.push_back(std::to_string(0));
-  _nodes_to_query_stat->report_change(finished_value);
+  if (_remaining_nodes_scalar != NULL)
+  {
+    _remaining_nodes_scalar->value = 0;
+  }
 }
 
 HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
@@ -198,11 +199,11 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
   {
     std::map<TimerID, int> delete_map;
 
-    rc = send_get(server_to_sync, 
-                  localhost, 
-                  PARAM_SYNC_MODE_VALUE_SCALE, 
+    rc = send_get(server_to_sync,
+                  localhost,
+                  PARAM_SYNC_MODE_VALUE_SCALE,
                   cluster_view_id,
-                  MAX_TIMERS_IN_RESPONSE, 
+                  MAX_TIMERS_IN_RESPONSE,
                   response);
 
     if ((rc == HTTP_PARTIAL_CONTENT) ||
@@ -263,7 +264,7 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
 
             bool store_timer = false;
             std::string error_str;
-            bool replicated_timer; 
+            bool replicated_timer;
             Timer* timer = Timer::from_json_obj(timer_id,
                                                 0,
                                                 error_str,
@@ -286,7 +287,7 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
 
             // Decide what we're going to do with this timer.
             int old_level = 0;
-            bool in_old_replica_list = get_replica_level(old_level, 
+            bool in_old_replica_list = get_replica_level(old_level,
                                                          localhost,
                                                          old_replicas);
             int new_level = 0;
@@ -299,7 +300,7 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
 
             if (in_new_replica_list)
             {
-              // Add the timer to my store if I can. 
+              // Add the timer to my store if I can.
               if (in_old_replica_list)
               {
                 if (old_level >= new_level)
@@ -328,7 +329,7 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
                 }
                 else
                 {
-                  // We can potentially replicate the timer to one of these nodes. 
+                  // We can potentially replicate the timer to one of these nodes.
                   // Check whether the new replica was involved previously
                   int old_rep_level = 0;
                   bool is_new_rep_in_old_rep = get_replica_level(old_rep_level,
@@ -348,8 +349,8 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
                 }
               }
 
-              // Now loop through the old replicas. We can send a tombstone 
-              // replication to any node that used to be a replica and was 
+              // Now loop through the old replicas. We can send a tombstone
+              // replication to any node that used to be a replica and was
               // higher in the replica list than the new replica.
               index = 0;
               for (std::vector<std::string>::iterator it = old_replicas.begin();
@@ -373,7 +374,7 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
               }
             }
 
-            // Add the timer to the store if we can. This is done 
+            // Add the timer to the store if we can. This is done
             // last so we don't invalidate the pointer to the timer.
             if (store_timer)
             {
@@ -385,14 +386,21 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
             }
 
             // Finally, note that we processed the timer
-            _timers_processed_stat->increment();
+            if (_timers_processed_table != NULL)
+            {
+              _timers_processed_table->increment();
+            }
+
           }
           catch (JsonFormatError err)
           {
-            // A single entry is badly formatted. This is unexpected but we'll try 
-            // to keep going and process the rest of the timers. 
+            // A single entry is badly formatted. This is unexpected but we'll try
+            // to keep going and process the rest of the timers.
             count_invalid_timers++;
-            _invalid_timers_processed_stat->increment();
+            if (_invalid_timers_processed_table != NULL)
+            {
+              _invalid_timers_processed_table->increment();
+            }
             TRC_INFO("JSON entry was invalid (hit error at %s:%d)",
                      err._file, err._line);
           }
@@ -401,7 +409,7 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
         // Check if we were able to successfully process any timers - if not
         // then bail out as there's something wrong with the node we're
         // querying
-        if ((total_timers != 0) && 
+        if ((total_timers != 0) &&
            (count_invalid_timers == total_timers))
         {
           TRC_WARNING("Unable to process any timer entries in GET response");
@@ -429,11 +437,11 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
           if (delete_rc != HTTP_ACCEPTED)
           {
             // We've received an error response to the DELETE request. There's
-            // not much more we can do here (a timeout will have already 
+            // not much more we can do here (a timeout will have already
             // been retried). A failed DELETE won't prevent the scaling operation
             // from finishing, it just means that we'll tell other nodes
-            // about timers inefficiently. 
-            TRC_INFO("Error response (%d) to DELETE request to %s", 
+            // about timers inefficiently.
+            TRC_INFO("Error response (%d) to DELETE request to %s",
                      delete_rc,
                     (*it).c_str());
           }
@@ -443,10 +451,10 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
     else
     {
       // We've received an error response to the GET request. A timeout
-      // will already have been retried by the underlying HTTPConnection, 
+      // will already have been retried by the underlying HTTPConnection,
       // so don't retry again
-      TRC_WARNING("Error response (%d) to GET request to %s", 
-                  rc, 
+      TRC_WARNING("Error response (%d) to GET request to %s",
+                  rc,
                   server_to_sync.c_str());
     }
   }
@@ -490,7 +498,7 @@ std::string ChronosInternalConnection::create_delete_body(std::map<TimerID, int>
   rapidjson::Writer<rapidjson::StringBuffer> writer(sb);
   writer.StartObject();
 
-  writer.String(JSON_IDS); 
+  writer.String(JSON_IDS);
   writer.StartArray();
 
   for (std::map<TimerID, int>::iterator it = delete_map.begin();
@@ -520,7 +528,7 @@ bool ChronosInternalConnection::get_replica_presence(std::string current_node,
   return get_replica_level(unused_index, current_node, replicas);
 }
 
-bool ChronosInternalConnection::get_replica_level(int& index, 
+bool ChronosInternalConnection::get_replica_level(int& index,
                                                   std::string current_node,
                                                   std::vector<std::string> replicas)
 {

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -165,7 +165,6 @@ int main(int argc, char** argv)
   SNMP::ContinuousAccumulatorTable* total_timers_table = NULL;
   SNMP::U32Scalar* current_timers_scalar = NULL;
 
-
   // Sets up SNMP statistics
   snmp_setup("chronos");
 
@@ -286,10 +285,10 @@ int main(int argc, char** argv)
             new ChronosInternalConnection(http_resolver,
                                           handler,
                                           handler_rep,
+                                          scale_operation_alarm,
                                           remaining_nodes_scalar,
                                           timers_processed_table,
-                                          invalid_timers_processed_table,
-                                          scale_operation_alarm);
+                                          invalid_timers_processed_table);
 
   // Finally, set up the HTTPStack and handlers
   HttpStack* http_stack = HttpStack::get_instance();
@@ -349,6 +348,12 @@ int main(int argc, char** argv)
   delete handler_rep; handler_rep = NULL;
   delete controller_rep; controller_rep = NULL;
   delete store; store = NULL;
+
+  delete remaining_nodes_scalar;
+  delete timers_processed_table;
+  delete invalid_timers_processed_table;
+  delete total_timers_table;
+  delete current_timers_scalar;
 
   hc->terminate();
   pthread_join(health_check_thread, NULL);

--- a/src/test/test_chronos_internal_connection.cpp
+++ b/src/test/test_chronos_internal_connection.cpp
@@ -73,9 +73,6 @@ protected:
     _chronos = new ChronosInternalConnection(_resolver,
                                              _th,
                                              _replicator,
-                                             NULL,
-                                             NULL,
-                                             NULL,
                                              NULL);
     __globals->get_cluster_addresses(_cluster_addresses);
     __globals->get_cluster_local_ip(_local_ip);

--- a/src/test/test_chronos_internal_connection.cpp
+++ b/src/test/test_chronos_internal_connection.cpp
@@ -49,9 +49,9 @@ using ::testing::_;
 using ::testing::Return;
 using ::testing::SaveArg;
 
-MATCHER(IsTombstone, "is a tombstone") 
-{ 
-  return arg->is_tombstone(); 
+MATCHER(IsTombstone, "is a tombstone")
+{
+  return arg->is_tombstone();
 }
 
 MATCHER(IsNotTombstone, "is not a tombstone")
@@ -70,10 +70,12 @@ protected:
     _resolver = new FakeHttpResolver("10.42.42.42");
     _replicator = new MockReplicator();
     _th = new MockTimerHandler();
-    _chronos = new ChronosInternalConnection(_resolver, 
+    _chronos = new ChronosInternalConnection(_resolver,
                                              _th,
-                                             _replicator, 
-                                             NULL, 
+                                             _replicator,
+                                             NULL,
+                                             NULL,
+                                             NULL,
                                              NULL);
     __globals->get_cluster_addresses(_cluster_addresses);
     __globals->get_cluster_local_ip(_local_ip);
@@ -172,7 +174,7 @@ TEST_F(TestChronosInternalConnection, ResynchronizeWithTimers)
   __globals->set_cluster_leaving_addresses(leaving_cluster_addresses);
   _cluster_addresses.push_back("10.0.0.4:9999");
 
-  // Timers from 10.0.0.2/10.0.0.3/10.0.0.4 - One timer that's having its replica list reordered. 
+  // Timers from 10.0.0.2/10.0.0.3/10.0.0.4 - One timer that's having its replica list reordered.
   // This isn't a valid response (as it should be different for .2/.3/.4), but it's sufficient
   fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.1:9999\", \"10.0.0.2:9999\", \"10.0.0.3:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.3:9999\", \"10.0.0.1:9999\", \"10.0.0.2:9999\" ] }}}]}";
 


### PR DESCRIPTION
In general just replaced existing LVC model with pre-defined SNMP counter tables, and added a Continuous Accumulator Table and a scalar to report the timer count. As timer changes occur within a mutex lock, this is also a safe place to update the count, and report the statistics