### PR TITLE
[Reviewer: Andy] - Fixed overflow errors when comparing

### DIFF
--- a/src/include/timer.h
+++ b/src/include/timer.h
@@ -102,20 +102,20 @@ public:
                                  std::vector<std::string>& extra_replicas,
                                  Hasher* hasher);
 
-  // Mark which replicas have been informed about the timer 
+  // Mark which replicas have been informed about the timer
   int update_replica_tracker(int replica_index);
 
-  // Return whether a particular replica has been informed about a timer  
+  // Return whether a particular replica has been informed about a timer
   bool has_replica_been_informed(int replica_index);
 
-  // Update the cluster information stored in the timer (replica list and 
+  // Update the cluster information stored in the timer (replica list and
   // cluster view ID)
   void update_cluster_information();
 
   // Member variables (mostly public since this is pretty much a struct with utility
   // functions, rather than a full-blown object).
   TimerID id;
-  uint32_t start_time_mono_ms;
+  uint64_t start_time_mono_ms;
   uint32_t interval;
   uint32_t repeat_for;
   uint32_t sequence_number;
@@ -130,8 +130,8 @@ private:
 
   // The replica tracker is used to track which replicas need to be informed
   // if the replica is being moved off the current node (e.g. during scale
-  // down). Each bit corresponds to a replica in the timer's replica list, 
-  // where the primary replica corresponds to the least significant bit, 
+  // down). Each bit corresponds to a replica in the timer's replica list,
+  // where the primary replica corresponds to the least significant bit,
   // the second replica to the next least significant bit, and so on...
   uint32_t _replica_tracker;
 

--- a/src/include/timer_store.h
+++ b/src/include/timer_store.h
@@ -60,15 +60,15 @@ public:
   // Get the next bucket of timers to pop.
   virtual void get_next_timers(std::unordered_set<Timer*>&);
 
-  // Mark which replicas have been informed for an individual timer. 
+  // Mark which replicas have been informed for an individual timer.
   // If all replicas are informed, then the timer will be tombstoned
   // NOTE -> This is currently only valid for scale down.
-  virtual void update_replica_tracker_for_timer(TimerID id, 
+  virtual void update_replica_tracker_for_timer(TimerID id,
                                                 int replica_index);
 
-  // Get timer information from the store for timers where 
+  // Get timer information from the store for timers where
   // request_node should be a replica
-  virtual HTTPCode get_timers_for_node(std::string request_node, 
+  virtual HTTPCode get_timers_for_node(std::string request_node,
                                        int max_responses,
                                        std::string cluster_view_id,
                                        std::string& get_response);
@@ -131,12 +131,12 @@ private:
 
   // A table of all known timers. Only the first timer in the timer list
   // is in the timer wheel - any other timers are stored for use when
-  // resynchronising between Chronos's. 
+  // resynchronising between Chronos's.
   std::map<TimerID, std::vector<Timer*>> _timer_lookup_table;
 
   // Health checker, which is notified when a timer is successfully added.
   HealthChecker* _health_checker;
-  
+
   // Constants controlling the size and resolution of the timer wheels.
   static const int SHORT_WHEEL_RESOLUTION_MS = 10;
   static const int SHORT_WHEEL_NUM_BUCKETS = 100;
@@ -183,8 +183,8 @@ private:
   // Utility methods to convert a timestamp to the resolution used by the
   // wheels.  These round down (so to 10ms accuracy, 12345 -> 12340, but 12340
   // -> 12340).
-  static uint64_t to_short_wheel_resolution(uint64_t t);
-  static uint64_t to_long_wheel_resolution(uint64_t t);
+  static uint32_t to_short_wheel_resolution(uint64_t t);
+  static uint32_t to_long_wheel_resolution(uint64_t t);
 
   // Refill timer wheels from the longer duration stores.
   //
@@ -208,7 +208,7 @@ private:
                   std::unordered_set<Timer*>& set);
 
   // Update a timer object with the current cluster configuration. Store off
-  // the old set of replicas, and return whether the requesting node is 
+  // the old set of replicas, and return whether the requesting node is
   // one of the new replicas
   bool timer_is_on_node(std::string request_node,
                         std::string cluster_view_id,
@@ -220,6 +220,9 @@ private:
 
   // Save the tombstone values from an existing timer
   void set_tombstone_values(Timer* t, Timer* existing);
+
+  // Compare two numbers that might have overflown
+  bool overflow_less_than(uint32_t a, uint32_t b);
 
 };
 

--- a/src/include/timer_store.h
+++ b/src/include/timer_store.h
@@ -183,8 +183,8 @@ private:
   // Utility methods to convert a timestamp to the resolution used by the
   // wheels.  These round down (so to 10ms accuracy, 12345 -> 12340, but 12340
   // -> 12340).
-  static uint32_t to_short_wheel_resolution(uint64_t t);
-  static uint32_t to_long_wheel_resolution(uint64_t t);
+  static uint64_t to_short_wheel_resolution(uint64_t t);
+  static uint64_t to_long_wheel_resolution(uint64_t t);
 
   // Refill timer wheels from the longer duration stores.
   //

--- a/src/include/timer_store.h
+++ b/src/include/timer_store.h
@@ -74,7 +74,7 @@ public:
                                        std::string& get_response);
 
   // Give the UT test fixture access to our member variables
-  friend class TestTimerStore;
+//  friend class TestTimerStore;
 
 private:
   // The timer store uses 4 data structures to ensure timers pop on time:

--- a/src/main/timer_store.cpp
+++ b/src/main/timer_store.cpp
@@ -373,14 +373,14 @@ uint64_t TimerStore::timestamp_ms()
   return time;
 }
 
-uint32_t TimerStore::to_short_wheel_resolution(uint64_t t)
+uint64_t TimerStore::to_short_wheel_resolution(uint64_t t)
 {
-  return (uint32_t)(t - (t % SHORT_WHEEL_RESOLUTION_MS));
+  return (t - (t % SHORT_WHEEL_RESOLUTION_MS));
 }
 
-uint32_t TimerStore::to_long_wheel_resolution(uint64_t t)
+uint64_t TimerStore::to_long_wheel_resolution(uint64_t t)
 {
-  return (uint32_t)(t - (t % LONG_WHEEL_RESOLUTION_MS));
+  return (t - (t % LONG_WHEEL_RESOLUTION_MS));
 }
 
 TimerStore::Bucket* TimerStore::short_wheel_bucket(Timer* timer)

