### PR TITLE
[Reviewer: Andy] Ensure uniqueness (kind of)

### DIFF
--- a/include/globals.h
+++ b/include/globals.h
@@ -98,6 +98,8 @@ public:
   GLOBAL(cluster_bloom_filters, std::map<std::string, uint64_t>);
   GLOBAL(cluster_view_id, std::string);
 
+  GLOBAL(instance_id, uint32_t);
+  GLOBAL(deployment_id, uint32_t);
 public:
   void update_config();
   void lock() { pthread_rwlock_wrlock(&_lock); }

--- a/include/timer.h
+++ b/include/timer.h
@@ -162,10 +162,6 @@ public:
                               std::string& error,
                               bool& replicated,
                               rapidjson::Value& doc);
-
-  // Class variables
-  static uint32_t deployment_id;
-  static uint32_t instance_id;
 };
 
 #endif

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -64,6 +64,8 @@ Globals::Globals(std::string config_file,
     ("cluster.joining", po::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(), "HOST"), "The addresses of nodes in the cluster that are joining")
     ("cluster.node", po::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(1, "localhost:7253"), "HOST"), "The addresses of nodes in the cluster that are staying")
     ("cluster.leaving", po::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(), "HOST"), "The addresses of nodes in the cluster that are leaving")
+    ("identity.instance_id", po::value<uint32_t>()->default_value(0), "A number between 0 and 127. The combination of instance ID and deployment ID should uniquely identify this node in the cluster, to remove the risk of timer collisions.")
+    ("identity.deployment_id", po::value<uint32_t>()->default_value(0), "A number between 0 and 7. The combination of instance ID and deployment ID should uniquely identify this node in the cluster, to remove the risk of timer collisions.")
     ("logging.folder", po::value<std::string>()->default_value("/var/log/chronos"), "Location to output logs to")
     ("logging.level", po::value<int>()->default_value(2), "Logging level: 1(lowest) - 5(highest)")
     ("http.threads", po::value<int>()->default_value(50), "Number of HTTP threads to create")
@@ -177,6 +179,14 @@ void Globals::update_config()
 
   TRC_STATUS("%s", _timer_id_format_parser.at(timer_id_format).c_str());
   set_timer_id_format(timer_id_format);
+
+  uint32_t instance_id = conf_map["identity.instance_id"].as<uint32_t>();
+  uint32_t deployment_id = conf_map["identity.deployment_id"].as<uint32_t>();
+  
+  set_instance_id(instance_id);
+  set_deployment_id(deployment_id);
+
+  TRC_STATUS("Instance ID is %d, deployment ID is %d", instance_id, deployment_id);
 
   std::string cluster_local_address = conf_map["cluster.localhost"].as<std::string>();
   set_cluster_local_ip(cluster_local_address);

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -576,9 +576,6 @@ void Timer::calculate_replicas(uint64_t replica_hash)
   }
 }
 
-uint32_t Timer::deployment_id = 0;
-uint32_t Timer::instance_id = 0;
-
 // Generate a timer that should be unique across the (possibly geo-redundant) cluster.
 // The idea is to use a combination of deployment id, instance id, timestamp and
 // an incrementing sequence number.
@@ -587,8 +584,14 @@ uint32_t Timer::instance_id = 0;
 // list of replicas, but this doesn't add much uniqueness.
 TimerID Timer::generate_timer_id()
 {
-  return (TimerID)Utils::generate_unique_integer(Timer::deployment_id,
-                                                 Timer::instance_id);
+  uint32_t instance_id = 0;
+  uint32_t deployment_id = 0;
+
+  __globals->get_instance_id(instance_id);
+  __globals->get_deployment_id(deployment_id);
+
+  return (TimerID)Utils::generate_unique_integer(deployment_id,
+                                                 instance_id);
 }
 
 // Created tombstones from delete operations are given


### PR DESCRIPTION
This extracts an instance ID and a deployment ID from ten bits of the UUID. This substantially mitigates https://github.com/Metaswitch/chronos/issues/70 (see the birthday paradox calculations in that issue).

As we discussed, I've made the cluster manager responsible for setting this, as in the long term we'll probably want to use the cluster manager to agree a guaranteed-unique ID.

Tested by spinning up four Sprout nodes and checking they got different values:

```
]$ for i in {1..4}; do ssh sprout-$i.rkd.cw-ngv.com "cat /etc/chronos/chronos_cluster.conf"; done
Warning: Permanently added 'sprout-1.rkd.cw-ngv.com' (ECDSA) to the list of known hosts.
Warning: the ECDSA host key for 'sprout-1.rkd.cw-ngv.com' differs from the key for the IP address '54.175.247.195'
Offending key for IP in /home/ubuntu/.ssh/known_hosts:243
# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
#
# WARNING - THIS FILE IS GENERATED BY ETCD AND SHOULD NOT BE EDITED DIRECTLY
#
# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[identity]
instance_id = 23
deployment_id = 7

[cluster]
localhost = 10.0.253.71
node = 10.0.253.71
node = 10.0.85.3
node = 10.0.171.0
node = 10.0.193.136
Warning: Permanently added 'sprout-2.rkd.cw-ngv.com' (ECDSA) to the list of known hosts.
Warning: the ECDSA host key for 'sprout-2.rkd.cw-ngv.com' differs from the key for the IP address '52.90.173.65'
Offending key for IP in /home/ubuntu/.ssh/known_hosts:246
# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
#
# WARNING - THIS FILE IS GENERATED BY ETCD AND SHOULD NOT BE EDITED DIRECTLY
#
# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[identity]
instance_id = 10
deployment_id = 7

[cluster]
localhost = 10.0.193.136
node = 10.0.253.71
node = 10.0.85.3
node = 10.0.171.0
node = 10.0.193.136
Warning: Permanently added 'sprout-3.rkd.cw-ngv.com' (ECDSA) to the list of known hosts.
Warning: the ECDSA host key for 'sprout-3.rkd.cw-ngv.com' differs from the key for the IP address '54.175.122.169'
Offending key for IP in /home/ubuntu/.ssh/known_hosts:240
# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
#
# WARNING - THIS FILE IS GENERATED BY ETCD AND SHOULD NOT BE EDITED DIRECTLY
#
# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[identity]
instance_id = 48
deployment_id = 2

[cluster]
localhost = 10.0.171.0
node = 10.0.253.71
node = 10.0.85.3
node = 10.0.171.0
node = 10.0.193.136
Warning: Permanently added 'sprout-4.rkd.cw-ngv.com' (ECDSA) to the list of known hosts.
Warning: the ECDSA host key for 'sprout-4.rkd.cw-ngv.com' differs from the key for the IP address '54.173.202.150'
Offending key for IP in /home/ubuntu/.ssh/known_hosts:242
# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
#
# WARNING - THIS FILE IS GENERATED BY ETCD AND SHOULD NOT BE EDITED DIRECTLY
#
# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
[identity]
instance_id = 5
deployment_id = 0

[cluster]
localhost = 10.0.85.3
node = 10.0.253.71
node = 10.0.85.3
node = 10.0.171.0
node = 10.0.193.136
```