### PR TITLE
[Reviewer: Andy] Use internal SNMP community for wait-sync operation

### DIFF
--- a/debian/chronos.init.d
+++ b/debian/chronos.init.d
@@ -139,7 +139,7 @@ do_wait_sync() {
   do
     # Retrieve the statistics.
     # Temporarily uses -c clearwater community string
-    nodes=`snmpget -Oqv -v2c -c clearwater localhost .1.2.826.0.1.1578918.9.10.1`
+    nodes=`snmpget -Oqv -v2c -c clearwater-internal localhost .1.2.826.0.1.1578918.9.10.1`
 
     # If the nodes left to query is 0 or unset, we're finished
     if [ "$nodes" = "0" ]


### PR DESCRIPTION
Andy,

Please can you review my fix to use an internal SNMP community for Chronos' wait-sync operation?

In combination with https://github.com/Metaswitch/clearwater-infrastructure/pull/242, this fixes Metaswitch/chronos#167.  I've tested live.

Matt