### PR TITLE
[Reviewer: None] Use updated check-uptime script.

### DIFF
--- a/chronos.root/usr/share/chronos/chronos.monit
+++ b/chronos.root/usr/share/chronos/chronos.monit
@@ -49,11 +49,11 @@ check process chronos_process with pidfile /var/run/chronos.pid
   if memory > 80% for 6 cycles then exec "/bin/bash -c '/usr/share/clearwater/bin/issue_alarm.py monit 3000.4; /etc/init.d/chronos abort'"
 
 # Clear any alarms if the process has been running long enough.
-check program chronos_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/chronos.pid"
+check program chronos_uptime with path "/usr/share/clearwater/bin/check-uptime /var/run/chronos.pid monit 3000.1"
   group chronos
   depends on chronos_process
   every 3 cycles
-  if status = 0 then exec "/usr/share/clearwater/bin/issue_alarm.py monit 3000.1"
+  if status != 0 then alert
 
 # Check the HTTP interface. This depends on the Chronos process (and so won't run
 # unless the Chronos process is running)


### PR DESCRIPTION
Use check-uptime to clear alarms and avoid suprious monit failures.