### PR TITLE
[Reviewer: Andy] Scalar infinite table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ GMOCK_DIR := $(ROOT)/modules/gmock
 TARGET := chronos
 TARGET_TEST := chronos_test
 TARGET_SOURCES_BUILD := main.cpp snmp_infinite_timer_count_table.cpp snmp_infinite_scalar_table.cpp snmp_counter_table.cpp snmp_continuous_increment_table.cpp
-TARGET_SOURCES_TEST := $(notdir $(wildcard src/test/*.cpp)) test_interposer.cpp fakelogger.cpp mock_sas.cpp fakecurl.cpp pthread_cond_var_helper.cpp mock_increment_table.cpp mock_infinite_table.cpp
+TARGET_SOURCES_TEST := $(notdir $(wildcard src/test/*.cpp)) test_interposer.cpp fakelogger.cpp mock_sas.cpp fakecurl.cpp pthread_cond_var_helper.cpp mock_increment_table.cpp mock_infinite_table.cpp mock_scalar_table.cpp
 TARGET_SOURCES := $(filter-out $(TARGET_SOURCES_BUILD) $(TARGET_SOURCES_TEST), $(notdir $(wildcard src/main/*.cpp) $(wildcard src/main/**/*.cpp)))
 TARGET_SOURCES += log.cpp logger.cpp unique.cpp signalhandler.cpp alarm.cpp httpstack.cpp httpstack_utils.cpp accesslogger.cpp utils.cpp health_checker.cpp exception_handler.cpp httpconnection.cpp statistic.cpp baseresolver.cpp dnscachedresolver.cpp dnsparser.cpp zmq_lvc.cpp httpresolver.cpp counter.cpp snmp_scalar.cpp snmp_agent.cpp snmp_row.cpp timer_counter.cpp
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GMOCK_DIR := $(ROOT)/modules/gmock
 
 TARGET := chronos
 TARGET_TEST := chronos_test
-TARGET_SOURCES_BUILD := main.cpp snmp_infinite_timer_count_table.cpp snmp_infinite_scalar_table.cpp snmp_counter_table.cpp snmp_continuous_increment_table.cpp
+TARGET_SOURCES_BUILD := main.cpp snmp_infinite_timer_count_table.cpp snmp_infinite_scalar_table.cpp snmp_counter_table.cpp snmp_continuous_increment_table.cpp snmp_infinite_base_table.cpp
 TARGET_SOURCES_TEST := $(notdir $(wildcard src/test/*.cpp)) test_interposer.cpp fakelogger.cpp mock_sas.cpp fakecurl.cpp pthread_cond_var_helper.cpp mock_increment_table.cpp mock_infinite_table.cpp mock_scalar_table.cpp
 TARGET_SOURCES := $(filter-out $(TARGET_SOURCES_BUILD) $(TARGET_SOURCES_TEST), $(notdir $(wildcard src/main/*.cpp) $(wildcard src/main/**/*.cpp)))
 TARGET_SOURCES += log.cpp logger.cpp unique.cpp signalhandler.cpp alarm.cpp httpstack.cpp httpstack_utils.cpp accesslogger.cpp utils.cpp health_checker.cpp exception_handler.cpp httpconnection.cpp statistic.cpp baseresolver.cpp dnscachedresolver.cpp dnsparser.cpp zmq_lvc.cpp httpresolver.cpp counter.cpp snmp_scalar.cpp snmp_agent.cpp snmp_row.cpp timer_counter.cpp

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GMOCK_DIR := $(ROOT)/modules/gmock
 
 TARGET := chronos
 TARGET_TEST := chronos_test
