### PR TITLE
[Reviewer: Ellie] Changes to fix callback lockup issue

### DIFF
--- a/src/include/timer_handler.h
+++ b/src/include/timer_handler.h
@@ -63,7 +63,9 @@ public:
                SNMP::InfiniteScalarTable*);
   virtual ~TimerHandler();
   virtual void add_timer(Timer*, bool=true);
-  virtual void return_timer(Timer*, bool);
+  virtual void return_timer(Timer*);
+  virtual void handle_successful_callback(TimerID id);
+  virtual void handle_failed_callback(TimerID id);
   virtual void update_replica_tracker_for_timer(TimerID id,
                                                 int replica_index);
   virtual HTTPCode get_timers_for_node(std::string node,

--- a/src/main/http_callback.cpp
+++ b/src/main/http_callback.cpp
@@ -108,10 +108,15 @@ void HTTPCallback::worker_thread_entry_point()
   Timer* timer;
   while (_q.pop(timer))
   {
+    // Pull out the timer details for use in the CURL request.
+    TimerID timer_id = timer->id;
+    std::string callback_url = timer->callback_url;
+    std::string callback_body = timer->callback_body;
+
     // Set up the request details.
-    curl_easy_setopt(curl, CURLOPT_URL, timer->callback_url.c_str());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, timer->callback_body.data());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, timer->callback_body.length());
+    curl_easy_setopt(curl, CURLOPT_URL, callback_url.c_str());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, callback_body.data());
+    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, callback_body.length());
 
     // Include the sequence number header.
     struct curl_slist* headers = NULL;
@@ -120,12 +125,17 @@ void HTTPCallback::worker_thread_entry_point()
     headers = curl_slist_append(headers, "Content-Type: application/octet-stream");
     curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
 
+    // Return the timer to the store. This avoids the error case where the client
+    // attempts to update the timer based on the pop, but finds nothing in the store.
+    _handler->return_timer(timer);
+    timer = NULL; // We relinquish control of the timer when we give it back to the store.
+
     // Send the request
     CURLcode curl_rc = curl_easy_perform(curl);
     if (curl_rc == CURLE_OK)
     {
-      _handler->return_timer(timer, true);
-      timer = NULL; // We relinquish control of the timer when we give it back to the store.
+      TRC_DEBUG("callback was successful");
+      _handler->handle_successful_callback(timer_id);
     }
     else
     {
@@ -133,15 +143,13 @@ void HTTPCallback::worker_thread_entry_point()
       {
         long http_rc = 0;
         curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_rc);
-        TRC_WARNING("Got HTTP error %d from %s", http_rc, timer->callback_url.c_str());
+        TRC_DEBUG("Got HTTP error %d from %s", http_rc, callback_url.c_str());
       }
 
-      TRC_WARNING("Failed to process callback for %lu: URL %s, curl error was: %s", timer->id,
-                  timer->callback_url.c_str(),
+      TRC_DEBUG("Failed to process callback for %lu: URL %s, curl error was: %s", timer_id,
+                  callback_url.c_str(),
                   curl_easy_strerror(curl_rc));
-
-      _handler->return_timer(timer, false);
-      timer = NULL; // We relinquish control of the timer when we give it back to the store.
+      _handler->handle_failed_callback(timer_id);
     }
 
     // Tidy up request-speciifc objects

--- a/src/main/timer_handler.cpp
+++ b/src/main/timer_handler.cpp
@@ -364,6 +364,7 @@ void TimerHandler::handle_failed_callback(TimerID timer_id)
       _all_timers_table->decrement(1);
     }
   }
+
   delete failed_pair.active_timer; failed_pair.active_timer = NULL;
   delete failed_pair.information_timer; failed_pair.information_timer = NULL;
 }

--- a/src/main/timer_handler.cpp
+++ b/src/main/timer_handler.cpp
@@ -331,9 +331,8 @@ void TimerHandler::handle_successful_callback(TimerID timer_id)
     {
       cluster_view_id_vector.push_back(timer_pair.information_timer->cluster_view_id);
     }
+    // Pass the timer pair back to the store, relinquishing responsibility for it.
     _store->insert(timer_pair, timer_id, timer->next_pop_time(), cluster_view_id_vector);
-    timer = NULL;
-    timer_pair.information_timer = NULL;
   }
 
   pthread_mutex_unlock(&_mutex);

