### PR TITLE
[Reviewer: Rob] Separate write_cluster_settings functionality

### DIFF
--- a/chronos.root/usr/share/clearwater/clearwater-cluster-manager/plugins/chronos_plugin.py
+++ b/chronos.root/usr/share/clearwater/clearwater-cluster-manager/plugins/chronos_plugin.py
@@ -93,14 +93,11 @@ class ChronosPlugin(SynchroniserPluginBase):
 
     def on_cluster_changing(self, cluster_view):
         self._alarm.set()
-        write_chronos_cluster_settings("/etc/chronos/chronos_cluster.conf",
-                                       cluster_view,
-                                       self.local_server)
-        run_command("service chronos reload")
+        self.write_cluster_settings(cluster_view)
 
     def on_joining_cluster(self, cluster_view):
         self._alarm.set()
-        self.on_cluster_changing(cluster_view)
+        self.write_cluster_settings(cluster_view)
 
     def on_new_cluster_config_ready(self, cluster_view):
         self._alarm.set()
@@ -108,11 +105,17 @@ class ChronosPlugin(SynchroniserPluginBase):
         run_command("service chronos wait-sync")
 
     def on_stable_cluster(self, cluster_view):
-        self.on_cluster_changing(cluster_view)
+        self.write_cluster_settings(cluster_view)
         self._alarm.clear()
 
     def on_leaving_cluster(self, cluster_view):
         pass
+
+    def write_cluster_settings(self, cluster_view):
+        write_chronos_cluster_settings("/etc/chronos/chronos_cluster.conf",
+                                       cluster_view,
+                                       self.local_server)
+        run_command("service chronos reload")
 
 def load_as_plugin(params):
     _log.info("Loading the Chronos plugin")


### PR DESCRIPTION
This should fix the alarm flicker issue seen in live testing. 
Previously, on_stable_cluster called on_cluster_changing, which set the alarm, before it then cleared the alarm. 
Now the function of write_chronos_cluster_settings has been pulled out of on_cluster_changing so that on_stable_cluster can call it without causing the alarm to flicker.

The same changes have been made in the memcached_plugin.py  https://github.com/Metaswitch/clearwater-infrastructure/pull/300