### PR TITLE
[Reveller: Andy] Set coverage-not-yet path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ COMMON_LDFLAGS := -Lbuild/usr/lib -lrt -lpthread -lcurl -levent -lboost_program_
 chronos_LDFLAGS := ${COMMON_LDFLAGS} -lsas -lz
 chronos_test_LDFLAGS := ${COMMON_LDFLAGS} -ldl
 
+chronos_test_EXCLUSION_FILE := src/test/coverage-not-yet
+
 VPATH := modules/cpp-common/src modules/cpp-common/test_utils src/main src/test src/main/murmur
 
 BUILD_DIR := build


### PR DESCRIPTION
For use alongside https://github.com/Metaswitch/clearwater-build-infra/pull/26/files. Note that it doesn't work:

```
74 14:52:19  chronos  [dev *%]$ make coverage_raw
------------------------------------------------------------------------------
File                                       Lines    Exec  Cover   Missing
------------------------------------------------------------------------------
------------------------------------------------------------------------------
TOTAL                                          0       0    --%
------------------------------------------------------------------------------
379 14:54:05  chronos  [coverage-not-yet *%]$ make -n build/chronos_test/coverage.xml                                                        
modules/gcovr/scripts/gcovr --root=/home/ubuntu/chronos --object-directory=/home/ubuntu/chronos --exclude="^ut|^modules/gmock" build/chronos_test --xml > build/chronos_test/coverage.xml || (rm build/chronos_test/coverage.xml; exit 2)
381 14:55:48  chronos  [coverage-not-yet *%]$ make build/chronos_test/coverage.xml
382 14:55:53  chronos  [coverage-not-yet *%]$ cat build/chronos_test/coverage.xml
<?xml version="1.0" ?>
<!DOCTYPE coverage
  SYSTEM 'http://cobertura.sourceforge.net/xml/coverage-03.dtd'>
<coverage branch-rate="0.0" line-rate="0.0" timestamp="1450104953" version="gcovr 3.2-prerelease">
<sources>
<source>/home/ubuntu/chronos</source>
</sources>
<packages/>
</coverage>

385 14:58:08  chronos  [coverage-not-yet *%]$ ls -1 build/chronos_test/*gcda* | wc -l
50
386 14:58:44  chronos  [coverage-not-yet *%]$ ls -1 build/chronos_test/*gcno* | wc -l
50
```

but I thought it worth passing along the partial work I'd done here.