### PR TITLE
[Reviewer: Andy] - Update bucket size and make timers consistent

### DIFF
--- a/src/include/timer.h
+++ b/src/include/timer.h
@@ -57,7 +57,7 @@ public:
 class Timer
 {
 public:
-  Timer(TimerID, uint32_t interval, uint32_t repeat_for);
+  Timer(TimerID, uint64_t interval_ms, uint32_t repeat_for);
   ~Timer();
 
   // For testing purposes.
@@ -116,8 +116,8 @@ public:
   // functions, rather than a full-blown object).
   TimerID id;
   uint64_t start_time_mono_ms;
-  uint32_t interval;
-  uint32_t repeat_for;
+  uint64_t interval_ms;
+  uint64_t repeat_for;
   uint32_t sequence_number;
   std::string cluster_view_id;
   std::vector<std::string> replicas;

--- a/src/include/timer.h
+++ b/src/include/timer.h
@@ -57,14 +57,14 @@ public:
 class Timer
 {
 public:
-  Timer(TimerID, uint64_t interval_ms, uint32_t repeat_for);
+  Timer(TimerID, uint32_t interval_ms, uint32_t repeat_for);
   ~Timer();
 
   // For testing purposes.
   friend class TestTimer;
 
   // Returns the next time to pop in ms after epoch
-  uint64_t next_pop_time();
+  uint32_t next_pop_time();
 
   // Construct the URL for this timer given a hostname
   std::string url(std::string host = "");
@@ -115,9 +115,9 @@ public:
   // Member variables (mostly public since this is pretty much a struct with utility
   // functions, rather than a full-blown object).
   TimerID id;
-  uint64_t start_time_mono_ms;
-  uint64_t interval_ms;
-  uint64_t repeat_for;
+  uint32_t start_time_mono_ms;
+  uint32_t interval_ms;
+  uint32_t repeat_for;
   uint32_t sequence_number;
   std::string cluster_view_id;
   std::vector<std::string> replicas;

--- a/src/include/timer_store.h
+++ b/src/include/timer_store.h
@@ -75,8 +75,8 @@ public:
 
 private:
   // The timer store uses 4 data structures to ensure timers pop on time:
-  // - A short timer wheel consisting of 100 10ms buckets (1s in total).
-  // - A long timer wheel consisting of 3600 1s buckets (1hr in total).
+  // - A short timer wheel consisting of 128 8ms buckets (1024ms in total).
+  // - A long timer wheel consisting of 4096 1024ms buckets (4194304ms in total).
   // - A heap,
   // - A set of overdue timers.
   //
@@ -88,7 +88,7 @@ private:
   //
   // Timers in the overdue set are popped whenever `get_next_timers` is called.
   //
-  // The short wheel ticks forward at the rate of 1 bucket per 10ms. On evey
+  // The short wheel ticks forward at the rate of 1 bucket per 8ms. On evey
   // tick the timers in the current bucket are popped. Every time the short
   // wheel does a full rotation, the long wheel ticks forward, and every timer
   // in the next bucket is placed into the correct place in the short wheel.
@@ -97,13 +97,13 @@ private:
   // short/long wheels.
   //
   // To achieve this the store tracks the time of the next tick to process
-  // _tick_timestamp, which is a multiple of 10ms. The wheels are arrays
+  // _tick_timestamp, which is a multiple of 8ms. The wheels are arrays
   // of sets that store pointers to timer objects. Any timestamp can be mapped
   // to an index into these arrays (using division and modulo arithmetic).
   //
   // When a tick is processed:
   // - All timers in the current short bucket are popped.
-  // - The tick time is increased by 10ms.
+  // - The tick time is increased by 8ms.
   // - If the new tick time is on a 1s boundary, all timers in the current
   //   long bucket are distributed to the appropriate short bucket.
   // - If the new tick time is on a 1hr boundary, all timers in the heap that
@@ -112,13 +112,14 @@ private:
   //
   // A result of this algorithm is that it is not possible to tell where a timer
   // is stored based solely on it's pop time. For example:
-  // - At time 0ms, a new timer was set to pop at time 3,600,030ms. It would
-  //   go straight into the heap as it's due to pop in >= 1hr.
-  // - At time 3,599,900ms, another new timer is set to pop, also at
-  //   3,600,030ms.  It would go in the short wheel as it's due to pop in <1s.
-  // - So at time 3,599,990 one the timers are in different locations, despite
+  // - At time 0ms, a new timer was set to pop at time 4,194,305ms. It would
+  //   go straight into the heap as it's due to pop in >= long timer wheel total.
+  // - At time 4,194,300ms, another new timer is set to pop, also at
+  //   4,194,305ms.  It would go in the short wheel as it's due to pop in <
+  //   short wheel timer total.
+  // - So at time 4,194,300 one the timers are in different locations, despite
   //   popping at the same time.
-  // - This is OK, because at time 3,600,000 the long wheel does a complete
+  // - This is OK, because at time 4,194,304 the long wheel does a complete
   //   rotation, and both timers get moved into the short wheel, to be popped
   //   at the right time.
   //
@@ -178,8 +179,8 @@ private:
   Bucket* long_wheel_bucket(uint32_t t);
 
   // Utility methods to convert a timestamp to the resolution used by the
-  // wheels.  These round down (so to 10ms accuracy, 12345 -> 12340, but 12340
-  // -> 12340).
+  // wheels.  These round down (so to 8ms accuracy, 1644 -> 1640, but 1640
+  // -> 1640).
   static uint32_t to_short_wheel_resolution(uint32_t t);
   static uint32_t to_long_wheel_resolution(uint32_t t);
 

--- a/src/include/timer_store.h
+++ b/src/include/timer_store.h
@@ -135,13 +135,13 @@ private:
   HealthChecker* _health_checker;
 
   // Constants controlling the size and resolution of the timer wheels.
-  static const int SHORT_WHEEL_RESOLUTION_MS = 10;
-  static const int SHORT_WHEEL_NUM_BUCKETS = 100;
+  static const int SHORT_WHEEL_RESOLUTION_MS = 8;
+  static const int SHORT_WHEEL_NUM_BUCKETS = 128;
   static const int SHORT_WHEEL_PERIOD_MS =
                                  (SHORT_WHEEL_RESOLUTION_MS * SHORT_WHEEL_NUM_BUCKETS);
 
   static const int LONG_WHEEL_RESOLUTION_MS = SHORT_WHEEL_PERIOD_MS;
-  static const int LONG_WHEEL_NUM_BUCKETS = 3600;
+  static const int LONG_WHEEL_NUM_BUCKETS = 4096;
   static const int LONG_WHEEL_PERIOD_MS =
                             (LONG_WHEEL_RESOLUTION_MS * LONG_WHEEL_NUM_BUCKETS);
 
@@ -162,10 +162,10 @@ private:
 
   // Timestamp of the next tick to process. This is stored in ms, and is always
   // a multiple of SHORT_WHEEL_RESOLUTION_MS.
-  uint64_t _tick_timestamp;
+  uint32_t _tick_timestamp;
 
   // Return the current timestamp in ms.
-  static uint64_t timestamp_ms();
+  static uint32_t timestamp_ms();
 
   // Utility functions to locate a Timer's correct home in the store's timer
   // wheels.
@@ -174,14 +174,14 @@ private:
 
   // Utility functions to locate a bucket in the timer wheels based on a
   // timestamp.
-  Bucket* short_wheel_bucket(uint64_t t);
-  Bucket* long_wheel_bucket(uint64_t t);
+  Bucket* short_wheel_bucket(uint32_t t);
+  Bucket* long_wheel_bucket(uint32_t t);
 
   // Utility methods to convert a timestamp to the resolution used by the
   // wheels.  These round down (so to 10ms accuracy, 12345 -> 12340, but 12340
   // -> 12340).
-  static uint64_t to_short_wheel_resolution(uint64_t t);
-  static uint64_t to_long_wheel_resolution(uint64_t t);
+  static uint32_t to_short_wheel_resolution(uint32_t t);
+  static uint32_t to_long_wheel_resolution(uint32_t t);
 
   // Refill timer wheels from the longer duration stores.
   //
@@ -217,6 +217,9 @@ private:
 
   // Save the tombstone values from an existing timer
   void set_tombstone_values(Timer* t, Timer* existing);
+
+  // Compare two number that might have overflown
+  bool overflow_less_than(uint32_t a, uint32_t b);
 
 };
 

--- a/src/include/timer_store.h
+++ b/src/include/timer_store.h
@@ -73,9 +73,6 @@ public:
                                        std::string cluster_view_id,
                                        std::string& get_response);
 
