### PR TITLE
[Reviewer: Andy] Don't truncate unique timer identifiers

### DIFF
--- a/src/include/handlers.h
+++ b/src/include/handlers.h
@@ -76,7 +76,7 @@ public:
 
   void run();
   HTTPCode parse_request();
-  void add_or_update_timer(int timer_id, int replica_hash);
+  void add_or_update_timer(TimerID timer_id, int replica_hash);
   void handle_get();
   void handle_delete();
   bool node_is_in_cluster(std::string requesting_node);

--- a/src/main/handlers.cpp
+++ b/src/main/handlers.cpp
@@ -97,7 +97,7 @@ void ControllerTask::run()
   delete this;
 }
 
-void ControllerTask::add_or_update_timer(int timer_id, int replica_hash)
+void ControllerTask::add_or_update_timer(TimerID timer_id, int replica_hash)
 {
   Timer* timer = NULL;
   bool replicated_timer;

--- a/src/test/test_handler.cpp
+++ b/src/test/test_handler.cpp
@@ -118,12 +118,16 @@ TEST_F(TestHandler, ValidJSONDeleteTimer)
 TEST_F(TestHandler, ValidJSONCreateTimer)
 {
   Timer* added_timer;
+  HttpStack::Request req(NULL, NULL);
 
   controller_request("/timers", htp_method_POST, "{\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}}", "");
   EXPECT_CALL(*_replicator, replicate(_));
   EXPECT_CALL(*_th, add_timer(_)).WillOnce(SaveArg<0>(&added_timer));
-  EXPECT_CALL(*_httpstack, send_reply(_, 200, _));
+  EXPECT_CALL(*_httpstack, send_reply(_, 200, _)).WillOnce(SaveArg<0>(&req));
   _task->run();
+
+  // TODO: Check that the timer is plausible - unfortunately, it's very hard to define "plausible" programmatically.
+  // EXPECT_EQ("/timers/...", std::string(evhtp_header_find(req.req()->headers_out, "Location")));
 
   delete added_timer; added_timer = NULL;
 }


### PR DESCRIPTION
Andy,

Please can you review?  As discussed, I couldn't find a decent way of UT-ing that timer IDs were "unique", so I checked it by eye and left my code in but commented out.

Fixes #169.

Matt