### PR TITLE
[Reviewer: Andy] Add overload control to keep latency below 50ms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ GMOCK_DIR := $(ROOT)/modules/gmock
 
 TARGET := chronos
 TARGET_TEST := chronos_test
-TARGET_SOURCES_BUILD := main.cpp snmp_infinite_timer_count_table.cpp snmp_counter_table.cpp snmp_continuous_increment_table.cpp
+TARGET_SOURCES_BUILD := main.cpp snmp_infinite_timer_count_table.cpp snmp_counter_table.cpp snmp_continuous_increment_table.cpp load_monitor.cpp
 TARGET_SOURCES_TEST := $(notdir $(wildcard src/test/*.cpp)) test_interposer.cpp fakelogger.cpp mock_sas.cpp fakecurl.cpp pthread_cond_var_helper.cpp mock_increment_table.cpp mock_infinite_table.cpp
 TARGET_SOURCES := $(filter-out $(TARGET_SOURCES_BUILD) $(TARGET_SOURCES_TEST), $(notdir $(wildcard src/main/*.cpp) $(wildcard src/main/**/*.cpp)))
 TARGET_SOURCES += log.cpp logger.cpp unique.cpp signalhandler.cpp alarm.cpp httpstack.cpp httpstack_utils.cpp accesslogger.cpp utils.cpp health_checker.cpp exception_handler.cpp httpconnection.cpp statistic.cpp baseresolver.cpp dnscachedresolver.cpp dnsparser.cpp zmq_lvc.cpp httpresolver.cpp counter.cpp snmp_scalar.cpp snmp_agent.cpp snmp_row.cpp timer_counter.cpp

--- a/src/include/globals.h
+++ b/src/include/globals.h
@@ -77,6 +77,10 @@ public:
   GLOBAL(threads, int);
   GLOBAL(max_ttl, int);
   GLOBAL(dns_servers, std::vector<std::string>);
+  GLOBAL(target_latency, int);
+  GLOBAL(max_tokens, int);
+  GLOBAL(initial_token_rate, int);
+  GLOBAL(min_token_rate, int);
 
   // Clustering configuration
   GLOBAL(cluster_local_ip, std::string);

--- a/src/main/globals.cpp
+++ b/src/main/globals.cpp
@@ -67,6 +67,10 @@ Globals::Globals(std::string config_file,
     ("logging.level", po::value<int>()->default_value(2), "Logging level: 1(lowest) - 5(highest)")
     ("http.threads", po::value<int>()->default_value(50), "Number of HTTP threads to create")
     ("exceptions.max_ttl", po::value<int>()->default_value(600), "Maximum time before the process exits after hitting an exception")
+    ("throttling.target_latency", po::value<int>()->default_value(500000), "Target latency (in microseconds) for HTTP responses")
+    ("throttling.max_tokens", po::value<int>()->default_value(20), "Maximum token bucket size for HTTP overload control")
+    ("throttling.initial_token_rate", po::value<int>()->default_value(500), "Initial token bucket refill rate for HTTP overload control")
+    ("throttling.min_token_rate", po::value<int>()->default_value(10), "Minimum token bucket refill rate for HTTP overload control")
     ("dns.servers", po::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(1, "127.0.0.1"), "HOST"), "The addresses of the DNS servers used by the Chronos process")
 
     // Deprecated option left in for backwards compatibility

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -47,6 +47,7 @@
 #include "httpstack.h"
 #include "httpstack_utils.h"
 #include "handlers.h"
+#include "load_monitor.h"
 #include "health_checker.h"
 #include "exception_handler.h"
 #include <getopt.h>
@@ -304,6 +305,22 @@ int main(int argc, char** argv)
                                           timers_processed_table,
                                           invalid_timers_processed_table);
 
+
+  int target_latency;
+  int max_tokens;
+  int initial_token_rate;
+  int min_token_rate;
+  __globals->get_target_latency(target_latency);
+  __globals->get_max_tokens(max_tokens);
+  __globals->get_initial_token_rate(initial_token_rate);
+  __globals->get_min_token_rate(min_token_rate);
+
+
+  LoadMonitor* load_monitor = new LoadMonitor(target_latency,
+                                              max_tokens,
+                                              initial_token_rate,
+                                              min_token_rate);
+
   // Finally, set up the HTTPStack and handlers
   HttpStack* http_stack = HttpStack::get_instance();
   int bind_port;
@@ -319,7 +336,7 @@ int main(int argc, char** argv)
   try
   {
     http_stack->initialize();
-    http_stack->configure(bind_address, bind_port, http_threads, exception_handler);
+    http_stack->configure(bind_address, bind_port, http_threads, exception_handler, NULL, load_monitor, NULL);
     http_stack->register_handler((char*)"^/ping$", &ping_handler);
     http_stack->register_handler((char*)"^/timers", &controller_handler);
     http_stack->start();


### PR DESCRIPTION
I've picked 50ms as the target latency (half of Sprout's), and a 500 req/sec initial request rate (equal to Sprout's rate on a two-core system).