-  // Give the UT test fixture access to our member variables
-//  friend class TestTimerStore;
-
 private:
   // The timer store uses 4 data structures to ensure timers pop on time:
   // - A short timer wheel consisting of 100 10ms buckets (1s in total).
@@ -220,9 +217,6 @@ private:
 
   // Save the tombstone values from an existing timer
   void set_tombstone_values(Timer* t, Timer* existing);
-
-  // Compare two numbers that might have overflown
-  bool overflow_less_than(uint32_t a, uint32_t b);
 
 };
 

--- a/src/include/timer_store.h
+++ b/src/include/timer_store.h
@@ -219,7 +219,7 @@ private:
   // Save the tombstone values from an existing timer
   void set_tombstone_values(Timer* t, Timer* existing);
 
-  // Compare two number that might have overflown
+  // Compare two numbers that might have overflown
   bool overflow_less_than(uint32_t a, uint32_t b);
 
 };

--- a/src/main/http_callback.cpp
+++ b/src/main/http_callback.cpp
@@ -127,7 +127,7 @@ void HTTPCallback::worker_thread_entry_point()
     {
       // Check if the next pop occurs before the repeat-for interval and,
       // if not, convert to a tombstone to indicate the timer is dead.
-      if ((timer->sequence_number + 1) * timer->interval > timer->repeat_for)
+      if ((timer->sequence_number + 1) * timer->interval_ms > timer->repeat_for)
       {
         timer->become_tombstone();
       }

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -173,6 +173,13 @@ int main(int argc, char** argv)
   current_timers_scalar = new SNMP::U32Scalar("chronos_current_timers_scalar",
                                               ".1.2.826.0.1.1578918.9.10.5");
 
+  remaining_nodes_scalar = new SNMP::U32Scalar("chronos_remaining_nodes_scalar",
+                                                ".1.2.826.0.1.1578918.9.10.1");
+  timers_processed_table = SNMP::CounterTable::create("chronos_processed_timers_table",
+                                                                    ".1.2.826.0.1.1578918.9.10.2");
+  invalid_timers_processed_table = SNMP::CounterTable::create("chronos_invalid_timers_processed_table",
+                                                                    ".1.2.826.0.1.1578918.9.10.3");
+
   // Must be called after all SNMP tables have been registered
   init_snmp_handler_threads("chronos");
 
@@ -273,13 +280,6 @@ int main(int argc, char** argv)
   }
 
   HttpResolver* http_resolver = new HttpResolver(dns_resolver, af);