-TARGET_SOURCES_BUILD := main.cpp snmp_infinite_timer_count_table.cpp snmp_counter_table.cpp snmp_continuous_increment_table.cpp
+TARGET_SOURCES_BUILD := main.cpp snmp_infinite_timer_count_table.cpp snmp_counter_table.cpp snmp_continuous_increment_table.cpp snmp_infinite_scalar_table.cpp
 TARGET_SOURCES_TEST := $(notdir $(wildcard src/test/*.cpp)) test_interposer.cpp fakelogger.cpp mock_sas.cpp fakecurl.cpp pthread_cond_var_helper.cpp mock_increment_table.cpp
 TARGET_SOURCES := $(filter-out $(TARGET_SOURCES_BUILD) $(TARGET_SOURCES_TEST), $(notdir $(wildcard src/main/*.cpp) $(wildcard src/main/**/*.cpp)))
 TARGET_SOURCES += log.cpp logger.cpp unique.cpp signalhandler.cpp alarm.cpp httpstack.cpp httpstack_utils.cpp accesslogger.cpp utils.cpp health_checker.cpp exception_handler.cpp httpconnection.cpp statistic.cpp baseresolver.cpp dnscachedresolver.cpp dnsparser.cpp zmq_lvc.cpp httpresolver.cpp counter.cpp snmp_scalar.cpp snmp_agent.cpp snmp_row.cpp timer_counter.cpp

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GMOCK_DIR := $(ROOT)/modules/gmock
 
 TARGET := chronos
 TARGET_TEST := chronos_test
-TARGET_SOURCES_BUILD := main.cpp snmp_infinite_timer_count_table.cpp snmp_counter_table.cpp snmp_continuous_increment_table.cpp
+TARGET_SOURCES_BUILD := main.cpp snmp_infinite_timer_count_table.cpp snmp_infinite_scalar_table.cpp snmp_counter_table.cpp snmp_continuous_increment_table.cpp
 TARGET_SOURCES_TEST := $(notdir $(wildcard src/test/*.cpp)) test_interposer.cpp fakelogger.cpp mock_sas.cpp fakecurl.cpp pthread_cond_var_helper.cpp mock_increment_table.cpp mock_infinite_table.cpp
 TARGET_SOURCES := $(filter-out $(TARGET_SOURCES_BUILD) $(TARGET_SOURCES_TEST), $(notdir $(wildcard src/main/*.cpp) $(wildcard src/main/**/*.cpp)))
 TARGET_SOURCES += log.cpp logger.cpp unique.cpp signalhandler.cpp alarm.cpp httpstack.cpp httpstack_utils.cpp accesslogger.cpp utils.cpp health_checker.cpp exception_handler.cpp httpconnection.cpp statistic.cpp baseresolver.cpp dnscachedresolver.cpp dnsparser.cpp zmq_lvc.cpp httpresolver.cpp counter.cpp snmp_scalar.cpp snmp_agent.cpp snmp_row.cpp timer_counter.cpp

--- a/src/include/timer_handler.h
+++ b/src/include/timer_handler.h
@@ -51,6 +51,7 @@
 #include "alarm.h"
 #include "snmp_continuous_increment_table.h"
 #include "snmp_infinite_timer_count_table.h"
+#include "snmp_infinite_scalar_table.h"
 #include "snmp_scalar.h"
 
 class TimerHandler
@@ -58,7 +59,8 @@ class TimerHandler
 public:
   TimerHandler(TimerStore*, Callback*, Replicator*, Alarm*,
                SNMP::ContinuousIncrementTable*,
-               SNMP::InfiniteTimerCountTable*);
+               SNMP::InfiniteTimerCountTable*,
+               SNMP::InfiniteScalarTable*);
   virtual ~TimerHandler();
   virtual void add_timer(Timer*, bool=true);
   virtual void return_timer(Timer*, bool);
@@ -110,6 +112,7 @@ private:
   Alarm* _timer_pop_alarm;
   SNMP::ContinuousIncrementTable* _all_timers_table;
   SNMP::InfiniteTimerCountTable* _tagged_timers_table;
