### PR TITLE
[Reviewer: Adam] Take a lock in the add_timer function, to prevent conflicting access …

### DIFF
--- a/src/main/timer_handler.cpp
+++ b/src/main/timer_handler.cpp
@@ -103,6 +103,7 @@ TimerHandler::~TimerHandler()
 
 void TimerHandler::add_timer(Timer* timer)
 {
+  pthread_mutex_lock(&_mutex);
   TimerPair new_tp;
   new_tp.active_timer = timer;
 
@@ -252,6 +253,7 @@ void TimerHandler::add_timer(Timer* timer)
 
   TRC_DEBUG("Inserting the new timer with ID %llu", id);
   _store->insert(new_tp, id, next_pop_time, cluster_view_id_vector);
+  pthread_mutex_unlock(&_mutex);
 }
 
 void TimerHandler::return_timer(Timer* timer, bool callback_successful)


### PR DESCRIPTION
…to std::map and std::vector

Should resolve https://github.com/Metaswitch/chronos/issues/181.

This basically just restores the lock which was removed in https://github.com/Metaswitch/chronos/commit/8df1b4ba1a1b9cd994b64a8fb227eea9fc4b20f1#diff-8aab902e370626638d257360f47fd4e2L101.

I've tested by running `for i in `seq 1 30000`; do curl -X "POST" -d '{"timing":{"interval":3,"repeat-for":60},"callback":{"http":{"uri":"http://127.0.0.1:9888/authentication-timeout","opaque":"string"}},"reliability":{"replication-factor":2}}' localhost:7253/timers; echo $i; done` on both nodes in a Chronos cluster simultaneously (i.e. injecting 60k timers as fast as possible) - this succeeded without any crashes.