--- a/src/test/mock_timer_handler.h
+++ b/src/test/mock_timer_handler.h
@@ -45,7 +45,9 @@ class MockTimerHandler : public TimerHandler
 {
 public:
   MOCK_METHOD2(add_timer,void(Timer*,bool));
-  MOCK_METHOD2(return_timer,void(Timer*,bool));
+  MOCK_METHOD1(return_timer,void(Timer*));
+  MOCK_METHOD1(handle_successful_callback,void(TimerID));
+  MOCK_METHOD1(handle_failed_callback,void(TimerID));
   MOCK_METHOD2(update_replica_tracker_for_timer, void(TimerID, int));
   MOCK_METHOD4(get_timers_for_node, HTTPCode(std::string request_node,
                                              int max_responses,

--- a/src/test/test_timer_handler.cpp
+++ b/src/test/test_timer_handler.cpp
@@ -437,7 +437,7 @@ TEST_F(TestTimerHandlerAddAndReturn, AddTimer)
                        WillOnce(SaveArg<0>(&insert_pair));
   _th->add_timer(timer);
 
-  // The timer is succesfully added. As it's a new timer it's passed through to
+  // The timer is successfully added. As it's a new timer it's passed through to
   // the store unchanged.
   EXPECT_EQ(insert_pair.active_timer, timer);
 
@@ -899,7 +899,7 @@ TEST_F(TestTimerHandlerAddAndReturn, ReturnTimerWillPopAgain)
                        WillOnce(SaveArg<0>(&insert_pair));
   _th->return_timer(timer);
 
-  // The timer is succesfully added. As it's a new timer (as the pop would have
+  // The timer is successfully added. As it's a new timer (as the pop would have
   // removed it from the store) it's passed through to the store unchanged.
   EXPECT_EQ(insert_pair.active_timer, timer);
 
@@ -930,7 +930,7 @@ TEST_F(TestTimerHandlerAddAndReturn, ReturnTimerWontPopAgain)
                        WillOnce(SaveArg<0>(&insert_pair));
   _th->return_timer(timer);
 
-  // The timer is succesfully added. As it's a new timer (as the pop would have
+  // The timer is successfully added. As it's a new timer (as the pop would have
   // removed it from the store) it's passed through to the store unchanged.
   EXPECT_EQ(insert_pair.active_timer, timer);
   EXPECT_TRUE(insert_pair.active_timer->is_tombstone());
@@ -958,12 +958,10 @@ TEST_F(TestTimerHandlerAddAndReturn, HandleCallbackSuccess)
                               WillOnce(SaveArg<0>(&insert_pair));
   _th->add_timer(timer);
 
-  // The timer is succesfully added. As it's a new timer it's passed through to
+  // The timer is successfully added. As it's a new timer it's passed through to
   // the store unchanged.
   EXPECT_EQ(insert_pair.active_timer, timer);
 
-  // Delete the timer (this is normally done by the insert call, but this
-  // is mocked out)
   timer = NULL;
 
   // Add an info timer to the pair, to check that the cluster view id vector can be built correctly.
@@ -998,7 +996,7 @@ TEST_F(TestTimerHandlerAddAndReturn, HandleCallbackFailure)
                               WillOnce(SaveArg<0>(&insert_pair));
   _th->add_timer(timer);
 
-  // The timer is succesfully added. As it's a new timer it's passed through to
+  // The timer is successfully added. As it's a new timer it's passed through to
   // the store unchanged.
   EXPECT_EQ(insert_pair.active_timer, timer);
 
@@ -1089,7 +1087,7 @@ TEST_F(TestTimerHandlerAddAndReturn, UpdateReplicaTrackerValueForOldActiveTimer)
                        WillOnce(DoAll(SetArgReferee<1>(insert_pair),Return(true)));
   EXPECT_CALL(*_store, insert(_,timer->id, timer->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
-    _th->update_replica_tracker_for_timer(1u, 0);
+  _th->update_replica_tracker_for_timer(1u, 0);
 
   ASSERT_EQ(0u, insert_pair.active_timer->_replica_tracker);
   ASSERT_EQ("different-id", insert_pair.active_timer->cluster_view_id);

--- a/src/test/test_timer_handler.cpp
+++ b/src/test/test_timer_handler.cpp
@@ -140,7 +140,7 @@ TEST_F(TestTimerHandlerFetchAndPop, PopOneTimer)
 
   _th = new TimerHandler(_store, _callback, _replicator, _mock_timer_alarm, _mock_increment_table, _mock_tag_table, _mock_scalar_table);
   _cond()->block_till_waiting();
-  delete timer;
+  delete timer; timer = NULL;
 }
 
 TEST_F(TestTimerHandlerFetchAndPop, PopRepeatedTimer)
@@ -886,19 +886,18 @@ TEST_F(TestTimerHandlerAddAndReturn, AddLowerSequenceNumber)
   delete insert_pair.active_timer;
 }
 
-// Return a timer to the handler as if it has been passed back from HTTPCallback
-TEST_F(TestTimerHandlerAddAndReturn, ReturnTimerSuccessful)
+// Return a timer to the handler as if it has been passed back from HTTPCallback and will pop again.
+TEST_F(TestTimerHandlerAddAndReturn, ReturnTimerWillPopAgain)
 {
   Timer* timer = default_timer(1);
   TimerPair insert_pair;
 
   // The timer is being returned from a callback. This shouldn't change any
   // counts/tags
-  EXPECT_CALL(*_replicator, replicate(timer));
   EXPECT_CALL(*_store, fetch(timer->id, _)).WillOnce(Return(false));
   EXPECT_CALL(*_store, insert(_, timer->id, timer->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
-  _th->return_timer(timer, true);
+  _th->return_timer(timer);
 
   // The timer is succesfully added. As it's a new timer (as the pop would have
   // removed it from the store) it's passed through to the store unchanged.
@@ -909,47 +908,115 @@ TEST_F(TestTimerHandlerAddAndReturn, ReturnTimerSuccessful)
   delete insert_pair.active_timer;
 }
 
-// Return a timer to the handler as if it has been passed back from HTTPCallback
-// but has been dropped (by failing to send it)
-TEST_F(TestTimerHandlerAddAndReturn, ReturnTimerFailure)
+// Return a timer to the handler as if it has been passed back from HTTPCallback and wont pop again.
+// The timer should be tombstoned before being put mack into the store.
+TEST_F(TestTimerHandlerAddAndReturn, ReturnTimerWontPopAgain)
 {
   Timer* timer = default_timer(1);
+  // Set timer up so that it wouldn't pop again.
+  timer->sequence_number = 1;
+  timer->interval_ms = 100;
+  timer->repeat_for = 100;
+
   TimerPair insert_pair;
 
-  // The timer failed its callback. This decrement the counts/tags and set an
-  // alarm. It won't be added back to the store
-  EXPECT_CALL(*_mock_timer_alarm, set());
+  // The timer is being returned from a callback, and won't pop again.
+  // This should update statistics, and be returned to the store as a tombstone.
   EXPECT_CALL(*_mock_increment_table, decrement(1)).Times(1);
   EXPECT_CALL(*_mock_tag_table, decrement("TAG1", 1)).Times(1);
   EXPECT_CALL(*_mock_scalar_table, decrement("TAG1", 1)).Times(1);
-  _th->return_timer(timer, false);
-}
-
-// Return a timer to the handler, but make it the last repeat (so it gets
-// converted to a tombstone)
-TEST_F(TestTimerHandlerAddAndReturn, ReturnTimerToTombstone)
-{
-  Timer* timer = default_timer(1);
-  timer->repeat_for = (timer->sequence_number + 1) * timer->interval_ms - 100;
-  TimerPair insert_pair;
-
-  // The timer is converted to a tombstone (decrementing counts/tags) and added
-  // to the store
-  EXPECT_CALL(*_replicator, replicate(timer));
   EXPECT_CALL(*_store, fetch(timer->id, _)).WillOnce(Return(false));
   EXPECT_CALL(*_store, insert(_, timer->id, timer->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
-  EXPECT_CALL(*_mock_increment_table, decrement(1)).Times(1);
-  EXPECT_CALL(*_mock_tag_table, decrement("TAG1", 1)).Times(1);
-  EXPECT_CALL(*_mock_scalar_table, decrement("TAG1", 1)).Times(1);
-  _th->return_timer(timer, true);
+  _th->return_timer(timer);
 
+  // The timer is succesfully added. As it's a new timer (as the pop would have
+  // removed it from the store) it's passed through to the store unchanged.
   EXPECT_EQ(insert_pair.active_timer, timer);
   EXPECT_TRUE(insert_pair.active_timer->is_tombstone());
 
   // Delete the timer (this is normally done by the insert call, but this
   // is mocked out)
   delete insert_pair.active_timer;
+}
+
+// Test that the handle_callback_success function fetches the timer specified,
+// replicates it, and re-inserts it into the store
+TEST_F(TestTimerHandlerAddAndReturn, HandleCallbackSuccess)
+{
+  // Add a timer. This is a new timer, so should cause the stats to
+  // increment (counts and tags)
+  Timer* timer = default_timer(1);
+  Timer* info_timer = default_timer(1);
+  TimerPair insert_pair;
+  TimerID id = timer->id;
+  EXPECT_CALL(*_store, fetch(timer->id, _)).Times(1);
+  EXPECT_CALL(*_mock_tag_table, increment("TAG1", 1)).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1", 1)).Times(1);
+  EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
+  EXPECT_CALL(*_store, insert(_, timer->id, timer->next_pop_time(), _)).
+                              WillOnce(SaveArg<0>(&insert_pair));
+  _th->add_timer(timer);
+
+  // The timer is succesfully added. As it's a new timer it's passed through to
+  // the store unchanged.
+  EXPECT_EQ(insert_pair.active_timer, timer);
+
+  // Delete the timer (this is normally done by the insert call, but this
+  // is mocked out)
+  timer = NULL;
+
+  // Add an info timer to the pair, to check that the cluster view id vector can be built correctly.
+  insert_pair.information_timer = info_timer;
+
+  // Now call handle_successful_callback as if called from http_callback
+  EXPECT_CALL(*_store, fetch(id, _)).Times(1).
+              WillOnce(DoAll(SetArgReferee<1>(insert_pair),Return(true)));
+  EXPECT_CALL(*_replicator, replicate(insert_pair.active_timer));
+  EXPECT_CALL(*_store, insert(_, insert_pair.active_timer->id, insert_pair.active_timer->next_pop_time(), _)).
+                              WillOnce(SaveArg<0>(&insert_pair));
+  _th->handle_successful_callback(id);
+
+  delete insert_pair.active_timer;
+  delete insert_pair.information_timer;
+}
+
+// Test that the handle_failed_callback function correctly handles setting the
+// alarm, and updating statistics, and then does not put it back into the store.
+TEST_F(TestTimerHandlerAddAndReturn, HandleCallbackFailure)
+{
+  // Add a timer. This is a new timer, so should cause the stats to
+  // increment (counts and tags)
+  Timer* timer = default_timer(1);
+  TimerPair insert_pair;
+  TimerID id = timer->id;
+  EXPECT_CALL(*_store, fetch(timer->id, _)).Times(1);
+  EXPECT_CALL(*_mock_tag_table, increment("TAG1", 1)).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, increment("TAG1", 1)).Times(1);
+  EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
+  EXPECT_CALL(*_store, insert(_, timer->id, timer->next_pop_time(), _)).
+                              WillOnce(SaveArg<0>(&insert_pair));
+  _th->add_timer(timer);
+
+  // The timer is succesfully added. As it's a new timer it's passed through to
+  // the store unchanged.
+  EXPECT_EQ(insert_pair.active_timer, timer);
+
+  // Delete the timer (this is normally done by the insert call, but this
+  // is mocked out)
+  timer = NULL;
+
+  // Now call handle_failed_callback as if called from http_callback
+  EXPECT_CALL(*_store, fetch(id, _)).Times(1).
+              WillOnce(DoAll(SetArgReferee<1>(insert_pair),Return(true)));
+  EXPECT_CALL(*_mock_timer_alarm, set());
+  EXPECT_CALL(*_mock_increment_table, decrement(1)).Times(1);
+  EXPECT_CALL(*_mock_tag_table, decrement("TAG1", 1)).Times(1);
+  EXPECT_CALL(*_mock_scalar_table, decrement("TAG1", 1)).Times(1);
+  EXPECT_CALL(*_store, insert(_, id, _, _)).Times(0);
+
+  _th->handle_failed_callback(id);
+  // Do not delete timer as this is already done in the function
 }
 
 // Test that marking some of the replicas as being informed
@@ -1022,7 +1089,7 @@ TEST_F(TestTimerHandlerAddAndReturn, UpdateReplicaTrackerValueForOldActiveTimer)
                        WillOnce(DoAll(SetArgReferee<1>(insert_pair),Return(true)));
   EXPECT_CALL(*_store, insert(_,timer->id, timer->next_pop_time(), _)).
                        WillOnce(SaveArg<0>(&insert_pair));
-  _th->update_replica_tracker_for_timer(1u, 0);
+    _th->update_replica_tracker_for_timer(1u, 0);
 
   ASSERT_EQ(0u, insert_pair.active_timer->_replica_tracker);
   ASSERT_EQ("different-id", insert_pair.active_timer->cluster_view_id);


### PR DESCRIPTION
This PR includes the changes made to overcome the issue of leaking statistics. 
The issue was being caused by sprout re-sending a timer PUT update before the chronos callback had completed, and then chronos setting a tombstone over the new timer, meaning it was never deleted properly.