### PR TITLE
[Reviewer: Rob] Change max_tokens default to 100

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -71,7 +71,7 @@ Globals::Globals(std::string config_file,
     ("http.threads", po::value<int>()->default_value(50), "Number of HTTP threads to create")
     ("exceptions.max_ttl", po::value<int>()->default_value(600), "Maximum time before the process exits after hitting an exception")
     ("throttling.target_latency", po::value<int>()->default_value(500000), "Target latency (in microseconds) for HTTP responses")
-    ("throttling.max_tokens", po::value<int>()->default_value(20), "Maximum token bucket size for HTTP overload control")
+    ("throttling.max_tokens", po::value<int>()->default_value(100), "Maximum token bucket size for HTTP overload control")
     ("throttling.initial_token_rate", po::value<int>()->default_value(500), "Initial token bucket refill rate for HTTP overload control")
     ("throttling.min_token_rate", po::value<int>()->default_value(10), "Minimum token bucket refill rate for HTTP overload control")
     ("dns.servers", po::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(1, "127.0.0.1"), "HOST"), "The addresses of the DNS servers used by the Chronos process")


### PR DESCRIPTION
Just want to check that we do want to be increasing the default tokens count in Chronos as well as all the main components.