-
-  remaining_nodes_scalar = new SNMP::U32Scalar("chronos_remaining_nodes_scalar",
-                                                ".1.2.826.0.1.1578918.9.10.1");
-  timers_processed_table = SNMP::CounterTable::create("chronos_processed_timers_table",
-                                                                    ".1.2.826.0.1.1578918.9.10.2");
-  invalid_timers_processed_table = SNMP::CounterTable::create("chronos_invalid_timers_processed_table",
-                                                                    ".1.2.826.0.1.1578918.9.10.3");
 
   ChronosInternalConnection* chronos_internal_connection =
             new ChronosInternalConnection(http_resolver,

--- a/src/main/timer.cpp
+++ b/src/main/timer.cpp
@@ -51,7 +51,6 @@
 #include <map>
 #include <atomic>
 #include <time.h>
-#include <cmath>
 
 uint32_t Hasher::do_hash(TimerID data, uint32_t seed)
 {
@@ -68,7 +67,7 @@ inline uint32_t clock_gettime_ms(int clock_id)
   clock_gettime(clock_id, &now);
   uint64_t time = now.tv_sec;
   time *= 1000;
-  time += std::floor(now.tv_nsec / 1000000.0);
+  time += now.tv_nsec / 1000000;
   return time;
 }
 

--- a/src/main/timer.cpp
+++ b/src/main/timer.cpp
@@ -68,9 +68,9 @@ inline uint64_t clock_gettime_ms(int clock_id)
   return ((time.tv_sec * 1000) + (time.tv_nsec / 1000000));
 }
 
-Timer::Timer(TimerID id, uint32_t interval, uint32_t repeat_for) :
+Timer::Timer(TimerID id, uint64_t interval_ms, uint32_t repeat_for) :
   id(id),
-  interval(interval),
+  interval_ms(interval_ms),
   repeat_for(repeat_for),
   sequence_number(0),
   replicas(std::vector<std::string>()),
@@ -109,7 +109,7 @@ uint64_t Timer::next_pop_time()
     }
   }
 
-  return start_time_mono_ms + ((sequence_number + 1) * interval) + (replica_index * 2 * 1000);
+  return start_time_mono_ms + ((sequence_number + 1) * interval_ms) + (replica_index * 2 * 1000);
 }
 
 // Create the timer's URL from a given hostname
@@ -194,7 +194,7 @@ void Timer::to_json_obj(rapidjson::Writer<rapidjson::StringBuffer>* writer)
     {
       uint64_t realtime = clock_gettime_ms(CLOCK_REALTIME);
       uint64_t monotime = clock_gettime_ms(CLOCK_MONOTONIC);
-      int32_t delta = start_time_mono_ms - monotime;
+      int32_t delta = (uint32_t)(start_time_mono_ms) - monotime;
       writer->String("start-time");
       writer->Int64(realtime + delta);
       writer->String("start-time-delta");
@@ -202,7 +202,7 @@ void Timer::to_json_obj(rapidjson::Writer<rapidjson::StringBuffer>* writer)
       writer->String("sequence-number");
       writer->Int(sequence_number);
       writer->String("interval");
-      writer->Int(interval/1000);
+      writer->Int(interval_ms/1000);
       writer->String("repeat-for");
       writer->Int(repeat_for/1000);
     }
@@ -270,7 +270,7 @@ void Timer::become_tombstone()
 
   // Since we're not bringing the start-time forward we have to extend the
   // repeat-for to ensure the tombstone gets added to the replica's store.
-  repeat_for = interval * (sequence_number + 1);
+  repeat_for = interval_ms * (sequence_number + 1);
 }
 
 bool Timer::is_matching_cluster_view_id(std::string cluster_view_id_to_match)
