### PR TITLE
Change version of SNMP libraries

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: http://github.com/Metaswitch/chronos
 
 Package: chronos
 Architecture: any
-Depends: clearwater-infrastructure, libboost-program-options1.54.0, libboost-regex1.54.0, libboost-filesystem1.54.0, libevent-2.0-5, libevent-pthreads-2.0-5, libc-ares-dev, clearwater-log-cleanup, libsnmp30 (= 5.7.2~dfsg-clearwater1), snmp (= 5.7.2~dfsg-clearwater1), libsnmp-base (= 5.7.2~dfsg-clearwater1), clearwater-snmpd
+Depends: clearwater-infrastructure, libboost-program-options1.54.0, libboost-regex1.54.0, libboost-filesystem1.54.0, libevent-2.0-5, libevent-pthreads-2.0-5, libc-ares-dev, clearwater-log-cleanup, libsnmp30 (= 5.7.2~dfsg-clearwater2), snmp (= 5.7.2~dfsg-clearwater2), libsnmp-base (= 5.7.2~dfsg-clearwater2), clearwater-snmpd
 Description: Distributed, redundant network timer service.
 
 Package: chronos-dbg


### PR DESCRIPTION
Co-req change to https://github.com/Metaswitch/clearwater-net-snmp/pull/2.