+  SNMP::InfiniteScalarTable* _scalar_timers_table;
   SNMP::U32Scalar* _current_timers_scalar;
 
   pthread_t _handler_thread;

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -53,6 +53,7 @@
 #include "chronos_internal_connection.h"
 #include "chronos_alarmdefinition.h"
 #include "snmp_infinite_timer_count_table.h"
+#include "snmp_infinite_scalar_table.h"
 #include "snmp_continuous_increment_table.h"
 #include "snmp_counter_table.h"
 #include "snmp_scalar.h"
@@ -165,6 +166,7 @@ int main(int argc, char** argv)
   SNMP::CounterTable* invalid_timers_processed_table = NULL;
   SNMP::ContinuousIncrementTable* all_timers_table = NULL;
   SNMP::InfiniteTimerCountTable* total_timers_table = NULL;
+  SNMP::InfiniteScalarTable* scalar_timers_table = NULL;
 
   // Sets up SNMP statistics
   snmp_setup("chronos");
@@ -173,6 +175,8 @@ int main(int argc, char** argv)
                                                             ".1.2.826.0.1.1578918.9.10.4");
   total_timers_table = SNMP::InfiniteTimerCountTable::create("chronos_tagged_timers_table",
                                                              ".1.2.826.0.1.1578918.999");
+  scalar_timers_table = SNMP::InfiniteScalarTable::create("chronos_scalar_timers_table",
+                                                             ".1.2.826.0.1.1578918.998");
 
   remaining_nodes_scalar = new SNMP::U32Scalar("chronos_remaining_nodes_scalar",
                                                ".1.2.826.0.1.1578918.9.10.1");
@@ -251,7 +255,8 @@ int main(int argc, char** argv)
                                            handler_rep,
                                            timer_pop_alarm,
                                            all_timers_table,
-                                           total_timers_table);
+                                           total_timers_table,
+                                           scalar_timers_table);
   callback->start(handler);
 
   // Create a Chronos internal connection class for scaling operations.

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -167,35 +167,6 @@ void signal_handler(int sig)
 
 int main(int argc, char** argv)
 {
-  Alarm* timer_pop_alarm = NULL;
-  Alarm* scale_operation_alarm = NULL;
-  SNMP::U32Scalar* remaining_nodes_scalar = NULL;
-  SNMP::CounterTable* timers_processed_table = NULL;
-  SNMP::CounterTable* invalid_timers_processed_table = NULL;
-  SNMP::ContinuousIncrementTable* all_timers_table = NULL;
-  SNMP::InfiniteTimerCountTable* total_timers_table = NULL;
-  SNMP::InfiniteScalarTable* scalar_timers_table = NULL;
-
-  // Sets up SNMP statistics
-  snmp_setup("chronos");
-
-  all_timers_table = SNMP::ContinuousIncrementTable::create("chronos_all_timers_table",
-                                                            ".1.2.826.0.1.1578918.9.10.4");
-  total_timers_table = SNMP::InfiniteTimerCountTable::create("chronos_tagged_timers_table",
-                                                             ".1.2.826.0.1.1578918.999");
-  scalar_timers_table = SNMP::InfiniteScalarTable::create("chronos_scalar_timers_table",
-                                                             ".1.2.826.0.1.1578918.998");
-
-  remaining_nodes_scalar = new SNMP::U32Scalar("chronos_remaining_nodes_scalar",
-                                               ".1.2.826.0.1.1578918.9.10.1");
-  timers_processed_table = SNMP::CounterTable::create("chronos_processed_timers_table",
-                                                      ".1.2.826.0.1.1578918.9.10.2");
-  invalid_timers_processed_table = SNMP::CounterTable::create("chronos_invalid_timers_processed_table",
-                                                              ".1.2.826.0.1.1578918.9.10.3");
-
-  // Must be called after all SNMP tables have been registered
-  init_snmp_handler_threads("chronos");
-
   // Initialize cURL before creating threads
   curl_global_init(CURL_GLOBAL_DEFAULT);
 
@@ -242,6 +213,35 @@ int main(int argc, char** argv)
       return 2;
     }
   }
