### PR TITLE
[Reviewer: Ellie] Apply cppcheck fixes

### DIFF
--- a/include/chronos_internal_connection.h
+++ b/include/chronos_internal_connection.h
@@ -92,13 +92,13 @@ private:
                          std::vector<std::string> replicas);
 
   // Sends a delete request
-  virtual HTTPCode send_delete(const std::string server,
-                               const std::string body);
+  virtual HTTPCode send_delete(const std::string& server,
+                               const std::string& body);
 
   // Sends a get request
-  virtual HTTPCode send_get(const std::string server,
-                            const std::string requesting_node,
-                            const std::string sync_mode,
+  virtual HTTPCode send_get(const std::string& server,
+                            const std::string& requesting_node,
+                            const std::string& sync_mode,
                             std::string cluster_view_id,
                             int max_timers,
                             std::string& response);
@@ -106,7 +106,7 @@ private:
   // Resynchronises with a single Chronos node (used in scale
   // operations).
   virtual HTTPCode resynchronise_with_single_node(
-                            const std::string server_to_sync,
+                            const std::string& server_to_sync,
                             std::vector<std::string> cluster_nodes,
                             std::string localhost);
 };

--- a/include/globals.h
+++ b/include/globals.h
@@ -70,6 +70,7 @@ public:
   Globals(std::string config_file,
           std::string cluster_config_file);
   ~Globals();
+  Globals(const Globals& copy) = delete;
 
   enum struct TimerIDFormat
   {

--- a/include/timer_handler.h
+++ b/include/timer_handler.h
@@ -64,6 +64,7 @@ public:
                SNMP::InfiniteTimerCountTable*,
                SNMP::InfiniteScalarTable*);
   virtual ~TimerHandler();
+  TimerHandler(const TimerHandler& copy) = delete;
   virtual void add_timer(Timer*, bool=true);
   virtual void return_timer(Timer*);
   virtual void handle_successful_callback(TimerID id);

--- a/src/chronos_internal_connection.cpp
+++ b/src/chronos_internal_connection.cpp
@@ -187,7 +187,7 @@ void ChronosInternalConnection::resynchronize()
 }
 
 HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
-                             const std::string server_to_sync,
+                             const std::string& server_to_sync,
                              std::vector<std::string> cluster_nodes,
                              std::string localhost)
 {
@@ -400,7 +400,7 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
             }
 
           }
-          catch (JsonFormatError err)
+          catch (JsonFormatError& err)
           {
             // A single entry is badly formatted. This is unexpected but we'll try
             // to keep going and process the rest of the timers.
@@ -424,7 +424,7 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
           rc = HTTP_BAD_REQUEST;
         }
       }
-      catch (JsonFormatError err)
+      catch (JsonFormatError& err)
       {
         // We've failed to find the Timers array. This suggests that
         // there's something seriously wrong with the node we're trying
@@ -434,7 +434,7 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
       }
 
       // Send a DELETE to all the nodes to update their timer references
-      if (delete_map.size() > 0)
+      if (!delete_map.empty())
       {
         std::string delete_body = create_delete_body(delete_map);
         for (std::vector<std::string>::iterator it = cluster_nodes.begin();
@@ -471,17 +471,17 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
   return rc;
 }
 
-HTTPCode ChronosInternalConnection::send_delete(const std::string server,
-                                                const std::string body)
+HTTPCode ChronosInternalConnection::send_delete(const std::string& server,
+                                                const std::string& body)
 {
   std::string path = "/timers/references";
   HTTPCode rc = _http->send_delete(path, 0, body, server);
   return rc;
 }
 
-HTTPCode ChronosInternalConnection::send_get(const std::string server,
-                                             const std::string node_for_replicas_param,
-                                             const std::string sync_mode_param,
+HTTPCode ChronosInternalConnection::send_get(const std::string& server,
+                                             const std::string& node_for_replicas_param,
+                                             const std::string& sync_mode_param,
                                              std::string cluster_view_id_param,
                                              int max_timers,
                                              std::string& response)

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -224,14 +224,14 @@ void ControllerTask::handle_delete()
         _cfg->_handler->update_replica_tracker_for_timer(timer_id,
                                                          replica_index);
       }
-      catch (JsonFormatError err)
+      catch (JsonFormatError& err)
       {
         TRC_INFO("JSON entry was invalid (hit error at %s:%d)",
                   err._file, err._line);
       }
     }
   }