@@ -521,8 +521,8 @@ Timer* Timer::from_json_obj(TimerID id,
     JSON_ASSERT_OBJECT(timing);
 
     JSON_ASSERT_CONTAINS(timing, "interval");
-    rapidjson::Value& interval = timing["interval"];
-    JSON_ASSERT_INT(interval);
+    rapidjson::Value& interval_ms = timing["interval"];
+    JSON_ASSERT_INT(interval_ms);
 
     // Extract the repeat-for parameter, if it's absent, set it to the interval
     // instead.
@@ -533,10 +533,10 @@ Timer* Timer::from_json_obj(TimerID id,
     }
     else
     {
-      repeat_for_int = interval.GetInt();
+      repeat_for_int = interval_ms.GetInt();
     }
 
-    if ((interval.GetInt() == 0) && (repeat_for_int != 0))
+    if ((interval_ms.GetInt() == 0) && (repeat_for_int != 0))
     {
       // If the interval time is 0 and the repeat_for_int isn't then reject the timer.
       error = "Can't have a zero interval time with a non-zero (%s) repeat-for time",
@@ -544,7 +544,7 @@ Timer* Timer::from_json_obj(TimerID id,
       return NULL;
     }
 
-    timer = new Timer(id, (interval.GetInt() * 1000), (repeat_for_int * 1000));
+    timer = new Timer(id, (interval_ms.GetInt() * 1000), (repeat_for_int * 1000));
 
     if (timing.HasMember("start-time-delta"))
     {
@@ -553,8 +553,7 @@ Timer* Timer::from_json_obj(TimerID id,
       uint64_t start_time_delta;
       JSON_GET_INT_64_MEMBER(timing, "start-time-delta", start_time_delta);
 
-      // This cast is safe as this sum is deliberately designed to wrap over UINT_MAX.
-      timer->start_time_mono_ms = (uint32_t)(clock_gettime_ms(CLOCK_MONOTONIC) + start_time_delta);
+      timer->start_time_mono_ms = clock_gettime_ms(CLOCK_MONOTONIC) + start_time_delta;
     }
     else if (timing.HasMember("start-time"))
     {
@@ -564,8 +563,7 @@ Timer* Timer::from_json_obj(TimerID id,
       uint64_t real_time = clock_gettime_ms(CLOCK_REALTIME);
       uint64_t mono_time = clock_gettime_ms(CLOCK_MONOTONIC);
 
-      // This cast is safe as this sum is deliberately designed to wrap over UINT_MAX.
-      timer->start_time_mono_ms = (uint32_t)(mono_time + real_start_time - real_time);
+      timer->start_time_mono_ms = mono_time + real_start_time - real_time;
     }
 
     if (timing.HasMember("sequence-number"))

--- a/src/main/timer_store.cpp
+++ b/src/main/timer_store.cpp
@@ -439,7 +439,7 @@ void TimerStore::maybe_refill_wheels()
 }
 
 // Refill the long timer wheel by taking all timers from the heap that are due
-// to pop in < 1hr.
+// to pop in < long wheel timer total.
 void TimerStore::refill_long_wheel()
 {
   if (!_extra_heap.empty())

--- a/src/main/timer_store.cpp
+++ b/src/main/timer_store.cpp
@@ -371,7 +371,6 @@ uint32_t TimerStore::timestamp_ms()
   // uinit64 to avoid wrapping).
   time = ts.tv_sec;
   time *= 1000;
-  //return (uint64_t)((ts.tv_sec * 1000) + std::floor(ts.tv_nsec / 1000000.0));
   time += ts.tv_nsec / 1000000;
   return time;
 }

--- a/src/main/timer_store.cpp
+++ b/src/main/timer_store.cpp
@@ -34,8 +34,6 @@
  * as those licenses appear in the file LICENSE-OPENSSL.
  */
 
-#include <cmath>
-
 #include "globals.h"
 #include "timer_store.h"
 #include "log.h"

--- a/src/test/test_timer.cpp
+++ b/src/test/test_timer.cpp
@@ -54,8 +54,8 @@ protected:
     replicas.push_back("10.0.0.1:9999");
     replicas.push_back("10.0.0.2:9999");
     TimerID id = (TimerID)UINT_MAX + 10;
-    uint32_t interval_ms = 100;
-    uint32_t repeat_for = 200;
+    uint64_t interval_ms = 100;
+    uint64_t repeat_for = 200;
 
     t1 = new Timer(id, interval_ms, repeat_for);
     t1->start_time_mono_ms = 1000000;
@@ -94,7 +94,7 @@ TEST_F(TestTimer, FromJSONTests)
   clock_gettime(CLOCK_MONOTONIC, &ts);
   uint32_t mono_time = (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
   clock_gettime(CLOCK_REALTIME, &ts);
-  uint64_t real_time = (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
+  uint32_t real_time = (ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
 
   std::vector<std::string> failing_test_data;
 
@@ -233,7 +233,7 @@ TEST_F(TestTimer, FromJSONTests)
   // If delta-start-time was provided, use that
   timer = Timer::from_json(1, 0x11011100011101, delta_start_time, err, replicated);
   EXPECT_NE((void*)NULL, timer);
-  EXPECT_EQ("", err); EXPECT_EQ(mono_time - 200, (uint32_t)(timer->start_time_mono_ms));
+  EXPECT_EQ("", err); EXPECT_EQ(mono_time - 200, timer->start_time_mono_ms);
   delete timer;
 
   // If absolute start time was proved (and no delta-time), use that.
@@ -243,7 +243,7 @@ TEST_F(TestTimer, FromJSONTests)
 
   // Note that this compares to monotonic time (but the offest is the same as
   // the offset to realtime when we made the JSON string).
-  EXPECT_EQ(mono_time - 300, (uint32_t)(timer->start_time_mono_ms));
+  EXPECT_EQ(mono_time - 300, timer->start_time_mono_ms);
   delete timer;
 
   // Restore real time
@@ -324,8 +324,8 @@ TEST_F(TestTimer, ToJSON)
   // We need to use a new timer here, because the values we use in
   // testing (100ms and 200ms) are too short to be specified on the
   // JSON interface (which counts in seconds).
-  uint32_t interval_ms = 1000;
-  uint32_t repeat_for = 2000;
+  uint64_t interval_ms = 1000;
+  uint64_t repeat_for = 2000;
 
   Timer* t2 = new Timer(1, interval_ms, repeat_for);
   t2->start_time_mono_ms = 1000000;

--- a/src/test/test_timer.cpp
+++ b/src/test/test_timer.cpp
@@ -54,10 +54,10 @@ protected:
     replicas.push_back("10.0.0.1:9999");
     replicas.push_back("10.0.0.2:9999");
     TimerID id = (TimerID)UINT_MAX + 10;
-    uint32_t interval = 100;
+    uint32_t interval_ms = 100;
     uint32_t repeat_for = 200;
 
-    t1 = new Timer(id, interval, repeat_for);
+    t1 = new Timer(id, interval_ms, repeat_for);
     t1->start_time_mono_ms = 1000000;
     t1->sequence_number = 0;
     t1->replicas = replicas;
@@ -227,13 +227,13 @@ TEST_F(TestTimer, FromJSONTests)
   timer = Timer::from_json(1, 0x11011100011101, no_repeat_for, err, replicated);
   EXPECT_NE((void*)NULL, timer);
   EXPECT_EQ("", err);
-  EXPECT_EQ(timer->interval, timer->repeat_for);
+  EXPECT_EQ(timer->interval_ms, timer->repeat_for);
   delete timer;
 
   // If delta-start-time was provided, use that
   timer = Timer::from_json(1, 0x11011100011101, delta_start_time, err, replicated);
   EXPECT_NE((void*)NULL, timer);
-  EXPECT_EQ("", err); EXPECT_EQ(mono_time - 200, timer->start_time_mono_ms);
+  EXPECT_EQ("", err); EXPECT_EQ(mono_time - 200, (uint32_t)(timer->start_time_mono_ms));
   delete timer;
 
   // If absolute start time was proved (and no delta-time), use that.
@@ -243,7 +243,7 @@ TEST_F(TestTimer, FromJSONTests)
 
   // Note that this compares to monotonic time (but the offest is the same as
   // the offset to realtime when we made the JSON string).
-  EXPECT_EQ(mono_time - 300, timer->start_time_mono_ms);
+  EXPECT_EQ(mono_time - 300, (uint32_t)(timer->start_time_mono_ms));
   delete timer;
 
   // Restore real time
@@ -324,10 +324,10 @@ TEST_F(TestTimer, ToJSON)
   // We need to use a new timer here, because the values we use in
   // testing (100ms and 200ms) are too short to be specified on the
   // JSON interface (which counts in seconds).
-  uint32_t interval = 1000;
+  uint32_t interval_ms = 1000;
   uint32_t repeat_for = 2000;
 
-  Timer* t2 = new Timer(1, interval, repeat_for);
+  Timer* t2 = new Timer(1, interval_ms, repeat_for);
   t2->start_time_mono_ms = 1000000;
   t2->sequence_number = 0;
   t2->replicas = t1->replicas;
@@ -348,8 +348,8 @@ TEST_F(TestTimer, ToJSON)
   ASSERT_NE((void*)NULL, t2);
 
   EXPECT_EQ(2u, t3->id) << json;
-  EXPECT_EQ(1000000u, t3->start_time_mono_ms) << json;
-  EXPECT_EQ(t2->interval, t3->interval) << json;
+  EXPECT_EQ(1000000u, (uint32_t)(t3->start_time_mono_ms)) << json;
+  EXPECT_EQ(t2->interval_ms, t3->interval_ms) << json;
   EXPECT_EQ(t2->repeat_for, t3->repeat_for) << json;
   EXPECT_EQ(2, get_replication_factor(t3)) << json;
   EXPECT_EQ(t2->replicas, t3->replicas) << json;
@@ -383,7 +383,7 @@ TEST_F(TestTimer, BecomeTombstone)
   t1->become_tombstone();
   EXPECT_TRUE(t1->is_tombstone());
   EXPECT_EQ(1000000u, t1->start_time_mono_ms);
-  EXPECT_EQ(100u, t1->interval);
+  EXPECT_EQ(100u, t1->interval_ms);
   EXPECT_EQ(100u, t1->repeat_for);
 }
 

--- a/src/test/test_timer.cpp
+++ b/src/test/test_timer.cpp
@@ -54,8 +54,8 @@ protected:
     replicas.push_back("10.0.0.1:9999");
     replicas.push_back("10.0.0.2:9999");
     TimerID id = (TimerID)UINT_MAX + 10;
-    uint64_t interval_ms = 100;
-    uint64_t repeat_for = 200;
+    uint32_t interval_ms = 100;
+    uint32_t repeat_for = 200;
 
     t1 = new Timer(id, interval_ms, repeat_for);
     t1->start_time_mono_ms = 1000000;
@@ -324,8 +324,8 @@ TEST_F(TestTimer, ToJSON)
   // We need to use a new timer here, because the values we use in
   // testing (100ms and 200ms) are too short to be specified on the
   // JSON interface (which counts in seconds).
-  uint64_t interval_ms = 1000;
-  uint64_t repeat_for = 2000;
+  uint32_t interval_ms = 1000;
+  uint32_t repeat_for = 2000;
 
   Timer* t2 = new Timer(1, interval_ms, repeat_for);
   t2->start_time_mono_ms = 1000000;
@@ -348,7 +348,7 @@ TEST_F(TestTimer, ToJSON)
   ASSERT_NE((void*)NULL, t2);
 
   EXPECT_EQ(2u, t3->id) << json;
-  EXPECT_EQ(1000000u, (uint32_t)(t3->start_time_mono_ms)) << json;
+  EXPECT_EQ(1000000u, t3->start_time_mono_ms) << json;
   EXPECT_EQ(t2->interval_ms, t3->interval_ms) << json;
   EXPECT_EQ(t2->repeat_for, t3->repeat_for) << json;
   EXPECT_EQ(2, get_replication_factor(t3)) << json;

--- a/src/test/test_timer_handler.cpp
+++ b/src/test/test_timer_handler.cpp
@@ -124,7 +124,7 @@ TEST_F(TestTimerHandler, PopRepeatedTimer)
 {
   std::unordered_set<Timer*> timers;
   Timer* timer = default_timer(1);
-  timer->repeat_for = timer->interval * 2;
+  timer->repeat_for = timer->interval_ms * 2;
   timers.insert(timer);
 
   EXPECT_CALL(*_store, get_next_timers(_)).
@@ -191,9 +191,9 @@ TEST_F(TestTimerHandler, PopMultipleRepeatingTimers)
   std::unordered_set<Timer*> timers1;
   std::unordered_set<Timer*> timers2;
   Timer* timer1 = default_timer(1);
-  timer1->repeat_for = timer1->interval * 2;
+  timer1->repeat_for = timer1->interval_ms * 2;
   Timer* timer2 = default_timer(2);
-  timer2->repeat_for = timer2->interval * 2;
+  timer2->repeat_for = timer2->interval_ms * 2;
   timers1.insert(timer1);
   timers2.insert(timer2);
 
@@ -288,7 +288,7 @@ TEST_F(TestTimerHandler, FutureTimerPop)
   cwtest_completely_control_time();
 
   Timer* timer = default_timer(1);
-  timer->interval = 100;
+  timer->interval_ms = 100;
   timer->repeat_for = 100;
 
   // Start the timer right now.

--- a/src/test/test_timer_store.cpp
+++ b/src/test/test_timer_store.cpp
@@ -141,13 +141,13 @@ protected:
     }
 
     // Timer 1 will pop in 100ms.
-    timers[0]->interval = 100;
+    timers[0]->interval_ms = 100;
 
     // Timer 2 will pop strictly after 1 second.
-    timers[1]->interval = 10000 + 200;
+    timers[1]->interval_ms = 10000 + 200;
 
     // Timer 3 will pop strictly after 1 hour
-    timers[2]->interval = (3600 * 1000) + 300;
+    timers[2]->interval_ms = (3600 * 1000) + 300;
 
     // Create an out of the blue tombstone for timer one.
     tombstone = Timer::create_tombstone(1, 0);
@@ -202,7 +202,7 @@ TYPED_TEST(TestTimerStore, NearGetNextTimersTest)
 
 TYPED_TEST(TestTimerStore, NearGetNextTimersOffsetTest)
 {
-  TestFixture::timers[0]->interval = 1600;
+  TestFixture::timers[0]->interval_ms = 1600;
 
   TestFixture::ts->add_timer(TestFixture::timers[0]);
 
@@ -253,7 +253,7 @@ TYPED_TEST(TestTimerStore, LongGetNextTimersTest)
   TestFixture::ts->get_next_timers(next_timers);
 
   ASSERT_EQ(0u, next_timers.size());
-  cwtest_advance_time_ms(TestFixture::timers[2]->interval + TIMER_GRANULARITY_MS);
+  cwtest_advance_time_ms(TestFixture::timers[2]->interval_ms + TIMER_GRANULARITY_MS);
 
   TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size());
@@ -269,7 +269,7 @@ TYPED_TEST(TestTimerStore, LongGetNextTimersTest)
 TYPED_TEST(TestTimerStore, MultiNearGetNextTimersTest)
 {
   // Shorten timer two to be under 1 second.
-  TestFixture::timers[1]->interval = 400;
+  TestFixture::timers[1]->interval_ms = 400;
 
   TestFixture::ts->add_timer(TestFixture::timers[0]);
   TestFixture::ts->add_timer(TestFixture::timers[1]);
@@ -294,14 +294,14 @@ TYPED_TEST(TestTimerStore, ClashingMultiMidGetNextTimersTest)
 {
   // Lengthen timer one to be in the same second bucket as timer two but different ms
   // buckets.
-  TestFixture::timers[0]->interval = 10000 + 100;
+  TestFixture::timers[0]->interval_ms = 10000 + 100;
 
   TestFixture::ts->add_timer(TestFixture::timers[0]);
   TestFixture::ts->add_timer(TestFixture::timers[1]);
 
   std::unordered_set<Timer*> next_timers;
 
-  cwtest_advance_time_ms(TestFixture::timers[0]->interval + TIMER_GRANULARITY_MS);
+  cwtest_advance_time_ms(TestFixture::timers[0]->interval_ms + TIMER_GRANULARITY_MS);
   TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
   TestFixture::timers[0] = *next_timers.begin();
@@ -309,7 +309,7 @@ TYPED_TEST(TestTimerStore, ClashingMultiMidGetNextTimersTest)
 
   next_timers.clear();
 
-  cwtest_advance_time_ms(TestFixture::timers[1]->interval - TestFixture::timers[0]->interval);
+  cwtest_advance_time_ms(TestFixture::timers[1]->interval_ms - TestFixture::timers[0]->interval_ms);
   TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
   TestFixture::timers[1] = *next_timers.begin();
@@ -326,14 +326,14 @@ TYPED_TEST(TestTimerStore, ClashingMultiMidGetNextTimersTest)
 TYPED_TEST(TestTimerStore, SeparateMultiMidGetNextTimersTest)
 {
   // Lengthen timer one to be in a different second bucket than timer two.
-  TestFixture::timers[0]->interval = 9000 + 100;
+  TestFixture::timers[0]->interval_ms = 9000 + 100;
 
   TestFixture::ts->add_timer(TestFixture::timers[0]);
   TestFixture::ts->add_timer(TestFixture::timers[1]);
 
   std::unordered_set<Timer*> next_timers;
 
-  cwtest_advance_time_ms(TestFixture::timers[0]->interval + TIMER_GRANULARITY_MS);
+  cwtest_advance_time_ms(TestFixture::timers[0]->interval_ms + TIMER_GRANULARITY_MS);
   TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
   TestFixture::timers[0] = *next_timers.begin();
@@ -341,7 +341,7 @@ TYPED_TEST(TestTimerStore, SeparateMultiMidGetNextTimersTest)
 
   next_timers.clear();
 
-  cwtest_advance_time_ms(TestFixture::timers[1]->interval - TestFixture::timers[0]->interval);
+  cwtest_advance_time_ms(TestFixture::timers[1]->interval_ms - TestFixture::timers[0]->interval_ms);
   TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
   TestFixture::timers[1] = *next_timers.begin();
@@ -356,8 +356,8 @@ TYPED_TEST(TestTimerStore, SeparateMultiMidGetNextTimersTest)
 TYPED_TEST(TestTimerStore, MultiLongGetTimersTest)
 {
   // Lengthen timer one and two to be in the extra heap.
-  TestFixture::timers[0]->interval = (3600 * 1000) + 100;
-  TestFixture::timers[1]->interval = (3600 * 1000) + 200;
+  TestFixture::timers[0]->interval_ms = (3600 * 1000) + 100;
+  TestFixture::timers[1]->interval_ms = (3600 * 1000) + 200;
 
   TestFixture::ts->add_timer(TestFixture::timers[0]);
   TestFixture::ts->add_timer(TestFixture::timers[1]);
@@ -365,7 +365,7 @@ TYPED_TEST(TestTimerStore, MultiLongGetTimersTest)
 
   std::unordered_set<Timer*> next_timers;
 
-  cwtest_advance_time_ms(TestFixture::timers[0]->interval + TIMER_GRANULARITY_MS);
+  cwtest_advance_time_ms(TestFixture::timers[0]->interval_ms + TIMER_GRANULARITY_MS);
   TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
   TestFixture::timers[0] = *next_timers.begin();
@@ -373,7 +373,7 @@ TYPED_TEST(TestTimerStore, MultiLongGetTimersTest)
 
   next_timers.clear();
 
-  cwtest_advance_time_ms(TestFixture::timers[1]->interval - TestFixture::timers[0]->interval);
+  cwtest_advance_time_ms(TestFixture::timers[1]->interval_ms - TestFixture::timers[0]->interval_ms);
   TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
   TestFixture::timers[1] = *next_timers.begin();
@@ -381,7 +381,7 @@ TYPED_TEST(TestTimerStore, MultiLongGetTimersTest)
 
   next_timers.clear();
 
-  cwtest_advance_time_ms(TestFixture::timers[2]->interval - TestFixture::timers[1]->interval);
+  cwtest_advance_time_ms(TestFixture::timers[2]->interval_ms - TestFixture::timers[1]->interval_ms);
   TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
   TestFixture::timers[2] = *next_timers.begin();
@@ -396,7 +396,7 @@ TYPED_TEST(TestTimerStore, MultiLongGetTimersTest)
 TYPED_TEST(TestTimerStore, ReallyLongTimer)
 {
   // Lengthen timer three to really long (10 hours)
-  TestFixture::timers[2]->interval = (3600 * 1000) * 10;
+  TestFixture::timers[2]->interval_ms = (3600 * 1000) * 10;
   TestFixture::ts->add_timer(TestFixture::timers[2]);
 
   std::unordered_set<Timer*> next_timers;
@@ -419,11 +419,11 @@ TYPED_TEST(TestTimerStore, ReallyLongTimer)
 
 TYPED_TEST(TestTimerStore, DeleteNearTimer)
 {
-  uint64_t interval = TestFixture::timers[0]->interval;
+  uint64_t interval_ms = TestFixture::timers[0]->interval_ms;
   TestFixture::ts->add_timer(TestFixture::timers[0]);
   TestFixture::ts->delete_timer(1);
   std::unordered_set<Timer*> next_timers;
-  cwtest_advance_time_ms(interval + TIMER_GRANULARITY_MS);
+  cwtest_advance_time_ms(interval_ms + TIMER_GRANULARITY_MS);
   TestFixture::ts->get_next_timers(next_timers);
   EXPECT_TRUE(next_timers.empty());
   delete TestFixture::timers[1];
@@ -433,11 +433,11 @@ TYPED_TEST(TestTimerStore, DeleteNearTimer)
 
 TYPED_TEST(TestTimerStore, DeleteMidTimer)
 {
-  uint64_t interval = TestFixture::timers[2]->interval;
+  uint64_t interval_ms = TestFixture::timers[2]->interval_ms;
   TestFixture::ts->add_timer(TestFixture::timers[1]);
   TestFixture::ts->delete_timer(2);
   std::unordered_set<Timer*> next_timers;
-  cwtest_advance_time_ms(interval + TIMER_GRANULARITY_MS);
+  cwtest_advance_time_ms(interval_ms + TIMER_GRANULARITY_MS);
   TestFixture::ts->get_next_timers(next_timers);
   EXPECT_TRUE(next_timers.empty());
   delete TestFixture::timers[0];
@@ -447,10 +447,10 @@ TYPED_TEST(TestTimerStore, DeleteMidTimer)
 
 TYPED_TEST(TestTimerStore, DeleteLongTimer)
 {
-  uint64_t interval = TestFixture::timers[2]->interval;
+  uint64_t interval_ms = TestFixture::timers[2]->interval_ms;
   TestFixture::ts->add_timer(TestFixture::timers[2]);
   TestFixture::ts->delete_timer(3);
-  cwtest_advance_time_ms(interval + TIMER_GRANULARITY_MS);
+  cwtest_advance_time_ms(interval_ms + TIMER_GRANULARITY_MS);
   std::unordered_set<Timer*> next_timers;
   TestFixture::ts->get_next_timers(next_timers);
   EXPECT_TRUE(next_timers.empty());
@@ -564,7 +564,7 @@ TYPED_TEST(TestTimerStore, OverwriteWithTombstone)
 
   Timer* extracted = *next_timers.begin();
   EXPECT_TRUE(extracted->is_tombstone());
-  EXPECT_EQ(100u, extracted->interval);
+  EXPECT_EQ(100u, extracted->interval_ms);
   EXPECT_EQ(100u, extracted->repeat_for);
 
   delete TestFixture::timers[1];
@@ -576,8 +576,8 @@ TYPED_TEST(TestTimerStore, OverwriteWithTombstone)
 // we should be able to reliably update/TestFixture::tombstone timers.
 TYPED_TEST(TestTimerStore, Non10msShortTimerUpdate)
 {
-  // Offset the interval of the first timer so it's not a multiple of 10ms.
-  TestFixture::timers[0]->interval += 4;
+  // Offset the interval_ms of the first timer so it's not a multiple of 10ms.
+  TestFixture::timers[0]->interval_ms += 4;
 
   TestFixture::ts->add_timer(TestFixture::timers[0]);
 
@@ -620,7 +620,7 @@ TYPED_TEST(TestTimerStore, Non10msShortTimerUpdate)
 TYPED_TEST(TestTimerStore, Non10msMediumTimerUpdate)
 {
   // Offset the interval of the second timer so it's not a multiple of 10ms.
-  TestFixture::timers[1]->interval += 4;
+  TestFixture::timers[1]->interval_ms += 4;
 
   TestFixture::ts->add_timer(TestFixture::timers[1]);
 
@@ -669,7 +669,7 @@ TYPED_TEST(TestTimerStore, MixtureOfTimerLengths)
 
   // Timers all pop 1hr, 1s, 500ms from the start of the test.
   // Set timer 1.
-  TestFixture::timers[0]->interval = ((60 * 60 * 1000) + (1 * 1000) + 500);
+  TestFixture::timers[0]->interval_ms = ((60 * 60 * 1000) + (1 * 1000) + 500);
   TestFixture::ts->add_timer(TestFixture::timers[0]);
 
   // Move on by 1hr. Nothing has popped.
@@ -680,7 +680,7 @@ TYPED_TEST(TestTimerStore, MixtureOfTimerLengths)
   EXPECT_EQ(0u, next_timers.size());
 
   // Timer 2 pops in 1s, 500ms
-  TestFixture::timers[1]->interval = ((1 * 1000) + 500);
+  TestFixture::timers[1]->interval_ms = ((1 * 1000) + 500);
   TestFixture::ts->add_timer(TestFixture::timers[1]);
 
   // Move on by 1s. Nothing has popped.
@@ -690,7 +690,7 @@ TYPED_TEST(TestTimerStore, MixtureOfTimerLengths)
   EXPECT_EQ(0u, next_timers.size());
 
   // Timer 3 pops in 500ms.
-  TestFixture::timers[2]->interval = 500;
+  TestFixture::timers[2]->interval_ms = 500;
   TestFixture::ts->add_timer(TestFixture::timers[2]);
 
   // Move on by 500ms. All timers pop.
@@ -713,7 +713,7 @@ TYPED_TEST(TestTimerStore, TimerPopsOnTheHour)
   pop_time_ms = (TestFixture::timers[0]->start_time_mono_ms / (60 * 60 * 1000));
   pop_time_ms += 2;
   pop_time_ms *= (60 * 60 * 1000);
-  TestFixture::timers[0]->interval = pop_time_ms - TestFixture::timers[0]->start_time_mono_ms;
+  TestFixture::timers[0]->interval_ms = pop_time_ms - TestFixture::timers[0]->start_time_mono_ms;
   TestFixture::ts->add_timer(TestFixture::timers[0]);
 
   // Move on to the pop time. The timer pops correctly.

--- a/src/test/test_timer_store.cpp
+++ b/src/test/test_timer_store.cpp
@@ -414,7 +414,7 @@ TYPED_TEST(TestTimerStore, ReallyLongTimer)
 
 TYPED_TEST(TestTimerStore, DeleteNearTimer)
 {
-  uint64_t interval_ms = TestFixture::timers[0]->interval_ms;
+  uint32_t interval_ms = TestFixture::timers[0]->interval_ms;
   TestFixture::ts->add_timer(TestFixture::timers[0]);
   TestFixture::ts->delete_timer(1);
   std::unordered_set<Timer*> next_timers;
@@ -428,7 +428,7 @@ TYPED_TEST(TestTimerStore, DeleteNearTimer)
 
 TYPED_TEST(TestTimerStore, DeleteMidTimer)
 {
-  uint64_t interval_ms = TestFixture::timers[2]->interval_ms;
+  uint32_t interval_ms = TestFixture::timers[2]->interval_ms;
   TestFixture::ts->add_timer(TestFixture::timers[1]);
   TestFixture::ts->delete_timer(2);
   std::unordered_set<Timer*> next_timers;
@@ -442,7 +442,7 @@ TYPED_TEST(TestTimerStore, DeleteMidTimer)
 
 TYPED_TEST(TestTimerStore, DeleteLongTimer)
 {
-  uint64_t interval_ms = TestFixture::timers[2]->interval_ms;
+  uint32_t interval_ms = TestFixture::timers[2]->interval_ms;
   TestFixture::ts->add_timer(TestFixture::timers[2]);
   TestFixture::ts->delete_timer(3);
   cwtest_advance_time_ms(interval_ms + TIMER_GRANULARITY_MS);
@@ -703,7 +703,7 @@ TYPED_TEST(TestTimerStore, MixtureOfTimerLengths)
 TYPED_TEST(TestTimerStore, TimerPopsOnTheHour)
 {
   std::unordered_set<Timer*> next_timers;
-  uint64_t pop_time_ms;
+  uint32_t pop_time_ms;
 
   pop_time_ms = (TestFixture::timers[0]->start_time_mono_ms / (60 * 60 * 1000));
   pop_time_ms += 2;

--- a/src/test/test_timer_store.cpp
+++ b/src/test/test_timer_store.cpp
@@ -34,8 +34,6 @@
  * as those licenses appear in the file LICENSE-OPENSSL.
  */
 
-#include <cmath>
-
 #include "timer_store.h"
 #include "timer_helper.h"
 #include "test_interposer.hpp"
@@ -54,7 +52,10 @@ static uint32_t get_time_ms()
   clock_gettime(CLOCK_MONOTONIC, &now);
 
   // Overflow to a 32 bit number is intentional
-  return ((now.tv_sec * 1000) + (now.tv_nsec / 1000000));
+  uint64_t time = now.tv_sec;
+  time *= 1000;
+  time += now.tv_nsec / 1000000;
+  return time;
 }
 
 
@@ -175,14 +176,8 @@ TYPED_TEST(TestTimerStore, NearGetNextTimersTest)
   std::unordered_set<Timer*> next_timers;
   TestFixture::ts->get_next_timers(next_timers);
 
-  struct timespec now2;
-  clock_gettime(CLOCK_MONOTONIC, &now2);
-
   ASSERT_EQ(0u, next_timers.size());
   cwtest_advance_time_ms(100 + TIMER_GRANULARITY_MS);
-
-  struct timespec now3;
-  clock_gettime(CLOCK_MONOTONIC, &now3);
 
   TestFixture::ts->get_next_timers(next_timers);
   ASSERT_EQ(1u, next_timers.size());


### PR DESCRIPTION
The branch name is now misleading as timers are now stored as 32 bit numbers and overflow is expected and accounted for.

Bucket sizes are now powers of 2 to reduce problems of overflow, when there would be two buckets covering the same time window. The short and long wheel covers nearly the same amount of time as before (1000ms -> 1024ms and 3,600,000ms -> 4,194,304ms)