+
+  Alarm* timer_pop_alarm = NULL;
+  Alarm* scale_operation_alarm = NULL;
+  SNMP::U32Scalar* remaining_nodes_scalar = NULL;
+  SNMP::CounterTable* timers_processed_table = NULL;
+  SNMP::CounterTable* invalid_timers_processed_table = NULL;
+  SNMP::ContinuousIncrementTable* all_timers_table = NULL;
+  SNMP::InfiniteTimerCountTable* total_timers_table = NULL;
+  SNMP::InfiniteScalarTable* scalar_timers_table = NULL;
+
+  // Sets up SNMP statistics
+  snmp_setup("chronos");
+
+  all_timers_table = SNMP::ContinuousIncrementTable::create("chronos_all_timers_table",
+                                                            ".1.2.826.0.1.1578918.9.10.4");
+  total_timers_table = SNMP::InfiniteTimerCountTable::create("chronos_tagged_timers_table",
+                                                             ".1.2.826.0.1.1578918.999");
+  scalar_timers_table = SNMP::InfiniteScalarTable::create("chronos_scalar_timers_table",
+                                                             ".1.2.826.0.1.1578918.998");
+
+  remaining_nodes_scalar = new SNMP::U32Scalar("chronos_remaining_nodes_scalar",
+                                               ".1.2.826.0.1.1578918.9.10.1");
+  timers_processed_table = SNMP::CounterTable::create("chronos_processed_timers_table",
+                                                      ".1.2.826.0.1.1578918.9.10.2");
+  invalid_timers_processed_table = SNMP::CounterTable::create("chronos_invalid_timers_processed_table",
+                                                              ".1.2.826.0.1.1578918.9.10.3");
+
+  // Must be called after all SNMP tables have been registered
+  init_snmp_handler_threads("chronos");
 
   // Create Chronos's alarm objects. Note that the alarm identifier strings must match those
   // in the alarm definition JSON file exactly.

--- a/src/main/timer_handler.cpp
+++ b/src/main/timer_handler.cpp
@@ -55,13 +55,15 @@ TimerHandler::TimerHandler(TimerStore* store,
                            Replicator* replicator,
                            Alarm* timer_pop_alarm,
                            SNMP::ContinuousIncrementTable* all_timers_table,
-                           SNMP::InfiniteTimerCountTable* tagged_timers_table) :
+                           SNMP::InfiniteTimerCountTable* tagged_timers_table,
+                           SNMP::InfiniteScalarTable* scalar_timers_table) :
                            _store(store),
                            _callback(callback),
                            _replicator(replicator),
                            _timer_pop_alarm(timer_pop_alarm),
                            _all_timers_table(all_timers_table),
                            _tagged_timers_table(tagged_timers_table),
+                           _scalar_timers_table(scalar_timers_table),
                            _terminate(false),
                            _nearest_new_timer(-1)
 {

--- a/src/main/timer_handler.cpp
+++ b/src/main/timer_handler.cpp
@@ -227,7 +227,12 @@ void TimerHandler::add_timer(Timer* timer, bool update_stats)
     TRC_DEBUG("Adding new timer");
   }
 
