### PR TITLE
[Reviewer: Andy] Make Chronos itself write a pidfile, as opposed to relying on start-s…

### DIFF
--- a/debian/chronos.init.d
+++ b/debian/chronos.init.d
@@ -77,7 +77,8 @@ do_start()
 {
   setup_environment
   start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null || return 1
-  $start_prefix start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON || return 2
+  DAEMON_ARGS="--pidfile $PIDFILE"
+  $start_prefix start-stop-daemon --start --quiet --background --pidfile $PIDFILE --exec $DAEMON -- $DAEMON_ARGS || return 2
 }
 
 do_stop()
@@ -85,7 +86,6 @@ do_stop()
   start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $EXECNAME
   RETVAL="$?"
   [ "$RETVAL" = 2 ] && return 2
-  rm -f $PIDFILE
   return $RETVAL
 }
 
@@ -112,7 +112,6 @@ do_abort()
   start-stop-daemon --stop --quiet --retry=ABRT/60/KILL/5 --pidfile $PIDFILE --name $EXECNAME
   RETVAL="$?"
   [ "$RETVAL" = 2 ] && return 2
-  rm -f $PIDFILE
   return $RETVAL
 }
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -67,6 +67,7 @@ struct options
 {
   std::string config_file;
   std::string cluster_config_file;
+  std::string pidfile;
 };
 
 // Enum for option types not assigned short-forms
@@ -74,6 +75,7 @@ enum OptionTypes
 {
   CONFIG_FILE = 128, // start after the ASCII set ends to avoid conflicts
   CLUSTER_CONFIG_FILE,
+  PIDFILE,
   HELP
 };
 
@@ -81,6 +83,7 @@ const static struct option long_opt[] =
 {
   {"config-file", required_argument, NULL, CONFIG_FILE},
   {"cluster-config-file", required_argument, NULL, CLUSTER_CONFIG_FILE},
+  {"pidfile", required_argument, NULL, PIDFILE},
   {"help", no_argument, NULL, HELP},
   {NULL, 0, NULL, 0},
 };
@@ -91,6 +94,7 @@ void usage(void)
        "\n"
        " --config-file <filename> Specify the per node configuration file\n"
        " --cluster-config-file <filename> Specify the cluster configuration file\n"
+       " --pidfile <filename> Specify the pidfile\n"
        " --help Show this help screen\n");
 }
 
@@ -109,6 +113,10 @@ int init_options(int argc, char**argv, struct options& options)
 
     case CLUSTER_CONFIG_FILE:
       options.cluster_config_file = std::string(optarg);
+      break;
+
+    case PIDFILE:
+      options.pidfile = std::string(optarg);
       break;
 
     case HELP:
@@ -197,6 +205,7 @@ int main(int argc, char** argv)
   struct options options;
   options.config_file = "/etc/chronos/chronos.conf";
   options.cluster_config_file = "/etc/chronos/chronos_cluster.conf";
+  options.pidfile = "";
 
   if (init_options(argc, argv, options) != 0)
   {
@@ -217,6 +226,17 @@ int main(int argc, char** argv)
 
   // Log the PID, this is useful for debugging if monit restarts chronos.
   TRC_STATUS("Starting with PID %d", getpid());
+
+  if (options.pidfile != "")
+  {
+    int rc = Utils::lock_and_write_pidfile(options.pidfile);
+    if (rc == -1)
+    {
+      // Failure to acquire pidfile lock
+      TRC_ERROR("Could not write pidfile - exiting");
+      return 2;
+    }
+  }
 
   // Create Chronos's alarm objects. Note that the alarm identifier strings must match those
   // in the alarm definition JSON file exactly.


### PR DESCRIPTION
…top-daemon

This removes a race condition where:

* start-stop-daemon A is started and sees no Chronos process running
* start-stop-daemon B is started and sees no Chronos process running
* start-stop-daemon A starts Chronos and writes out the pidfile
* start-stop-daemon B starts Chronos and writes out the pidfile
* start-stop-daemon A's Chronos is now orphaned and unreachable

Probably sorts out #164.