-  catch (JsonFormatError err)
+  catch (JsonFormatError& err)
   {
     TRC_INFO("JSON body didn't contain the IDs array");
     send_http_reply(HTTP_BAD_REQUEST);

--- a/src/http_callback.cpp
+++ b/src/http_callback.cpp
@@ -41,7 +41,8 @@
 
 HTTPCallback::HTTPCallback() :
   _q(),
-  _running(false)
+  _running(false),
+  _handler(NULL)
 {
 }
 
@@ -94,7 +95,7 @@ void HTTPCallback::perform(Timer* timer)
 
 void* HTTPCallback::worker_thread_entry_point(void* arg)
 {
-  HTTPCallback* callback = (HTTPCallback*)arg;
+  HTTPCallback* callback = static_cast<HTTPCallback*>(arg);
   callback->worker_thread_entry_point();
   return NULL;
 }

--- a/src/replicator.cpp
+++ b/src/replicator.cpp
@@ -83,7 +83,7 @@ Replicator::~Replicator()
 
 void* Replicator::worker_thread_entry_point(void* arg)
 {
-  Replicator* rep = (Replicator*)arg;
+  Replicator* rep = static_cast<Replicator*>(arg);
   rep->worker_thread_entry_point();
   return NULL;
 }

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -392,7 +392,7 @@ static void calculate_rendezvous_hash(std::vector<std::string> cluster,
   // Pick the lowest hash value as the primary replica.
   for (std::map<uint32_t, size_t>::iterator ii = hash_to_idx.begin();
        ii != hash_to_idx.end();
-       ii++)
+       ++ii)
   {
     ordered_cluster.push_back(cluster[ii->second]);
   }
@@ -423,7 +423,7 @@ void Timer::calculate_replicas(TimerID id,
                                Hasher* hasher)
 {
   std::vector<std::string> old_replicas;
-  replicas.empty();
+  replicas.clear();
 
   // Calculate the replicas for the current cluster.
   calculate_rendezvous_hash(new_cluster,
@@ -868,7 +868,7 @@ Timer* Timer::from_json_obj(TimerID id,
       TRC_DEBUG("Statistics object not present, or badly formed. Discarding all tags.");
     }
   }
-  catch (JsonFormatError err)
+  catch (JsonFormatError& err)
   {
     error = "Badly formed Timer entry - hit error on line " + std::to_string(err._line);
     delete timer; timer = NULL;

--- a/src/timer_handler.cpp
+++ b/src/timer_handler.cpp
@@ -46,7 +46,7 @@
 
 void* TimerHandler::timer_handler_entry_func(void* arg)
 {
-  ((TimerHandler*)arg)->run();
+  static_cast<TimerHandler*>(arg)->run();
   return NULL;
 }
 
@@ -106,7 +106,6 @@ TimerHandler::~TimerHandler()
 void TimerHandler::add_timer(Timer* timer, bool update_stats)
 {
   pthread_mutex_lock(&_mutex);
-  bool will_add_timer = true;
 
   // Convert the new timer to a timer pair
   TimerPair new_tp;
@@ -119,6 +118,7 @@ void TimerHandler::add_timer(Timer* timer, bool update_stats)
   // We've found a timer.
   if (timer_found)
   {
+    bool will_add_timer = true;
     std::string cluster_view_id;
     __globals->get_cluster_view_id(cluster_view_id);
 
@@ -434,7 +434,6 @@ HTTPCode TimerHandler::get_timers_for_node(std::string request_node,
                                            std::string& get_response)
 {
   pthread_mutex_lock(&_mutex);
-  std::unordered_set<TimerPair> timers;
 
   // Create the JSON doc for the Timer information
   rapidjson::StringBuffer sb;
@@ -572,7 +571,6 @@ bool TimerHandler::timer_is_on_node(std::string request_node,
 // pop, check the timer store to make sure we're holding the nearest timers.
 void TimerHandler::run() {
   std::unordered_set<TimerPair> next_timers;
-  std::unordered_set<Timer*>::iterator sample_timer;
 
   pthread_mutex_lock(&_mutex);
 
@@ -674,6 +672,7 @@ void TimerHandler::pop(Timer* timer)
   timer->update_cluster_information();
 
   // The callback borrows of the timer at this point.
+  // cppcheck-suppress uselessAssignmentPtrArg
   _callback->perform(timer); timer = NULL;
 }
 

--- a/src/timer_store.cpp
+++ b/src/timer_store.cpp
@@ -479,10 +479,10 @@ TimerStore::TSIterator::TSIterator(TimerStore* ts) :
 
 TimerStore::TSIterator& TimerStore::TSIterator::operator++()
 {
-  inner_iterator++;
+  ++inner_iterator;
   if (inner_iterator == outer_iterator->second.end())
   {
-    outer_iterator++;
+    ++outer_iterator;
     inner_next();
   }
   return *this;
@@ -515,7 +515,7 @@ void TimerStore::TSIterator::inner_next()
   while (outer_iterator != _ts->_timer_view_id_table.end() &&
          outer_iterator->first == _cluster_view_id)
   {
-    outer_iterator++;
+    ++outer_iterator;
   }
 
   if (outer_iterator != _ts->_timer_view_id_table.end())


### PR DESCRIPTION
This fixes up some warnings from running cppcheck (http://cppcheck.sourceforge.net/) over our codebase. (I'm going to send an email round the team on whether we should do this systematically - I like the results.)

In order of importance:

* We were using `replicas.empty()` in one place where we meant `replicas.clear()`
* We weren't catching exceptions by reference (http://stackoverflow.com/questions/8350526/catching-exceptions-by-reference)
* `Globals` and `TimerHandler` had pointer members (so couldn't safely be copy-constructed) but we hadn't explicitly removed the copy constructor
* We used C-style casts instead of (safer and easier to grep for) C++-style casts
* We had some unused variables, and some which could be narrower in scope
* Some constructors weren't initialising all their arguments
* A couple of performance things:
    * prefix rather than postfix increment (http://stackoverflow.com/a/24904)
    * always passing const arguments by reference
    * checking `x.empty()` rather than `x.size() == 0`