-  // Update statistics
+  // Would be good in future work to pull all statistics logic out into a 
+  // separate statistics module, passing in new and old tags, and what is
+  // happening to the timer (add, update, delete), to keep the timer_handler
+  // scope of responsibility clear.
+
+  // Update statistics 
   if (update_stats)
   {
     std::vector<std::string> tags_to_add = std::vector<std::string>();
@@ -687,6 +692,7 @@ void TimerHandler::update_statistics(std::vector<std::string> new_tags,
     {
       TRC_DEBUG("Incrementing for %s:", (*it).c_str());
       _tagged_timers_table->increment(*it);
+      _scalar_timers_table->increment(*it);
     }
 
     TRC_DEBUG("Statistics to delete:");
@@ -696,6 +702,7 @@ void TimerHandler::update_statistics(std::vector<std::string> new_tags,
     {
       TRC_DEBUG("Decrementing for %s:", (*it).c_str());
       _tagged_timers_table->decrement(*it);
+      _scalar_timers_table->decrement(*it);
     }
   }
 }

--- a/src/test/test_timer_handler.cpp
+++ b/src/test/test_timer_handler.cpp
@@ -431,6 +431,7 @@ TEST_F(TestTimerHandlerAddAndReturn, AddTimer)
   TimerPair insert_pair;
   EXPECT_CALL(*_store, fetch(timer->id, _)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_store, insert(_, timer->id, timer->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
@@ -454,6 +455,7 @@ TEST_F(TestTimerHandlerAddAndReturn, UpdateTimer)
   TimerPair insert_pair;
   EXPECT_CALL(*_store, fetch(timer->id, _)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_store, insert(_, timer->id, timer->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
@@ -499,6 +501,7 @@ TEST_F(TestTimerHandlerAddAndReturn, AddExistingTimerChangedTags)
   TimerPair insert_pair;
   EXPECT_CALL(*_store, fetch(timer->id, _)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_store, insert(_, timer->id, timer->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
@@ -513,7 +516,9 @@ TEST_F(TestTimerHandlerAddAndReturn, AddExistingTimerChangedTags)
   EXPECT_CALL(*_store, fetch(timer2->id, _)).
                        WillOnce(DoAll(SetArgReferee<1>(insert_pair),Return(true)));
   EXPECT_CALL(*_mock_tag_table, increment("NEWTAG")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("NEWTAG")).Times(1);
   EXPECT_CALL(*_mock_tag_table, decrement("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, decrement("TAG1")).Times(1);
   EXPECT_CALL(*_store, insert(_, timer2->id, timer2->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
   _th->add_timer(timer2);
@@ -536,6 +541,7 @@ TEST_F(TestTimerHandlerAddAndReturn, OverrideInformationTimer)
   TimerPair insert_pair;
   EXPECT_CALL(*_store, fetch(timer->id, _)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_store, insert(_, timer->id, timer->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
@@ -599,6 +605,7 @@ TEST_F(TestTimerHandlerAddAndReturn, AddOlderTimer)
   // increment (counts and tags)
   EXPECT_CALL(*_store, fetch(timer->id, _)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_store, insert(_, timer->id, timer->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
@@ -632,6 +639,7 @@ TEST_F(TestTimerHandlerAddAndReturn, PreserveInformationTimers)
   TimerPair insert_pair;
   EXPECT_CALL(*_store, fetch(timer->id, _)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_store, insert(_, timer->id, timer->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
@@ -751,6 +759,7 @@ TEST_F(TestTimerHandlerAddAndReturn, AddTombstoneToExisting)
   // increment (counts and tags)
   EXPECT_CALL(*_store, fetch(timer->id, _)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_store, insert(_, timer->id, timer->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
@@ -764,7 +773,9 @@ TEST_F(TestTimerHandlerAddAndReturn, AddTombstoneToExisting)
                        WillOnce(SaveArg<0>(&insert_pair));
   EXPECT_CALL(*_mock_increment_table, decrement(1)).Times(1);
   EXPECT_CALL(*_mock_tag_table, decrement("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, decrement("TAG1")).Times(1);
   EXPECT_CALL(*_mock_tag_table, decrement("NEWTAG")).Times(0);
+  EXPECT_CALL(*_mock_scalar_table, decrement("NEWTAG")).Times(0);
   _th->add_timer(tombstone);
 
   // Check that the new tombstone has the correct interval
@@ -788,6 +799,7 @@ TEST_F(TestTimerHandlerAddAndReturn, AddNewTombstone)
   // Add the tombstone - this shouldn't affect the statistics
   EXPECT_CALL(*_store, fetch(tombstone->id, _)).Times(1);
   EXPECT_CALL(*_mock_tag_table, decrement("TAG1")).Times(0);
+  EXPECT_CALL(*_mock_scalar_table, decrement("TAG1")).Times(0);
   EXPECT_CALL(*_mock_increment_table, decrement(1)).Times(0);
   EXPECT_CALL(*_store, insert(_, tombstone->id, _, _)).
                        WillOnce(SaveArg<0>(&insert_pair));
@@ -818,6 +830,7 @@ TEST_F(TestTimerHandlerAddAndReturn, AddLowerSequenceNumber)
   EXPECT_CALL(*_store, fetch(timer1->id, _)).Times(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   EXPECT_CALL(*_store, insert(_, timer1->id, timer1->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
   _th->add_timer(timer1);
@@ -874,6 +887,7 @@ TEST_F(TestTimerHandlerAddAndReturn, ReturnTimerFailure)
   EXPECT_CALL(*_mock_timer_alarm, set());
   EXPECT_CALL(*_mock_increment_table, decrement(1)).Times(1);
   EXPECT_CALL(*_mock_tag_table, decrement("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, decrement("TAG1")).Times(1);
   _th->return_timer(timer, false);
 }
 
@@ -893,6 +907,7 @@ TEST_F(TestTimerHandlerAddAndReturn, ReturnTimerToTombstone)
                        WillOnce(SaveArg<0>(&insert_pair));
   EXPECT_CALL(*_mock_increment_table, decrement(1)).Times(1);
   EXPECT_CALL(*_mock_tag_table, decrement("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, decrement("TAG1")).Times(1);
   _th->return_timer(timer, true);
 
   EXPECT_EQ(insert_pair.active_timer, timer);
@@ -915,6 +930,7 @@ TEST_F(TestTimerHandlerAddAndReturn, UpdateReplicaTrackerValueForNewTimer)
   TimerPair insert_pair;
   EXPECT_CALL(*_store, fetch(timer->id, _)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_store, insert(_, timer->id, timer->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
@@ -949,6 +965,7 @@ TEST_F(TestTimerHandlerAddAndReturn, UpdateReplicaTrackerValueForOldActiveTimer)
   EXPECT_CALL(*_store, fetch(timer->id, _));
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   EXPECT_CALL(*_store, insert(_, timer->id, timer->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
   _th->add_timer(timer);
@@ -1084,6 +1101,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNode)
   Timer* timer1 = default_timer(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   _th->add_timer(timer1);
 
   // Now update the current cluster view ID
@@ -1112,6 +1130,7 @@ TEST_F(TestTimerHandlerRealStore, SelectTimersNoMatchesReqNode)
   Timer* timer1 = default_timer(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   _th->add_timer(timer1);
 
   // Now update the current cluster view ID
@@ -1141,6 +1160,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeNoClusterChange)
   timer1->interval_ms = 100;
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   _th->add_timer(timer1);
 
   // Now just call get_timers_for_node (as if someone had done a resync without
@@ -1162,7 +1182,9 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeHitMaxResponses)
 
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(2);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG2")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG2")).Times(1);
   _th->add_timer(timer1);
   _th->add_timer(timer2);
 
@@ -1193,6 +1215,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeInformationalTimers)
 
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
   EXPECT_CALL(*_mock_tag_table, increment("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1")).Times(1);
   _th->add_timer(timer1);
 
   // Now update the current cluster view ID
@@ -1210,6 +1233,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeInformationalTimers)
   timer2->cluster_view_id = "updated-cluster-view-id";
   EXPECT_CALL(*_mock_increment_table, decrement(1)).Times(1);
   EXPECT_CALL(*_mock_tag_table, decrement("TAG1")).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, decrement("TAG1")).Times(1);
   _th->add_timer(timer2);
 
   // Now call get_timers_for_node. This returns the informational timer


### PR DESCRIPTION
Shifted table initialisation to below Pidfile lock. Spread the scalar table throughout the files and the tests. Not really much going on here.