--- a/src/main/timer_store.cpp
+++ b/src/main/timer_store.cpp
@@ -72,9 +72,9 @@ TimerStore::TimerStore(HealthChecker* hc) :
 TimerStore::~TimerStore()
 {
   // Delete the timers in the lookup table as they will never pop now.
-  for (std::map<TimerID, std::vector<Timer*>>::iterator it = 
-                                                _timer_lookup_table.begin(); 
-                                                it != _timer_lookup_table.end(); 
+  for (std::map<TimerID, std::vector<Timer*>>::iterator it =
+                                                _timer_lookup_table.begin();
+                                                it != _timer_lookup_table.end();
                                                 ++it)
   {
     for (std::vector<Timer*>::iterator it_timer = it->second.begin();
@@ -108,21 +108,21 @@ void TimerStore::add_timer(Timer* t)
   std::vector<Timer*> timers;
 
   // First check if this timer already exists.
-  std::map<TimerID, std::vector<Timer*>>::iterator map_it = 
+  std::map<TimerID, std::vector<Timer*>>::iterator map_it =
                                                 _timer_lookup_table.find(t->id);
 
   if (map_it != _timer_lookup_table.end())
   {
-    // There's already a timer with this ID in the store. We can update the 
-    // existing timer, discard the new timer, or add the new timer, and move the 
-    // old timer out of the timer wheel, but still save the timer information 
-    // in the timer map (this last option is used in scaling operations) 
+    // There's already a timer with this ID in the store. We can update the
+    // existing timer, discard the new timer, or add the new timer, and move the
+    // old timer out of the timer wheel, but still save the timer information
+    // in the timer map (this last option is used in scaling operations)
     TRC_DEBUG("Already a timer with ID %ld in the store", t->id);
 
     Timer* existing = map_it->second.front();
 
     // Compare timers for precedence, start-time then sequence-number.
-    if ((t->start_time_mono_ms < existing->start_time_mono_ms) ||
+    if (overflow_less_than(t->start_time_mono_ms, existing->start_time_mono_ms) ||
         ((t->start_time_mono_ms == existing->start_time_mono_ms) &&
          (t->sequence_number < existing->sequence_number)))
     {
@@ -132,24 +132,24 @@ void TimerStore::add_timer(Timer* t)
     }
     else
     {
-      // We want to add the timer, so decide whether this is an update, or 
-      // if we need to save off the old timer. 
+      // We want to add the timer, so decide whether this is an update, or
+      // if we need to save off the old timer.
       if (existing->cluster_view_id != t->cluster_view_id)
       {
         // The cluster IDs on the new and existing timers are different.
-        // This means that the cluster configuration has changed between 
-        // and when the timer was last updated. 
+        // This means that the cluster configuration has changed between
+        // and when the timer was last updated.
         TRC_DEBUG("Cluster view IDs are different on the new and existing timers");
 
         if (map_it->second.size() > 1)
         {
           // There's already a saved timer, but the new timer doesn't match the
-          // existing timer. This is an error condition, and suggests that 
+          // existing timer. This is an error condition, and suggests that
           // a scaling operation has been started before an old scaling operation
-          // finished, or there was a node failure during a scaling operation. 
-          // Either way, the saved timer information is out of date, and is 
-          // deleted (by not saving a copy of it when we delete the entire Timer 
-          // ID in the next step) 
+          // finished, or there was a node failure during a scaling operation.
+          // Either way, the saved timer information is out of date, and is
+          // deleted (by not saving a copy of it when we delete the entire Timer
+          // ID in the next step)
           TRC_WARNING("Deleting out of date timer from timer map");
         }
 
@@ -164,7 +164,7 @@ void TimerStore::add_timer(Timer* t)
       {
         set_tombstone_values(t, existing);
         timers.push_back(t);
-  
+
         if (map_it->second.size() > 1)
         {
           Timer* existing_copy = new Timer(*map_it->second.back());
@@ -179,7 +179,7 @@ void TimerStore::add_timer(Timer* t)
   }
   else
   {
-    // The timer doesn't already exist, so add it to the store. 
+    // The timer doesn't already exist, so add it to the store.
     TRC_DEBUG("Adding a new timer to the store with ID %ld", t->id);
     timers.push_back(t);
   }
@@ -195,7 +195,7 @@ void TimerStore::add_timer(Timer* t)
   uint64_t next_pop_time = t->next_pop_time();
   Bucket* bucket;
 
-  if (next_pop_time < _tick_timestamp)
+  if (overflow_less_than(next_pop_time, _tick_timestamp))
   {
     // The timer should have already popped so put it in the overdue timers,
     // and warn the user.
@@ -210,15 +210,15 @@ void TimerStore::add_timer(Timer* t)
                 TIMER_LOG_PARAMS(t));
     _overdue_timers.insert(t);
   }
-  else if (to_short_wheel_resolution(next_pop_time) <
-           to_short_wheel_resolution(_tick_timestamp + SHORT_WHEEL_PERIOD_MS))
+  else if (overflow_less_than(to_short_wheel_resolution(next_pop_time),
+           to_short_wheel_resolution(_tick_timestamp + SHORT_WHEEL_PERIOD_MS)))
   {
 
     bucket = short_wheel_bucket(next_pop_time);
     bucket->insert(t);
   }
-  else if (to_long_wheel_resolution(next_pop_time) <
-           to_long_wheel_resolution(_tick_timestamp + LONG_WHEEL_PERIOD_MS))
+  else if (overflow_less_than(to_long_wheel_resolution(next_pop_time),
+           to_long_wheel_resolution(_tick_timestamp + LONG_WHEEL_PERIOD_MS)))
   {
     bucket = long_wheel_bucket(next_pop_time);
     bucket->insert(t);
@@ -252,10 +252,10 @@ void TimerStore::delete_timer(TimerID id)
   if (it != _timer_lookup_table.end())
   {
     // The timer(s) are still present in the store.
-    // Delete the first timer from the timer wheel, delete any 
+    // Delete the first timer from the timer wheel, delete any
     // other timers in the timer list, then erase the entry from
-    // the timer map. 
-    Timer* timer = it->second.front(); 
+    // the timer map.
+    Timer* timer = it->second.front();
     delete_timer_from_timer_wheel(timer);
 
     for (std::vector<Timer*>::iterator it_timer = it->second.begin();
@@ -329,11 +329,11 @@ void TimerStore::get_next_timers(std::unordered_set<Timer*>& set)
 
   // Now process the required number of ticks. Integer division does the
   // necessary rounding for us.
-  uint64_t current_timestamp = timestamp_ms();
-  int num_ticks = ((current_timestamp - _tick_timestamp) /
+  uint32_t current_timestamp = timestamp_ms();
+  uint32_t num_ticks = ((current_timestamp - _tick_timestamp) /
                    SHORT_WHEEL_RESOLUTION_MS);
 
-  for (int ii = 0; ii < num_ticks; ++ii)
+  for (int ii = 0; ii < (int)(num_ticks); ++ii)
   {
     // Pop all timers in the current bucket.
     Bucket* bucket = short_wheel_bucket(_tick_timestamp);
@@ -373,14 +373,14 @@ uint64_t TimerStore::timestamp_ms()
   return time;
 }
 
-uint64_t TimerStore::to_short_wheel_resolution(uint64_t t)
+uint32_t TimerStore::to_short_wheel_resolution(uint64_t t)
 {
-  return (t - (t % SHORT_WHEEL_RESOLUTION_MS));
+  return (uint32_t)(t - (t % SHORT_WHEEL_RESOLUTION_MS));
 }
 
-uint64_t TimerStore::to_long_wheel_resolution(uint64_t t)
+uint32_t TimerStore::to_long_wheel_resolution(uint64_t t)
 {
-  return (t - (t % LONG_WHEEL_RESOLUTION_MS));
+  return (uint32_t)(t - (t % LONG_WHEEL_RESOLUTION_MS));
 }
 
 TimerStore::Bucket* TimerStore::short_wheel_bucket(Timer* timer)
@@ -408,8 +408,8 @@ TimerStore::Bucket* TimerStore::long_wheel_bucket(uint64_t t)
 void TimerStore::pop_bucket(TimerStore::Bucket* bucket,
                             std::unordered_set<Timer*>& set)
 {
-  for(TimerStore::Bucket::iterator it = bucket->begin(); 
-                                   it != bucket->end(); 
+  for(TimerStore::Bucket::iterator it = bucket->begin();
+                                   it != bucket->end();
                                    ++it)
   {
     _timer_lookup_table.erase((*it)->id);
@@ -446,7 +446,7 @@ void TimerStore::refill_long_wheel()
     Timer* timer = _extra_heap.back();
 
     while ((timer != NULL) &&
-           (timer->next_pop_time() < _tick_timestamp + LONG_WHEEL_PERIOD_MS))
+           (overflow_less_than(timer->next_pop_time(), _tick_timestamp + LONG_WHEEL_PERIOD_MS)))
     {
       // Remove timer from heap
       _extra_heap.pop_back();
@@ -478,8 +478,8 @@ void TimerStore::refill_short_wheel()
 {
   Bucket* long_bucket = long_wheel_bucket(_tick_timestamp);
 
-  for (Bucket::iterator it = long_bucket->begin(); 
-                        it != long_bucket->end(); 
+  for (Bucket::iterator it = long_bucket->begin();
+                        it != long_bucket->end();
                         ++it)
   {
     Timer* timer = *it;
@@ -517,11 +517,11 @@ void TimerStore::purge_timer_from_wheels(Timer* t)
 }
 // LCOV_EXCL_STOP
 
-void TimerStore::update_replica_tracker_for_timer(TimerID id, 
+void TimerStore::update_replica_tracker_for_timer(TimerID id,
                                                   int replica_index)
 {
   // Check if the timer exists.
-  std::map<TimerID, std::vector<Timer*>>::iterator map_it = 
+  std::map<TimerID, std::vector<Timer*>>::iterator map_it =
                                                    _timer_lookup_table.find(id);
 
   if (map_it != _timer_lookup_table.end())
@@ -531,11 +531,11 @@ void TimerStore::update_replica_tracker_for_timer(TimerID id,
 
     if (map_it->second.size() == 1)
     {
-      timer = map_it->second.front(); 
+      timer = map_it->second.front();
     }
-    else 
+    else
     {
-      timer = map_it->second.back(); 
+      timer = map_it->second.back();
       timer_in_wheel = false;
     }
 
@@ -544,7 +544,7 @@ void TimerStore::update_replica_tracker_for_timer(TimerID id,
 
     if (!timer->is_matching_cluster_view_id(cluster_view_id))
     {
-      // The cluster view ID is out of date, so update the tracker. 
+      // The cluster view ID is out of date, so update the tracker.
       int remaining_replicas = timer->update_replica_tracker(replica_index);
 
       if (remaining_replicas == 0)
@@ -552,24 +552,24 @@ void TimerStore::update_replica_tracker_for_timer(TimerID id,
         if (!timer_in_wheel)
         {
           // All the new replicas have been told about the timer. We don't
-          // need to store the information about the timer anymore. 
+          // need to store the information about the timer anymore.
           delete timer; timer = NULL;
           map_it->second.pop_back();
         }
         else
         {
-          // This is a window condition where node is responsible for an 
-          // old timer replica. The node knows that all new replicas that 
-          // should know about the timer are in the process of being told, 
-          // but it hasn't yet received an update or tombstone for its 
-          // replica. It will receive this soon. 
+          // This is a window condition where node is responsible for an
+          // old timer replica. The node knows that all new replicas that
+          // should know about the timer are in the process of being told,
+          // but it hasn't yet received an update or tombstone for its
+          // replica. It will receive this soon.
         }
       }
     }
   }
 }
 
-HTTPCode TimerStore::get_timers_for_node(std::string request_node, 
+HTTPCode TimerStore::get_timers_for_node(std::string request_node,
                                          int max_responses,
                                          std::string cluster_view_id,
                                          std::string& get_response)
@@ -585,14 +585,14 @@ HTTPCode TimerStore::get_timers_for_node(std::string request_node,
   writer.StartArray();
 
   int retrieved_timers = 0;
-  for (std::map<TimerID, std::vector<Timer*>>::iterator it = 
+  for (std::map<TimerID, std::vector<Timer*>>::iterator it =
                                            _timer_lookup_table.begin();
-                                           it != _timer_lookup_table.end();                                        
+                                           it != _timer_lookup_table.end();
                                            ++it)
   {
-    // Take a copy of the timer so we don't change the timer in the wheel/map. 
-    // If there's a saved timer in the timer map, use that rather than 
-    // the timer in the wheel. 
+    // Take a copy of the timer so we don't change the timer in the wheel/map.
+    // If there's a saved timer in the timer map, use that rather than
+    // the timer in the wheel.
     Timer* timer_copy;
     if (it->second.size() == 1)
     {
@@ -600,38 +600,38 @@ HTTPCode TimerStore::get_timers_for_node(std::string request_node,
     }
     else
     {
-      timer_copy = new Timer(*it->second.back());   
+      timer_copy = new Timer(*it->second.back());
     }
 
-    if (!timer_copy->is_tombstone())   
+    if (!timer_copy->is_tombstone())
     {
       std::vector<std::string> old_replicas;
       if (timer_is_on_node(request_node,
                            cluster_view_id,
-                           timer_copy, 
+                           timer_copy,
                            old_replicas))
       {
         writer.StartObject();
         {
-          // The timer will have a replica on the requesting node. Add this entry 
+          // The timer will have a replica on the requesting node. Add this entry
           // to the JSON document
-  
+
           // Add in Old Timer ID
           writer.String(JSON_TIMER_ID);
           writer.Int(timer_copy->id);
-  
+
           // Add the old replicas
           writer.String(JSON_OLD_REPLICAS);
           writer.StartArray();
           for (std::vector<std::string>::const_iterator i = old_replicas.begin();
                                                         i != old_replicas.end();
-                                                      ++i) 
+                                                      ++i)
           {
             writer.String((*i).c_str());
           }
           writer.EndArray();
 
-          // Finally, add the timer itself 
+          // Finally, add the timer itself
           writer.String(JSON_TIMER);
           timer_copy->to_json_obj(&writer);
         }
@@ -644,24 +644,24 @@ HTTPCode TimerStore::get_timers_for_node(std::string request_node,
     // Tidy up the copy
     delete timer_copy;
 
-    // Break out of the for loop once we hit the maximum number of 
+    // Break out of the for loop once we hit the maximum number of
     // timers to collect
-    if ((max_responses != 0) && 
+    if ((max_responses != 0) &&
         (retrieved_timers == max_responses))
     {
       TRC_DEBUG("Reached the max number of timers to collect");
       break;
     }
   }
- 
+
   writer.EndArray();
-  writer.EndObject(); 
+  writer.EndObject();
 
   get_response = sb.GetString();
 
   TRC_DEBUG("Retrieved %d timers", retrieved_timers);
   return ((max_responses != 0) &&
-          (retrieved_timers == max_responses)) ? HTTP_PARTIAL_CONTENT : 
+          (retrieved_timers == max_responses)) ? HTTP_PARTIAL_CONTENT :
                                                  HTTP_OK;
 }
 
@@ -671,8 +671,8 @@ bool TimerStore::timer_is_on_node(std::string request_node,
                                   std::vector<std::string>& old_replicas)
 {
   bool timer_is_on_requesting_node = false;
- 
-  if (!timer->is_matching_cluster_view_id(cluster_view_id)) 
+
+  if (!timer->is_matching_cluster_view_id(cluster_view_id))
   {
     // Store the old replica list
     std::string localhost;
@@ -681,14 +681,14 @@ bool TimerStore::timer_is_on_node(std::string request_node,
 
     // Calculate whether the new request node is interested in the timer. This
     // updates the replica list in the timer object to be the new replica list
-    timer->update_cluster_information(); 
+    timer->update_cluster_information();
 
     int index = 0;
     for (std::vector<std::string>::iterator it = timer->replicas.begin();
                                             it != timer->replicas.end();
                                             ++it, ++index)
     {
-      if ((*it == request_node) && 
+      if ((*it == request_node) &&
           !(timer->has_replica_been_informed(index)))
       {
         timer_is_on_requesting_node = true;
@@ -709,4 +709,9 @@ void TimerStore::set_tombstone_values(Timer* t, Timer* existing)
     t->interval = existing->interval;
     t->repeat_for = existing->interval;
   }
+}
+
+bool TimerStore::overflow_less_than(uint32_t a, uint32_t b)
+{
+  return ((a - b) > ((uint32_t)(1) << 31));
 }

--- a/src/main/timer_store.cpp
+++ b/src/main/timer_store.cpp
@@ -330,7 +330,7 @@ void TimerStore::get_next_timers(std::unordered_set<Timer*>& set)
   // Now process the required number of ticks. Integer division does the
   // necessary rounding for us.
   uint32_t current_timestamp = timestamp_ms();
-  uint32_t num_ticks = ((current_timestamp - _tick_timestamp) /
+  uint32_t num_ticks = ((current_timestamp - (uint32_t)(_tick_timestamp)) /
                    SHORT_WHEEL_RESOLUTION_MS);
 
   for (int ii = 0; ii < (int)(num_ticks); ++ii)

--- a/src/test/coverage-not-yet
+++ b/src/test/coverage-not-yet
@@ -1,10 +1,10 @@
 # This file lists filenames for which we do not currently expect 100%
 # coverage. These include files from cpp-common as they're tested
-# elsewhere, and some files in Chronos that still need UTs. 
+# elsewhere, and some files in Chronos that still need UTs.
 # New files should have 100% code coverage (by lines); it may
 # be acceptable to use exclusion markers to achieve this.
 
-# Currently untested Chronos files. These should only be in 
+# Currently untested Chronos files. These should only be in
 # here temporarily
 src/main/replicator.cpp
 src/main/globals.cpp
@@ -12,7 +12,7 @@ src/main/murmur/MurmurHash3.cpp
 src/main/http_callback.cpp
 src/main/timer_handler.cpp
 
-# cpp-common files 
+# cpp-common files
 modules/cpp-common/src/baseresolver.cpp
 modules/cpp-common/src/httpstack.cpp
 modules/cpp-common/src/httpstack_utils.cpp
@@ -33,3 +33,8 @@ modules/cpp-common/src/dnsparser.cpp
 modules/cpp-common/src/logger.cpp
 modules/cpp-common/src/utils.cpp
 modules/cpp-common/src/zmq_lvc.cpp
+modules/cpp-common/src/snmp_agent.cpp
+modules/cpp-common/src/snmp_row.cpp
+modules/cpp-common/src/snmp_scalar.cpp
+modules/cpp-common/src/snmp_counter_table.cpp
+modules/cpp-common/src/snmp_continuous_accumulator_table.cpp

--- a/src/test/test_timer.cpp
+++ b/src/test/test_timer.cpp
@@ -92,7 +92,7 @@ TEST_F(TestTimer, FromJSONTests)
 
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
-  uint64_t mono_time = (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
+  uint32_t mono_time = (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
   clock_gettime(CLOCK_REALTIME, &ts);
   uint64_t real_time = (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
 
@@ -233,7 +233,7 @@ TEST_F(TestTimer, FromJSONTests)
   // If delta-start-time was provided, use that
   timer = Timer::from_json(1, 0x11011100011101, delta_start_time, err, replicated);
   EXPECT_NE((void*)NULL, timer);
-  EXPECT_EQ("", err); EXPECT_EQ((uint32_t)(mono_time - 200), timer->start_time_mono_ms);
+  EXPECT_EQ("", err); EXPECT_EQ(mono_time - 200, timer->start_time_mono_ms);
   delete timer;
 
   // If absolute start time was proved (and no delta-time), use that.
@@ -243,7 +243,7 @@ TEST_F(TestTimer, FromJSONTests)
 
   // Note that this compares to monotonic time (but the offest is the same as
   // the offset to realtime when we made the JSON string).
-  EXPECT_EQ((uint32_t)(mono_time - 300), timer->start_time_mono_ms);
+  EXPECT_EQ(mono_time - 300, timer->start_time_mono_ms);
   delete timer;
 
   // Restore real time

--- a/src/test/test_timer.cpp
+++ b/src/test/test_timer.cpp
@@ -233,7 +233,7 @@ TEST_F(TestTimer, FromJSONTests)
   // If delta-start-time was provided, use that
   timer = Timer::from_json(1, 0x11011100011101, delta_start_time, err, replicated);
   EXPECT_NE((void*)NULL, timer);
-  EXPECT_EQ("", err); EXPECT_EQ(mono_time - 200, timer->start_time_mono_ms);
+  EXPECT_EQ("", err); EXPECT_EQ((uint32_t)(mono_time - 200), timer->start_time_mono_ms);
   delete timer;
 
   // If absolute start time was proved (and no delta-time), use that.
@@ -243,7 +243,7 @@ TEST_F(TestTimer, FromJSONTests)
 
   // Note that this compares to monotonic time (but the offest is the same as
   // the offset to realtime when we made the JSON string).
-  EXPECT_EQ(mono_time - 300, timer->start_time_mono_ms);
+  EXPECT_EQ((uint32_t)(mono_time - 300), timer->start_time_mono_ms);
   delete timer;
 
   // Restore real time

--- a/src/test/test_timer_store.cpp
+++ b/src/test/test_timer_store.cpp
@@ -51,10 +51,67 @@ using ::testing::MatchesRegex;
 // when advancing time to guarantee that a timer has popped.
 const int TIMER_GRANULARITY_MS = 10;
 
+class Overflow2h {
+  static void set_time() {
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    uint64_t now_ms = (now.tv_sec * 1000) + (now.tv_nsec / 1000000);
+
+    // Align with overflow point minus 2 hours
+    cwtest_advance_time_ms(( - (uint32_t)(now_ms)) - (2 * 60 * 60 * 1000));
+  }
+};
+
+class Overflow45m {
+  static void set_time() {
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    uint64_t now_ms = (now.tv_sec * 1000) + (now.tv_nsec / 1000000);
+
+    // Align with overflow point minus 45 minutes
+    cwtest_advance_time_ms(( - (uint32_t)(now_ms)) - (45 * 60 * 1000));
+  }
+};
+
+class Overflow45s {
+  static void set_time() {
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    uint64_t now_ms = (now.tv_sec * 1000) + (now.tv_nsec / 1000000);
+
+    // Align with overflow point minus 45 seconds
+    cwtest_advance_time_ms(( - (uint32_t)(now_ms)) - (45000));
+  }
+};
+
+class Overflow45ms {
+  static void set_time() {
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    uint64_t now_ms = (now.tv_sec * 1000) + (now.tv_nsec / 1000000);
+
+    // Align with overflow point minus 45ms
+    cwtest_advance_time_ms(( - (uint32_t)(now_ms)) - 45);
+  }
+};
+
+class NoOverflow {
+  static void set_time() {
+    // Set the time to be just after overflow
+    struct timespec now;
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    uint64_t now_ms = (now.tv_sec * 1000) + (now.tv_nsec / 1000000);
+
+    cwtest_advance_time_ms( - (uint32_t)(now_ms));
+  }
+};
+
+
 /*****************************************************************************/
 /* Test fixture                                                              */
 /*****************************************************************************/
 
+template <class T>
 class TestTimerStore : public Base
 {
 protected:
@@ -65,33 +122,10 @@ protected:
     // I mark the hours, every one, Nor have I yet outrun the Sun.
     // My use and value, unto you, Are gauged by what you have to do.
     cwtest_completely_control_time();
-
-    // Rollback the time to 45 minutes before the timer would overflow
-    // See whether we've already overflown
-    struct timespec now;
-    clock_gettime(CLOCK_MONOTONIC, &now);
-    uint64_t now_ms = (now.tv_sec * 1000) + (now.tv_nsec / 1000000);
-
-    if (now_ms >= ((uint64_t)(1) << 32))
-    {
-      // Align with overflow point
-      cwtest_reverse_time_ms(now_ms - ((uint64_t)(1) << 32));
-    }
-    else
-    {
-      // Align with overflow point
-      cwtest_advance_time_ms(((uint64_t)(1) << 32) - now_ms);
-    }
-
-    // Rollback 45 minutes
-    cwtest_reverse_time_ms(45 * 60 * 1000);
+    T::set_time();
 
     // We are now at a point in time where timestamps will exist in 32
-    // bit integers, but will overflow in 45 minutes time.
-
-    // Default some timers to short, mid and long.
-    struct timespec new_time;
-    clock_gettime(CLOCK_MONOTONIC, &new_time);
+    // bit integers, but will overflow in a specified amount of time.
 
     hc = new HealthChecker();
     ts = new TimerStore(hc);
@@ -141,386 +175,391 @@ protected:
 /* Instance Functions                                                        */
 /*****************************************************************************/
 
-TEST_F(TestTimerStore, NearGetNextTimersTest)
+using testing::Types;
+
+typedef ::testing::Types<Overflow2h, Overflow45m, Overflow45s, Overflow45ms, NoOverflow> TimeTypes;
+TYPED_TEST_CASE(TestTimerStore, TimeTypes);
+
+TYPED_TEST(TestTimerStore, NearGetNextTimersTest)
 {
-  ts->add_timer(timers[0]);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
   std::unordered_set<Timer*> next_timers;
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
 
   ASSERT_EQ(0u, next_timers.size());
   cwtest_advance_time_ms(100 + TIMER_GRANULARITY_MS);
 
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size());
-  timers[0] = *next_timers.begin();
-  EXPECT_EQ(1u, timers[0]->id);
+  TestFixture::timers[0] = *next_timers.begin();
+  EXPECT_EQ(1u, TestFixture::timers[0]->id);
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, NearGetNextTimersOffsetTest)
+TYPED_TEST(TestTimerStore, NearGetNextTimersOffsetTest)
 {
-  timers[0]->interval = 1600;
+  TestFixture::timers[0]->interval = 1600;
 
-  ts->add_timer(timers[0]);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
 
   std::unordered_set<Timer*> next_timers;
 
   cwtest_advance_time_ms(1500);
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(0u, next_timers.size()) << "Bucket should have 0 timers";
 
   next_timers.clear();
 
   cwtest_advance_time_ms(100 + TIMER_GRANULARITY_MS);
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timers";
 
   next_timers.clear();
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, MidGetNextTimersTest)
+TYPED_TEST(TestTimerStore, MidGetNextTimersTest)
 {
-  ts->add_timer(timers[1]);
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
   std::unordered_set<Timer*> next_timers;
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
 
   ASSERT_EQ(0u, next_timers.size());
   cwtest_advance_time_ms(100000);
 
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size());
-  timers[1] = *next_timers.begin();
-  EXPECT_EQ(2u, timers[1]->id);
+  TestFixture::timers[1] = *next_timers.begin();
+  EXPECT_EQ(2u, TestFixture::timers[1]->id);
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, LongGetNextTimersTest)
+TYPED_TEST(TestTimerStore, LongGetNextTimersTest)
 {
-  ts->add_timer(timers[2]);
+  TestFixture::ts->add_timer(TestFixture::timers[2]);
   std::unordered_set<Timer*> next_timers;
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
 
   ASSERT_EQ(0u, next_timers.size());
-  cwtest_advance_time_ms(timers[2]->interval + TIMER_GRANULARITY_MS);
+  cwtest_advance_time_ms(TestFixture::timers[2]->interval + TIMER_GRANULARITY_MS);
 
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size());
-  timers[2] = *next_timers.begin();
-  EXPECT_EQ(3u, timers[2]->id);
+  TestFixture::timers[2] = *next_timers.begin();
+  EXPECT_EQ(3u, TestFixture::timers[2]->id);
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, MultiNearGetNextTimersTest)
+TYPED_TEST(TestTimerStore, MultiNearGetNextTimersTest)
 {
   // Shorten timer two to be under 1 second.
-  timers[1]->interval = 400;
+  TestFixture::timers[1]->interval = 400;
 
-  ts->add_timer(timers[0]);
-  ts->add_timer(timers[1]);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
 
   std::unordered_set<Timer*> next_timers;
 
   cwtest_advance_time_ms(1000 + TIMER_GRANULARITY_MS);
 
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
 
   ASSERT_EQ(2u, next_timers.size()) << "Bucket should have 2 timers";
 
   next_timers.clear();
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, ClashingMultiMidGetNextTimersTest)
+TYPED_TEST(TestTimerStore, ClashingMultiMidGetNextTimersTest)
 {
   // Lengthen timer one to be in the same second bucket as timer two but different ms
   // buckets.
-  timers[0]->interval = 10000 + 100;
+  TestFixture::timers[0]->interval = 10000 + 100;
 
-  ts->add_timer(timers[0]);
-  ts->add_timer(timers[1]);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
 
   std::unordered_set<Timer*> next_timers;
 
-  cwtest_advance_time_ms(timers[0]->interval + TIMER_GRANULARITY_MS);
-  ts->get_next_timers(next_timers);
+  cwtest_advance_time_ms(TestFixture::timers[0]->interval + TIMER_GRANULARITY_MS);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
-  timers[0] = *next_timers.begin();
-  EXPECT_EQ(1u, timers[0]->id);
+  TestFixture::timers[0] = *next_timers.begin();
+  EXPECT_EQ(1u, TestFixture::timers[0]->id);
 
   next_timers.clear();
 
-  cwtest_advance_time_ms(timers[1]->interval - timers[0]->interval);
-  ts->get_next_timers(next_timers);
+  cwtest_advance_time_ms(TestFixture::timers[1]->interval - TestFixture::timers[0]->interval);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
-  timers[1] = *next_timers.begin();
-  EXPECT_EQ(2u, timers[1]->id);
+  TestFixture::timers[1] = *next_timers.begin();
+  EXPECT_EQ(2u, TestFixture::timers[1]->id);
 
   next_timers.clear();
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, SeparateMultiMidGetNextTimersTest)
+TYPED_TEST(TestTimerStore, SeparateMultiMidGetNextTimersTest)
 {
   // Lengthen timer one to be in a different second bucket than timer two.
-  timers[0]->interval = 9000 + 100;
+  TestFixture::timers[0]->interval = 9000 + 100;
 
-  ts->add_timer(timers[0]);
-  ts->add_timer(timers[1]);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
 
   std::unordered_set<Timer*> next_timers;
 
-  cwtest_advance_time_ms(timers[0]->interval + TIMER_GRANULARITY_MS);
-  ts->get_next_timers(next_timers);
+  cwtest_advance_time_ms(TestFixture::timers[0]->interval + TIMER_GRANULARITY_MS);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
-  timers[0] = *next_timers.begin();
-  EXPECT_EQ(1u, timers[0]->id);
+  TestFixture::timers[0] = *next_timers.begin();
+  EXPECT_EQ(1u, TestFixture::timers[0]->id);
 
   next_timers.clear();
 
-  cwtest_advance_time_ms(timers[1]->interval - timers[0]->interval);
-  ts->get_next_timers(next_timers);
+  cwtest_advance_time_ms(TestFixture::timers[1]->interval - TestFixture::timers[0]->interval);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
-  timers[1] = *next_timers.begin();
-  EXPECT_EQ(2u, timers[1]->id);
+  TestFixture::timers[1] = *next_timers.begin();
+  EXPECT_EQ(2u, TestFixture::timers[1]->id);
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, MultiLongGetTimersTest)
+TYPED_TEST(TestTimerStore, MultiLongGetTimersTest)
 {
   // Lengthen timer one and two to be in the extra heap.
-  timers[0]->interval = (3600 * 1000) + 100;
-  timers[1]->interval = (3600 * 1000) + 200;
+  TestFixture::timers[0]->interval = (3600 * 1000) + 100;
+  TestFixture::timers[1]->interval = (3600 * 1000) + 200;
 
-  ts->add_timer(timers[0]);
-  ts->add_timer(timers[1]);
-  ts->add_timer(timers[2]);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
+  TestFixture::ts->add_timer(TestFixture::timers[2]);
 
   std::unordered_set<Timer*> next_timers;
 
-  cwtest_advance_time_ms(timers[0]->interval + TIMER_GRANULARITY_MS);
-  ts->get_next_timers(next_timers);
+  cwtest_advance_time_ms(TestFixture::timers[0]->interval + TIMER_GRANULARITY_MS);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
-  timers[0] = *next_timers.begin();
-  EXPECT_EQ(1u, timers[0]->id);
+  TestFixture::timers[0] = *next_timers.begin();
+  EXPECT_EQ(1u, TestFixture::timers[0]->id);
 
   next_timers.clear();
 
-  cwtest_advance_time_ms(timers[1]->interval - timers[0]->interval);
-  ts->get_next_timers(next_timers);
+  cwtest_advance_time_ms(TestFixture::timers[1]->interval - TestFixture::timers[0]->interval);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
-  timers[1] = *next_timers.begin();
-  EXPECT_EQ(2u, timers[1]->id);
+  TestFixture::timers[1] = *next_timers.begin();
+  EXPECT_EQ(2u, TestFixture::timers[1]->id);
 
   next_timers.clear();
 
-  cwtest_advance_time_ms(timers[2]->interval - timers[1]->interval);
-  ts->get_next_timers(next_timers);
+  cwtest_advance_time_ms(TestFixture::timers[2]->interval - TestFixture::timers[1]->interval);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
-  timers[2] = *next_timers.begin();
-  EXPECT_EQ(3u, timers[2]->id);
+  TestFixture::timers[2] = *next_timers.begin();
+  EXPECT_EQ(3u, TestFixture::timers[2]->id);
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, ReallyLongTimer)
+TYPED_TEST(TestTimerStore, ReallyLongTimer)
 {
   // Lengthen timer three to really long (10 hours)
-  timers[2]->interval = (3600 * 1000) * 10;
-  ts->add_timer(timers[2]);
+  TestFixture::timers[2]->interval = (3600 * 1000) * 10;
+  TestFixture::ts->add_timer(TestFixture::timers[2]);
 
   std::unordered_set<Timer*> next_timers;
 
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(0u, next_timers.size());
 
   cwtest_advance_time_ms(((3600 * 1000) * 10) + TIMER_GRANULARITY_MS);
 
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
-  timers[2] = *next_timers.begin();
-  EXPECT_EQ(3u, timers[2]->id);
+  TestFixture::timers[2] = *next_timers.begin();
+  EXPECT_EQ(3u, TestFixture::timers[2]->id);
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, DeleteNearTimer)
+TYPED_TEST(TestTimerStore, DeleteNearTimer)
 {
-  uint64_t interval = timers[0]->interval;
-  ts->add_timer(timers[0]);
-  ts->delete_timer(1);
+  uint64_t interval = TestFixture::timers[0]->interval;
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::ts->delete_timer(1);
   std::unordered_set<Timer*> next_timers;
   cwtest_advance_time_ms(interval + TIMER_GRANULARITY_MS);
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_TRUE(next_timers.empty());
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, DeleteMidTimer)
+TYPED_TEST(TestTimerStore, DeleteMidTimer)
 {
-  uint64_t interval = timers[2]->interval;
-  ts->add_timer(timers[1]);
-  ts->delete_timer(2);
+  uint64_t interval = TestFixture::timers[2]->interval;
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
+  TestFixture::ts->delete_timer(2);
   std::unordered_set<Timer*> next_timers;
   cwtest_advance_time_ms(interval + TIMER_GRANULARITY_MS);
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_TRUE(next_timers.empty());
-  delete timers[0];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, DeleteLongTimer)
+TYPED_TEST(TestTimerStore, DeleteLongTimer)
 {
-  uint64_t interval = timers[2]->interval;
-  ts->add_timer(timers[2]);
-  ts->delete_timer(3);
+  uint64_t interval = TestFixture::timers[2]->interval;
+  TestFixture::ts->add_timer(TestFixture::timers[2]);
+  TestFixture::ts->delete_timer(3);
   cwtest_advance_time_ms(interval + TIMER_GRANULARITY_MS);
   std::unordered_set<Timer*> next_timers;
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_TRUE(next_timers.empty());
-  delete timers[0];
-  delete timers[1];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, UpdateTimer)
+TYPED_TEST(TestTimerStore, UpdateTimer)
 {
-  ts->add_timer(timers[0]);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
 
   // Replace timer one, using a newer timer with the same ID.
-  timers[1]->id = 1;
-  timers[1]->start_time_mono_ms++;
-  ts->add_timer(timers[1]);
+  TestFixture::timers[1]->id = 1;
+  TestFixture::timers[1]->start_time_mono_ms++;
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
   cwtest_advance_time_ms(1000000);
 
   // Fetch the newly updated timer.
   std::unordered_set<Timer*> next_timers;
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(1u, next_timers.size());
 
   // Now the timer store is empty.
   next_timers.clear();
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_TRUE(next_timers.empty());
 
   // Timer one was deleted when it was overwritten
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, DontUpdateTimerAge)
+TYPED_TEST(TestTimerStore, DontUpdateTimerAge)
 {
-  ts->add_timer(timers[0]);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
 
   // Attempt to replace timer one but the replacement is older
-  timers[1]->id = 1;
-  timers[1]->start_time_mono_ms--;
-  ts->add_timer(timers[1]);
+  TestFixture::timers[1]->id = 1;
+  TestFixture::timers[1]->start_time_mono_ms--;
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
   cwtest_advance_time_ms(1000000);
 
   // Fetch the newly updated timer.
   std::unordered_set<Timer*> next_timers;
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(1u, next_timers.size());
 
   // Now the timer store is empty.
   next_timers.clear();
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_TRUE(next_timers.empty());
 
   // Timer two was deleted when it failed to overwrite timer one
-  delete timers[0];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, DontUpdateTimerSeqNo)
+TYPED_TEST(TestTimerStore, DontUpdateTimerSeqNo)
 {
-  timers[0]->sequence_number++;
-  ts->add_timer(timers[0]);
+  TestFixture::timers[0]->sequence_number++;
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
 
   // Attempt to replace timer one but the replacement has a lower SeqNo
-  timers[1]->id = 1;
-  ts->add_timer(timers[1]);
+  TestFixture::timers[1]->id = 1;
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
   cwtest_advance_time_ms(1000000);
 
   // Fetch the newly updated timer.
   std::unordered_set<Timer*> next_timers;
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(1u, next_timers.size());
 
   // Now the timer store is empty.
   next_timers.clear();
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_TRUE(next_timers.empty());
 
   // Timer two was deleted when it failed to overwrite timer one
-  delete timers[0];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, AddTombstone)
+TYPED_TEST(TestTimerStore, AddTombstone)
 {
-  ts->add_timer(tombstone);
+  TestFixture::ts->add_timer(TestFixture::tombstone);
 
   std::unordered_set<Timer*> next_timers;
   cwtest_advance_time_ms(1000000);
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(1u, next_timers.size());
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, OverwriteWithTombstone)
+TYPED_TEST(TestTimerStore, OverwriteWithTombstone)
 {
-  ts->add_timer(timers[0]);
-  ts->add_timer(tombstone);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::ts->add_timer(TestFixture::tombstone);
 
   std::unordered_set<Timer*> next_timers;
   cwtest_advance_time_ms(1000000);
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size());
 
   Timer* extracted = *next_timers.begin();
@@ -528,19 +567,19 @@ TEST_F(TestTimerStore, OverwriteWithTombstone)
   EXPECT_EQ(100u, extracted->interval);
   EXPECT_EQ(100u, extracted->repeat_for);
 
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
 // Test for issue #19, even if time is moving in non-10ms steps
-// we should be able to reliably update/tombstone timers.
-TEST_F(TestTimerStore, Non10msShortTimerUpdate)
+// we should be able to reliably update/TestFixture::tombstone timers.
+TYPED_TEST(TestTimerStore, Non10msShortTimerUpdate)
 {
   // Offset the interval of the first timer so it's not a multiple of 10ms.
-  timers[0]->interval += 4;
+  TestFixture::timers[0]->interval += 4;
 
-  ts->add_timer(timers[0]);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
 
   // Move time on more than the timer's shift but less than 10ms, even
   // after this the timer store should know which bucket the timer is in.
@@ -549,41 +588,41 @@ TEST_F(TestTimerStore, Non10msShortTimerUpdate)
   // Attempting to get a set of timers updates the internal clock in the
   // timer store.
   std::unordered_set<Timer*> next_timers;
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(0u, next_timers.size());
 
   // Now, to prove the timer store can still find the timer, update it to
-  // a tombstone.
-  ts->add_timer(tombstone);
+  // a TestFixture::tombstone.
+  TestFixture::ts->add_timer(TestFixture::tombstone);
 
   // No timers are ready to pop yet
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(0u, next_timers.size());
 
-  // Move on till the tombstone should pop (50 ms offset from timer[0])
+  // Move on till the TestFixture::tombstone should pop (50 ms offset from timer[0])
   cwtest_advance_time_ms(150 + TIMER_GRANULARITY_MS);
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(1u, next_timers.size());
   next_timers.clear();
 
   // Move on again to ensure there are no more timers in the store.
   cwtest_advance_time_ms(100000);
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(0u, next_timers.size());
 
   // timer[0] was deleted when it was updated in the timer store.
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
 // Test for issue #19
-TEST_F(TestTimerStore, Non10msMediumTimerUpdate)
+TYPED_TEST(TestTimerStore, Non10msMediumTimerUpdate)
 {
   // Offset the interval of the second timer so it's not a multiple of 10ms.
-  timers[1]->interval += 4;
+  TestFixture::timers[1]->interval += 4;
 
-  ts->add_timer(timers[1]);
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
 
   // Move time on to less than 1s but closer than the timer's offset, even
   // after this the timer store should know which bucket the timer is in.
@@ -592,36 +631,36 @@ TEST_F(TestTimerStore, Non10msMediumTimerUpdate)
   // Attempting to get a set of timers updates the internal clock in the
   // timer store.
   std::unordered_set<Timer*> next_timers;
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(0u, next_timers.size());
 
   // Now, to prove the timer store can still find the timer, update it to
-  // a tombstone.
-  tombstone->id = timers[1]->id;
-  ts->add_timer(tombstone);
+  // a TestFixture::tombstone.
+  TestFixture::tombstone->id = TestFixture::timers[1]->id;
+  TestFixture::ts->add_timer(TestFixture::tombstone);
 
   // No timers are ready to pop yet
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(0u, next_timers.size());
 
   // Move on till the timer should pop
   cwtest_advance_time_ms(100000);
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(1u, next_timers.size());
   next_timers.clear();
 
   // Move on again to ensure there are no more timers in the store.
   cwtest_advance_time_ms(100000);
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(0u, next_timers.size());
 
   // timer[1] was deleted when it was updated in the timer store.
-  delete timers[0];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, MixtureOfTimerLengths)
+TYPED_TEST(TestTimerStore, MixtureOfTimerLengths)
 {
   // Add timers that all pop at the same time, but in such a way that one ends
   // up in the short wheel, one in the long wheel, and one in the heap.  Check
@@ -630,154 +669,154 @@ TEST_F(TestTimerStore, MixtureOfTimerLengths)
 
   // Timers all pop 1hr, 1s, 500ms from the start of the test.
   // Set timer 1.
-  timers[0]->interval = ((60 * 60 * 1000) + (1 * 1000) + 500);
-  ts->add_timer(timers[0]);
+  TestFixture::timers[0]->interval = ((60 * 60 * 1000) + (1 * 1000) + 500);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
 
   // Move on by 1hr. Nothing has popped.
   cwtest_advance_time_ms(60 * 60 * 1000);
-  timers[1]->start_time_mono_ms += (60 * 60 * 1000);
-  timers[2]->start_time_mono_ms += (60 * 60 * 1000);
-  ts->get_next_timers(next_timers);
+  TestFixture::timers[1]->start_time_mono_ms += (60 * 60 * 1000);
+  TestFixture::timers[2]->start_time_mono_ms += (60 * 60 * 1000);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(0u, next_timers.size());
 
   // Timer 2 pops in 1s, 500ms
-  timers[1]->interval = ((1 * 1000) + 500);
-  ts->add_timer(timers[1]);
+  TestFixture::timers[1]->interval = ((1 * 1000) + 500);
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
 
   // Move on by 1s. Nothing has popped.
   cwtest_advance_time_ms(1 * 1000);
-  timers[2]->start_time_mono_ms += (1 * 1000);
-  ts->get_next_timers(next_timers);
+  TestFixture::timers[2]->start_time_mono_ms += (1 * 1000);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(0u, next_timers.size());
 
   // Timer 3 pops in 500ms.
-  timers[2]->interval = 500;
-  ts->add_timer(timers[2]);
+  TestFixture::timers[2]->interval = 500;
+  TestFixture::ts->add_timer(TestFixture::timers[2]);
 
   // Move on by 500ms. All timers pop.
   cwtest_advance_time_ms(500 + TIMER_GRANULARITY_MS);
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(3u, next_timers.size());
   next_timers.clear();
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, TimerPopsOnTheHour)
+TYPED_TEST(TestTimerStore, TimerPopsOnTheHour)
 {
   std::unordered_set<Timer*> next_timers;
   uint64_t pop_time_ms;
 
-  pop_time_ms = (timers[0]->start_time_mono_ms / (60 * 60 * 1000));
+  pop_time_ms = (TestFixture::timers[0]->start_time_mono_ms / (60 * 60 * 1000));
   pop_time_ms += 2;
   pop_time_ms *= (60 * 60 * 1000);
-  timers[0]->interval = pop_time_ms - timers[0]->start_time_mono_ms;
-  ts->add_timer(timers[0]);
+  TestFixture::timers[0]->interval = pop_time_ms - TestFixture::timers[0]->start_time_mono_ms;
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
 
   // Move on to the pop time. The timer pops correctly.
-  cwtest_advance_time_ms(pop_time_ms - timers[0]->start_time_mono_ms + TIMER_GRANULARITY_MS);
-  ts->get_next_timers(next_timers);
+  cwtest_advance_time_ms(pop_time_ms - TestFixture::timers[0]->start_time_mono_ms + TIMER_GRANULARITY_MS);
+  TestFixture::ts->get_next_timers(next_timers);
   EXPECT_EQ(1u, next_timers.size());
   next_timers.clear();
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, PopOverdueTimer)
+TYPED_TEST(TestTimerStore, PopOverdueTimer)
 {
   cwtest_advance_time_ms(500);
   std::unordered_set<Timer*> next_timers;
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
 
-  ts->add_timer(timers[0]);
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::ts->get_next_timers(next_timers);
 
   ASSERT_EQ(1u, next_timers.size());
-  timers[0] = *next_timers.begin();
-  EXPECT_EQ(1u, timers[0]->id);
+  TestFixture::timers[0] = *next_timers.begin();
+  EXPECT_EQ(1u, TestFixture::timers[0]->id);
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
-TEST_F(TestTimerStore, DeleteOverdueTimer)
+TYPED_TEST(TestTimerStore, DeleteOverdueTimer)
 {
   cwtest_advance_time_ms(500);
   std::unordered_set<Timer*> next_timers;
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
 
-  ts->add_timer(timers[0]);
-  ts->delete_timer(1);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::ts->delete_timer(1);
 
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(0u, next_timers.size());
 
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
 // Test that marking some of the replicas as being informed
 // doesn't change the timer if it's got an up-to-date
 // cluster view ID
-TEST_F(TestTimerStore, UpdateReplicaTrackerValueForNewTimer)
+TYPED_TEST(TestTimerStore, UpdateReplicaTrackerValueForNewTimer)
 {
   cwtest_advance_time_ms(500);
   std::unordered_set<Timer*> next_timers;
-  timers[0]->_replica_tracker = 15;
-  ts->add_timer(timers[0]);
-  ts->update_replica_tracker_for_timer(1u, 3);
+  TestFixture::timers[0]->_replica_tracker = 15;
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::ts->update_replica_tracker_for_timer(1u, 3);
 
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size());
-  timers[0] = *next_timers.begin();
-  ASSERT_EQ(15u, timers[0]->_replica_tracker);
+  TestFixture::timers[0] = *next_timers.begin();
+  ASSERT_EQ(15u, TestFixture::timers[0]->_replica_tracker);
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
 // Test that marking some of the replicas as being informed
 // changes the replica tracker if the cluster view ID is
 // different
-TEST_F(TestTimerStore, UpdateReplicaTrackerValueForOldTimer)
+TYPED_TEST(TestTimerStore, UpdateReplicaTrackerValueForOldTimer)
 {
   cwtest_advance_time_ms(500);
   std::unordered_set<Timer*> next_timers;
-  timers[0]->_replica_tracker = 15;
-  timers[0]->cluster_view_id = "different-id";
-  ts->add_timer(timers[0]);
-  ts->update_replica_tracker_for_timer(1u, 3);
+  TestFixture::timers[0]->_replica_tracker = 15;
+  TestFixture::timers[0]->cluster_view_id = "different-id";
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::ts->update_replica_tracker_for_timer(1u, 3);
 
-  ts->get_next_timers(next_timers);
+  TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size());
-  timers[0] = *next_timers.begin();
-  ASSERT_EQ(7u, timers[0]->_replica_tracker);
+  TestFixture::timers[0] = *next_timers.begin();
+  ASSERT_EQ(7u, TestFixture::timers[0]->_replica_tracker);
 
-  delete timers[0];
-  delete timers[1];
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[0];
+  delete TestFixture::timers[1];
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
 // Test that getting timers for a node returns the set of timers
 // (up to the maximum requested)
-TEST_F(TestTimerStore, SelectTimers)
+TYPED_TEST(TestTimerStore, SelectTimers)
 {
   std::unordered_set<Timer*> next_timers;
-  ts->add_timer(timers[0]);
-  ts->add_timer(timers[1]);
-  ts->add_timer(timers[2]);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
+  TestFixture::ts->add_timer(TestFixture::timers[2]);
   std::string get_response;
 
   std::string updated_cluster_view_id = "updated-cluster-view-id";
@@ -788,7 +827,7 @@ TEST_F(TestTimerStore, SelectTimers)
   __globals->set_cluster_view_id(updated_cluster_view_id);
   __globals->unlock();
 
-  ts->get_timers_for_node("10.0.0.1:9999", 2, updated_cluster_view_id, get_response);
+  TestFixture::ts->get_timers_for_node("10.0.0.1:9999", 2, updated_cluster_view_id, get_response);
 
   // Check the GET has the right format. This is two timers out of the three available (as the
   // max number of timers is set to 2). We're using a simple regex here as we use JSON
@@ -804,63 +843,63 @@ TEST_F(TestTimerStore, SelectTimers)
   __globals->set_cluster_addresses(cluster_addresses);
   __globals->unlock();
 
-  delete tombstone;
+  delete TestFixture::tombstone;
 }
 
 // Test that if there are no timers for the requesting node,
 // that trying to get the timers returns an empty list
-TEST_F(TestTimerStore, SelectTimersTakeInformationalTimers)
+TYPED_TEST(TestTimerStore, SelectTimersTakeInformationalTimers)
 {
   std::unordered_set<Timer*> next_timers;
 
   // Add a timer to the store, then update it with a new cluster view ID.
-  timers[0]->cluster_view_id = "old-cluster-view-id";
-  ts->add_timer(timers[0]);
-  timers[1]->id = 1;
-  ts->add_timer(timers[1]);
+  TestFixture::timers[0]->cluster_view_id = "old-cluster-view-id";
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::timers[1]->id = 1;
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
 
   std::string get_response;
-  ts->get_timers_for_node("10.0.0.3:9999", 1, "cluster-view-id", get_response);
+  TestFixture::ts->get_timers_for_node("10.0.0.3:9999", 1, "cluster-view-id", get_response);
 
   // Check that the response is based on the informational timer, rather than the timer
   // in the timer wheel (the uri should be callback1 rather than callback2)
   std::string exp_rsp = "\\\{\"Timers\":\\\[\\\{\"TimerID\":1,\"OldReplicas\":\\\[\"10.0.0.1:9999\"],\"Timer\":\\\{\"timing\":\\\{\"start-time\".*,\"sequence-number\":0,\"interval\":0,\"repeat-for\":0},\"callback\":\\\{\"http\":\\\{\"uri\":\"localhost:80/callback1\",\"opaque\":\"stuff stuff stuff\"}},\"reliability\":\\\{\"cluster-view-id\":\"cluster-view-id\",\"replicas\":\\\[\"10.0.0.3:9999\"]}}}]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
 
-  delete timers[2];
-  delete tombstone;
+  delete TestFixture::timers[2];
+  delete TestFixture::tombstone;
 }
 
 // Test that if there are no timers for the requesting node,
 // that trying to get the timers returns an empty list
-TEST_F(TestTimerStore, SelectTimersNoMatchesReqNode)
+TYPED_TEST(TestTimerStore, SelectTimersNoMatchesReqNode)
 {
   std::unordered_set<Timer*> next_timers;
-  ts->add_timer(timers[0]);
-  ts->add_timer(timers[1]);
-  ts->add_timer(timers[2]);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
+  TestFixture::ts->add_timer(TestFixture::timers[2]);
   std::string get_response;
-  ts->get_timers_for_node("10.0.0.4:9999", 1, "cluster-view-id", get_response);
+  TestFixture::ts->get_timers_for_node("10.0.0.4:9999", 1, "cluster-view-id", get_response);
 
   ASSERT_EQ(get_response, "{\"Timers\":[]}");
 
-  delete tombstone;
+  delete TestFixture::tombstone;
 }
 
 // Test that if there are no timers with an out of date cluster
 // ID then trying to get the timers returns an empty list
-TEST_F(TestTimerStore, SelectTimersNoMatchesClusterID)
+TYPED_TEST(TestTimerStore, SelectTimersNoMatchesClusterID)
 {
   std::unordered_set<Timer*> next_timers;
-  ts->add_timer(timers[0]);
-  ts->add_timer(timers[1]);
-  ts->add_timer(timers[2]);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
+  TestFixture::ts->add_timer(TestFixture::timers[2]);
   std::string get_response;
-  ts->get_timers_for_node("10.0.0.1:9999", 1, "cluster-view-id", get_response);
+  TestFixture::ts->get_timers_for_node("10.0.0.1:9999", 1, "cluster-view-id", get_response);
 
   ASSERT_EQ(get_response, "{\"Timers\":[]}");
 
-  delete tombstone;
+  delete TestFixture::tombstone;
 }
 
 // Test that updating a timer with a new cluster ID causes the original
@@ -869,28 +908,28 @@ TEST_F(TestTimerStore, SelectTimersNoMatchesClusterID)
 // WARNING: In this test we look directly in the timer store as there's no
 // other way to test what's in the timer map (when it's not also in the timer
 // wheel)
-TEST_F(TestTimerStore, UpdateClusterViewID)
+TYPED_TEST(TestTimerStore, UpdateClusterViewID)
 {
   // Add the first timer with ID 1
-  ts->add_timer(timers[0]);
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
 
   // Find this timer in the store, and check there's no saved timers
   // associated with it
   std::map<TimerID, std::vector<Timer*>>::iterator map_it =
-                                                    ts->_timer_lookup_table.find(1);
-  EXPECT_TRUE(map_it != ts->_timer_lookup_table.end());
+                                                    TestFixture::ts->_timer_lookup_table.find(1);
+  EXPECT_TRUE(map_it != TestFixture::ts->_timer_lookup_table.end());
   EXPECT_EQ(1u, map_it->second.size());
   EXPECT_EQ(1u, map_it->second.front()->id);
 
   // Add a new timer with the same ID, and an updated Cluster View ID
-  timers[1]->id = 1;
-  timers[1]->cluster_view_id = "updated-cluster-view-id";
-  ts->add_timer(timers[1]);
+  TestFixture::timers[1]->id = 1;
+  TestFixture::timers[1]->cluster_view_id = "updated-cluster-view-id";
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
 
   // Find this timer in the store, and check there's a saved timer. The saved
   // timer has the old cluster view ID, and the new timer has the new one.
-  map_it = ts->_timer_lookup_table.find(1);
-  EXPECT_TRUE(map_it != ts->_timer_lookup_table.end());
+  map_it = TestFixture::ts->_timer_lookup_table.find(1);
+  EXPECT_TRUE(map_it != TestFixture::ts->_timer_lookup_table.end());
   EXPECT_EQ(2u, map_it->second.size());
   EXPECT_EQ(1u, map_it->second.front()->id);
   EXPECT_EQ("updated-cluster-view-id", map_it->second.front()->cluster_view_id);
@@ -898,16 +937,16 @@ TEST_F(TestTimerStore, UpdateClusterViewID)
   EXPECT_EQ("cluster-view-id", map_it->second.back()->cluster_view_id);
 
   // Add a new timer with the same ID, an updated Cluster View ID,
-  // and make it a tombstone
-  timers[2]->id = 1;
-  timers[2]->cluster_view_id = "updated-again-cluster-view-id";
-  timers[2]->become_tombstone();
-  ts->add_timer(timers[2]);
+  // and make it a TestFixture::tombstone
+  TestFixture::timers[2]->id = 1;
+  TestFixture::timers[2]->cluster_view_id = "updated-again-cluster-view-id";
+  TestFixture::timers[2]->become_tombstone();
+  TestFixture::ts->add_timer(TestFixture::timers[2]);
 
   // Find this timer in the store, and check there's a saved timer. The saved
   // timer has the old cluster view ID, and the new timer has the new one.
-  map_it = ts->_timer_lookup_table.find(1);
-  EXPECT_TRUE(map_it != ts->_timer_lookup_table.end());
+  map_it = TestFixture::ts->_timer_lookup_table.find(1);
+  EXPECT_TRUE(map_it != TestFixture::ts->_timer_lookup_table.end());
   EXPECT_EQ(2u, map_it->second.size());
   EXPECT_EQ(1u, map_it->second.front()->id);
   EXPECT_EQ("updated-again-cluster-view-id", map_it->second.front()->cluster_view_id);
@@ -916,7 +955,7 @@ TEST_F(TestTimerStore, UpdateClusterViewID)
   EXPECT_EQ("updated-cluster-view-id", map_it->second.back()->cluster_view_id);
   EXPECT_FALSE(map_it->second.back()->is_tombstone());
 
-  delete tombstone;
+  delete TestFixture::tombstone;
 }
 
 // Test that the store uses the saved timers (rather than the timers in the
@@ -925,42 +964,42 @@ TEST_F(TestTimerStore, UpdateClusterViewID)
 // WARNING: In this test we look directly in the timer store as there's no
 // other way to test what's in the timer map (when it's not also in the timer
 // wheel)
-TEST_F(TestTimerStore, ModifySavedTimers)
+TYPED_TEST(TestTimerStore, ModifySavedTimers)
 {
   // Add a timer to the store with an old cluster ID and three replicas
-  timers[0]->cluster_view_id = "old-cluster-view-id";
-  timers[0]->_replica_tracker = 7;
-  timers[0]->replicas.push_back("10.0.0.2:9999");
-  timers[0]->replicas.push_back("10.0.0.3:9999");
-  ts->add_timer(timers[0]);
+  TestFixture::timers[0]->cluster_view_id = "old-cluster-view-id";
+  TestFixture::timers[0]->_replica_tracker = 7;
+  TestFixture::timers[0]->replicas.push_back("10.0.0.2:9999");
+  TestFixture::timers[0]->replicas.push_back("10.0.0.3:9999");
+  TestFixture::ts->add_timer(TestFixture::timers[0]);
 
   // Add a timer to the store with the same ID as the previous timer,
   // but an updated cluster-view ID. This will take the original timer
   // out of the timer wheel and save it just in the map
-  timers[1]->id = 1;
-  timers[1]->_replica_tracker = 7;
-  timers[1]->replicas.push_back("10.0.0.2:9999");
-  timers[1]->replicas.push_back("10.0.0.3:9999");
-  ts->add_timer(timers[1]);
+  TestFixture::timers[1]->id = 1;
+  TestFixture::timers[1]->_replica_tracker = 7;
+  TestFixture::timers[1]->replicas.push_back("10.0.0.2:9999");
+  TestFixture::timers[1]->replicas.push_back("10.0.0.3:9999");
+  TestFixture::ts->add_timer(TestFixture::timers[1]);
 
   // Update the replica tracker for Timer ID 1. This should update the
   // saved timer to mark that the third replica has been informed, not
   // the new first timer.
-  ts->update_replica_tracker_for_timer(1u, 2);
+  TestFixture::ts->update_replica_tracker_for_timer(1u, 2);
   std::map<TimerID, std::vector<Timer*>>::iterator map_it =
-                                                    ts->_timer_lookup_table.find(1);
-  EXPECT_TRUE(map_it != ts->_timer_lookup_table.end());
+                                                    TestFixture::ts->_timer_lookup_table.find(1);
+  EXPECT_TRUE(map_it != TestFixture::ts->_timer_lookup_table.end());
   EXPECT_EQ(2u, map_it->second.size());
   EXPECT_EQ(7u, map_it->second.front()->_replica_tracker);
   EXPECT_EQ(3u, map_it->second.back()->_replica_tracker);
 
   // Now update the timer. This should change the first timer but not the
   // second timer in the timer map
-  timers[2]->id = 1;
-  timers[2]->_replica_tracker = 7;
-  ts->add_timer(timers[2]);
-  map_it = ts->_timer_lookup_table.find(1);
-  EXPECT_TRUE(map_it != ts->_timer_lookup_table.end());
+  TestFixture::timers[2]->id = 1;
+  TestFixture::timers[2]->_replica_tracker = 7;
+  TestFixture::ts->add_timer(TestFixture::timers[2]);
+  map_it = TestFixture::ts->_timer_lookup_table.find(1);
+  EXPECT_TRUE(map_it != TestFixture::ts->_timer_lookup_table.end());
   EXPECT_EQ(2u, map_it->second.size());
   EXPECT_EQ(7u, map_it->second.front()->_replica_tracker);
   EXPECT_EQ(1u, map_it->second.front()->replicas.size());
@@ -970,14 +1009,14 @@ TEST_F(TestTimerStore, ModifySavedTimers)
   // Finally, update the replica tracker to mark all replicas
   // as having been informed for Timer ID 1. This should
   // delete the saved timer.
-  ts->update_replica_tracker_for_timer(1u, 0);
-  map_it = ts->_timer_lookup_table.find(1);
-  EXPECT_TRUE(map_it != ts->_timer_lookup_table.end());
+  TestFixture::ts->update_replica_tracker_for_timer(1u, 0);
+  map_it = TestFixture::ts->_timer_lookup_table.find(1);
+  EXPECT_TRUE(map_it != TestFixture::ts->_timer_lookup_table.end());
   EXPECT_EQ(1u, map_it->second.size());
   std::string get_response;
-  ts->get_timers_for_node("10.0.0.1:9999", 1, "cluster-view-id", get_response);
+  TestFixture::ts->get_timers_for_node("10.0.0.1:9999", 1, "cluster-view-id", get_response);
   ASSERT_EQ(get_response, "{\"Timers\":[]}");
 
-  delete tombstone;
+  delete TestFixture::tombstone;
 }
 


### PR DESCRIPTION
Sorry for all the hideous whitespace updates.

In general, most variables are kept as 64-bit integers, but when comparing or doing calculations with them, we either cast them down to 32, or use the function with takes 32bit integers as parameters

Confirms it passes all unit tests, although added SNMP stats to the "non-covered" list.