### PR TITLE
[Reviewer: Andy] Faster UTs

### DIFF
--- a/include/timer_store.h
+++ b/include/timer_store.h
@@ -142,7 +142,15 @@ public:
   // Constants controlling the size of the short wheel buckets (this needs to
   // be public so that the timer handler can work out how long it should
   // wait for a tick)
+#ifndef UNIT_TEST
   static const int SHORT_WHEEL_RESOLUTION_MS = 8;
+#else
+  // Use fewer, larger buckets in UT, so we do less work when iterating over
+  // timers, and run at an acceptable speed under Valgrind. The timer wheel
+  // algorithms are independent of particular bucket sizes, so this doesn't
+  // reduce the quality of our testing.
+  static const int SHORT_WHEEL_RESOLUTION_MS = 256;
+#endif
 
   class TSIterator
   {
@@ -227,12 +235,21 @@ private:
   HealthChecker* _health_checker;
 
   // Constants controlling the size and resolution of the timer wheels.
+#ifndef UNIT_TEST
   static const int SHORT_WHEEL_NUM_BUCKETS = 128;
+  static const int LONG_WHEEL_NUM_BUCKETS = 4096;
+#else
+  // Use fewer, larger buckets in UT, so we do less work when iterating over
+  // timers, and run at an acceptable speed under Valgrind. The timer wheel
+  // algorithms are independent of particular bucket sizes, so this doesn't
+  // reduce the quality of our testing.
+  static const int SHORT_WHEEL_NUM_BUCKETS = 4;
+  static const int LONG_WHEEL_NUM_BUCKETS = 2048;
+#endif
   static const int SHORT_WHEEL_PERIOD_MS =
                                  (SHORT_WHEEL_RESOLUTION_MS * SHORT_WHEEL_NUM_BUCKETS);
 
   static const int LONG_WHEEL_RESOLUTION_MS = SHORT_WHEEL_PERIOD_MS;
-  static const int LONG_WHEEL_NUM_BUCKETS = 4096;
   static const int LONG_WHEEL_PERIOD_MS =
                             (LONG_WHEEL_RESOLUTION_MS * LONG_WHEEL_NUM_BUCKETS);
 

--- a/src/ut/test_timer_replica_choosing.cpp
+++ b/src/ut/test_timer_replica_choosing.cpp
@@ -49,7 +49,7 @@ using testing::Types;
 /*****************************************************************************/
 
 static uint32_t REPLICATION_FACTOR = 2u;
-static int MAX_TIMERS = 4096;
+static int MAX_TIMERS = 768;
 static Hasher normal_hasher;
 
 class WithReplicas {
@@ -208,8 +208,8 @@ TYPED_TEST(TestTimerReplicaChoosing, MinimumTimersMovePrimary)
   }
 
   // To balance the cluster when we moved from N replicas to N+1, approximately
-  // 1/N+1th of existing timers should have moved. Allow a 5% difference to account for randomness.
-  EXPECT_THAT(different, ::testing::Lt((MAX_TIMERS / TestFixture::new_cluster.size()) * 1.05));
+  // 1/N+1th of existing timers should have moved. Allow a 10% difference to account for randomness.
+  EXPECT_THAT(different, ::testing::Lt((MAX_TIMERS / TestFixture::new_cluster.size()) * 1.1));
 }
 
 // Same logic as previous test, but checking backup instead of primary.

--- a/src/ut/test_timer_store.cpp
+++ b/src/ut/test_timer_store.cpp
@@ -59,10 +59,10 @@ static uint32_t get_time_ms()
 }
 
 
-// The timer store has a granularity of 10ms. This means that timers may pop up
-// to 10ms late. As a result the timer store tests often add this granularity
-// when advancing time to guarantee that a timer has popped.
-const int TIMER_GRANULARITY_MS = 8;
+// The timer store has a granularity of , for example, 10ms. This means that
+// timers may pop up to 10ms late. As a result the timer store tests often add
+// this granularity when advancing time to guarantee that a timer has popped.
+const int TIMER_GRANULARITY_MS = TimerStore::SHORT_WHEEL_RESOLUTION_MS;
 
 class Overflow2h {
   static void set_time() {
@@ -293,7 +293,8 @@ TYPED_TEST(TestTimerStore, ClashingMultiMidGetNextTimersTest)
 {
   // Lengthen timer one to be in the same second bucket as timer two but different ms
   // buckets.
-  TestFixture::timers[0]->interval_ms = 10000 + 100;
+  TestFixture::timers[0]->interval_ms = 10000;
+  TestFixture::timers[1]->interval_ms = 10000 + (TIMER_GRANULARITY_MS * 3);
 
   TestFixture::ts_insert_helper(TestFixture::timers[0]);
   TestFixture::ts_insert_helper(TestFixture::timers[1]);
@@ -347,8 +348,9 @@ TYPED_TEST(TestTimerStore, SeparateMultiMidGetNextTimersTest)
 TYPED_TEST(TestTimerStore, MultiLongGetTimersTest)
 {
   // Lengthen timer one and two to be in the extra heap.
-  TestFixture::timers[0]->interval_ms = (3600 * 1000) + 100;
-  TestFixture::timers[1]->interval_ms = (3600 * 1000) + 200;
+  TestFixture::timers[0]->interval_ms = (3600 * 1000) + (TIMER_GRANULARITY_MS * 2);
+  TestFixture::timers[1]->interval_ms = (3600 * 1000) + (TIMER_GRANULARITY_MS * 4);
+  TestFixture::timers[2]->interval_ms = (3600 * 1000) + (TIMER_GRANULARITY_MS * 6);
 
   TestFixture::ts_insert_helper(TestFixture::timers[0]);
   TestFixture::ts_insert_helper(TestFixture::timers[1]);


### PR DESCRIPTION
The Chronos UTs are slow because we do too much work. I have changed some constants so we do less work. We still get full coverage, and `make full_test` finishes in 1m30s in my test, whereas it's taken 30+ minutes recently on the repo server.