### PR TITLE
[No reviewer] Move cpp-common UTs to cpp-common

### DIFF
--- a/src/test/coverage-not-yet
+++ b/src/test/coverage-not-yet
@@ -16,31 +16,3 @@ src/include/replicator.h
 
 # Murmur hash not covered by UTs
 src/main/murmur/MurmurHash3.cpp
-
-# cpp-common files
-modules/cpp-common/src/baseresolver.cpp
-modules/cpp-common/src/httpstack.cpp
-modules/cpp-common/src/httpstack_utils.cpp
-modules/cpp-common/src/exception_handler.cpp
-modules/cpp-common/src/accumulator.cpp
-modules/cpp-common/src/chronosconnection.cpp
-modules/cpp-common/src/dnscachedresolver.cpp
-modules/cpp-common/src/log.cpp
-modules/cpp-common/src/health_checker.cpp
-modules/cpp-common/src/httpconnection.cpp
-modules/cpp-common/src/statistic.cpp
-modules/cpp-common/src/counter.cpp
-modules/cpp-common/src/fakelogger.cpp
-modules/cpp-common/src/httpresolver.cpp
-modules/cpp-common/src/accesslogger.cpp
-modules/cpp-common/src/alarm.cpp
-modules/cpp-common/src/dnsparser.cpp
-modules/cpp-common/src/logger.cpp
-modules/cpp-common/src/utils.cpp
-modules/cpp-common/src/zmq_lvc.cpp
-modules/cpp-common/src/snmp_agent.cpp
-modules/cpp-common/src/snmp_row.cpp
-modules/cpp-common/src/snmp_scalar.cpp
-modules/cpp-common/src/snmp_counter_table.cpp
-modules/cpp-common/src/snmp_continuous_accumulator_table.cpp
-modules/cpp-common/src/timer_counter.cpp


### PR DESCRIPTION
Take out cpp-common files from coverage-not-yet