### PR TITLE
[Reviewer: Ellie] Move to working timer heap

### DIFF
--- a/include/timer.h
+++ b/include/timer.h
@@ -55,7 +55,7 @@ public:
   virtual uint32_t do_hash(TimerID data, uint32_t seed);
 };
 
-class Timer : public TimerHeap::Timer
+class Timer : public HeapableTimer
 {
 public:
   Timer(TimerID, uint32_t interval_ms, uint32_t repeat_for);
@@ -65,10 +65,10 @@ public:
   friend class TestTimer;
 
   // Returns the next time to pop in ms after epoch
-  uint32_t next_pop_time();
+  uint32_t next_pop_time() const;
   
-  // Required method for TimerHeap::Timer
-  uint64_t get_pop_time() { return next_pop_time(); }
+  // Required method for use in a heap
+  uint64_t get_pop_time() const { return next_pop_time(); }
 
   // Construct the URL for this timer given a hostname
   std::string url(std::string host = "");

--- a/include/timer.h
+++ b/include/timer.h
@@ -42,6 +42,7 @@
 #include <string>
 #include "rapidjson/document.h"
 #include "rapidjson/writer.h"
+#include "timer_heap.h"
 
 typedef uint64_t TimerID;
 
@@ -54,7 +55,7 @@ public:
   virtual uint32_t do_hash(TimerID data, uint32_t seed);
 };
 
-class Timer
+class Timer : public TimerHeap::Timer
 {
 public:
   Timer(TimerID, uint32_t interval_ms, uint32_t repeat_for);
@@ -65,6 +66,9 @@ public:
 
   // Returns the next time to pop in ms after epoch
   uint32_t next_pop_time();
+  
+  // Required method for TimerHeap::Timer
+  uint64_t get_pop_time() { return next_pop_time(); }
 
   // Construct the URL for this timer given a hostname
   std::string url(std::string host = "");

--- a/include/timer.h
+++ b/include/timer.h
@@ -68,7 +68,7 @@ public:
   uint32_t next_pop_time() const;
   
   // Required method for use in a heap
-  uint64_t get_pop_time() const { return next_pop_time(); }
+  uint64_t get_pop_time() const;
 
   // Construct the URL for this timer given a hostname
   std::string url(std::string host = "");

--- a/include/timer_store.h
+++ b/include/timer_store.h
@@ -134,6 +134,9 @@ public:
   // Fetch the next buckets of timers to pop and remove from store
   virtual void fetch_next_timers(std::unordered_set<TimerPair>& set);
 
+  // Removes all timers from the wheels and heap, without deleting them. Useful for cleanup in UT.
+  void clear();
+
   // A table of all known timers indexed by ID. The TimerPair is in the
   // timer wheel - any other timers are stored for use when
   // resynchronising between Chronos's.

--- a/include/timer_store.h
+++ b/include/timer_store.h
@@ -269,7 +269,12 @@ private:
   Bucket _long_wheel[LONG_WHEEL_NUM_BUCKETS];
 
   // Heap of longer-lived timers (> 1hr)
-  std::vector<TimerPair> _extra_heap;
+  std::vector<Timer*> _extra_heap;
+
+  // We store Timer*s in the heap (as the TimerHeap interface requires
+  // heap-allocated pointers and the TimerPair is always stack-allocated), so
+  // this utility method looks up the timer ID to get back to a TimerPair.
+  TimerPair pop_from_heap();
 
   // Timestamp of the next tick to process. This is stored in ms, and is always
   // a multiple of SHORT_WHEEL_RESOLUTION_MS.

--- a/include/timer_store.h
+++ b/include/timer_store.h
@@ -38,6 +38,7 @@
 #define TIMER_STORE_H__
 
 #include "timer.h"
+#include "timer_heap.h"
 #include "health_checker.h"
 #include "httpconnection.h"
 
@@ -269,7 +270,7 @@ private:
   Bucket _long_wheel[LONG_WHEEL_NUM_BUCKETS];
 
   // Heap of longer-lived timers (> 1hr)
-  std::vector<Timer*> _extra_heap;
+  TimerHeap _extra_heap;
 
   // We store Timer*s in the heap (as the TimerHeap interface requires
   // heap-allocated pointers and the TimerPair is always stack-allocated), so

--- a/include/timer_store.h
+++ b/include/timer_store.h
@@ -135,7 +135,8 @@ public:
   // Fetch the next buckets of timers to pop and remove from store
   virtual void fetch_next_timers(std::unordered_set<TimerPair>& set);
 
-  // Removes all timers from the wheels and heap, without deleting them. Useful for cleanup in UT.
+  // Removes all timers from the wheels and heap, without deleting them. Useful
+  // for cleanup in UT.
   void clear();
 
   // A table of all known timers indexed by ID. The TimerPair is in the
@@ -275,7 +276,7 @@ private:
   // We store Timer*s in the heap (as the TimerHeap interface requires
   // heap-allocated pointers and the TimerPair is always stack-allocated), so
   // this utility method looks up the timer ID to get back to a TimerPair.
-  TimerPair pop_from_heap();
+  TimerPair get_top_of_heap();
 
   // Timestamp of the next tick to process. This is stored in ms, and is always
   // a multiple of SHORT_WHEEL_RESOLUTION_MS.

--- a/src/Makefile
+++ b/src/Makefile
@@ -9,6 +9,7 @@ COMMON_SOURCES := chronos_internal_connection.cpp \
                   http_callback.cpp \
                   timer.cpp \
                   timer_store.cpp \
+                  timer_heap.cpp \
                   log.cpp \
                   pdlog.cpp \
                   logger.cpp \

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -97,13 +97,13 @@ Timer::~Timer()
 }
 
 // Returns the next pop time in ms.
-uint32_t Timer::next_pop_time()
+uint32_t Timer::next_pop_time() const
 {
   std::string localhost;
   int replica_index = 0;
   __globals->get_cluster_local_ip(localhost);
 
-  for (std::vector<std::string>::iterator it = replicas.begin();
+  for (std::vector<std::string>::const_iterator it = replicas.begin();
                                           it != replicas.end();
                                           ++it, ++replica_index)
   {

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -116,6 +116,20 @@ uint32_t Timer::next_pop_time() const
   return start_time_mono_ms + ((sequence_number + 1) * interval_ms) + (replica_index * 2 * 1000);
 }
 
+uint64_t Timer::get_pop_time() const
+{
+  // The timer heap operates on 64-bit numbers, and expects times to overflow
+  // at the 64-bit overflow point, whereas Chronos uses 32-bit numbers. If we
+  // just provide 32-bit numbers to the heap, they will wrap at the wrong point
+  // and our overflow tests will fail. To avoid that, we shift the pop time 32
+  // bits to the left when providing it to the heap, so that times are still in
+  // the same order but they wrap at the 64-bit overflow point.
+  //
+  // This time is only used for heap ordering - when we get this out of the
+  // heap, we'll use next_pop_time() which returns the right time.
+  return (uint64_t)next_pop_time() << 32;
+}
+
 // Create the timer's URL from a given hostname
 std::string Timer::url(std::string host)
 {

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -104,8 +104,8 @@ uint32_t Timer::next_pop_time() const
   __globals->get_cluster_local_ip(localhost);
 
   for (std::vector<std::string>::const_iterator it = replicas.begin();
-                                          it != replicas.end();
-                                          ++it, ++replica_index)
+       it != replicas.end();
+       ++it, ++replica_index)
   {
     if (*it == localhost)
     {

--- a/src/timer_store.cpp
+++ b/src/timer_store.cpp
@@ -149,8 +149,7 @@ void TimerStore::insert(TimerPair tp,
   {
     // Timer is too far in the future to be handled by the wheels, put it in
     // the extra heap.
-    TRC_WARNING("Adding timer to extra heap, consider re-building with a larger "
-                "LONG_WHEEL_NUM_BUCKETS constant");
+    TRC_DEBUG("Adding timer to extra heap");
     _extra_heap.insert(tp.active_timer);
   }
 

--- a/src/timer_store.cpp
+++ b/src/timer_store.cpp
@@ -309,7 +309,7 @@ void TimerStore::maybe_refill_wheels()
   }
 }
 
-TimerPair TimerStore::pop_from_heap()
+TimerPair TimerStore::get_top_of_heap()
 {
   Timer* t = static_cast<Timer*>(_extra_heap.get_next_timer());
   return _timer_lookup_id_table[t->id];
@@ -321,7 +321,7 @@ void TimerStore::refill_long_wheel()
 {
   if (!_extra_heap.empty())
   {
-    TimerPair timer = pop_from_heap();
+    TimerPair timer = get_top_of_heap();
 
     if (timer.active_timer != NULL)
     {
@@ -338,7 +338,7 @@ void TimerStore::refill_long_wheel()
 
       if (!_extra_heap.empty())
       {
-        timer = pop_from_heap();
+        timer = get_top_of_heap();
       }
       else
       {

--- a/src/ut/test_timer_store.cpp
+++ b/src/ut/test_timer_store.cpp
@@ -395,13 +395,8 @@ TYPED_TEST(TestTimerStore, HeapPropertyTest)
   //  - the timer with ID 1 is the last one to pop
   //
   //  This avoids bugs where the timers are ordered by ID instead of pop time.
-  //
-  //  Make sure all of these are >2 hours - otherwise the Overflow2h case wraps
-  //  one of them and causes unexpected behaviour. (This is probably the case
-  //  for all tests, but this uses three long timers so it's most noticeable
-  //  here.)
   TestFixture::timers[0]->interval_ms = (3600 * 1000 * 10) + (TIMER_GRANULARITY_MS * 2);
-  TestFixture::timers[1]->interval_ms = (3600 * 1000 * 3) + (TIMER_GRANULARITY_MS * 4);
+  TestFixture::timers[1]->interval_ms = (3600 * 1000) + (TIMER_GRANULARITY_MS * 4);
   TestFixture::timers[2]->interval_ms = (3600 * 1000 * 5) + (TIMER_GRANULARITY_MS * 6);
 
   TestFixture::ts_insert_helper(TestFixture::timers[0]);

--- a/src/ut/test_timer_store.cpp
+++ b/src/ut/test_timer_store.cpp
@@ -414,6 +414,15 @@ TYPED_TEST(TestTimerStore, HeapPropertyTest)
   EXPECT_EQ(2u, t->id);
 }
 
+TYPED_TEST(TestTimerStore, RemoveNonexistentTimer)
+{
+  // Don't insert any timers into the store, but try and remove one. This won't
+  // do anything - this test just checks it doesn't crash.
+  TimerPair tp;
+  tp.active_timer = TestFixture::timers[2];
+  TestFixture::ts->remove_timer_from_timer_wheel(tp);
+}
+
 
 TYPED_TEST(TestTimerStore, ReallyLongTimer)
 {

--- a/src/ut/test_timer_store.cpp
+++ b/src/ut/test_timer_store.cpp
@@ -154,6 +154,8 @@ protected:
     delete timers[2]; timers[2] = NULL;
     delete tombstone; tombstone = NULL;
 
+    // Clearing the timer store before deleting it prevents double-deletion of timers
+    ts->clear();
     delete ts; ts = NULL;
     delete hc; hc = NULL;
     cwtest_reset_time();
@@ -380,6 +382,38 @@ TYPED_TEST(TestTimerStore, MultiLongGetTimersTest)
   TestFixture::timers[2] = (*next_timers.begin()).active_timer;
   EXPECT_EQ(3u, TestFixture::timers[2]->id);
 }
+
+TYPED_TEST(TestTimerStore, HeapPropertyTest)
+{
+  // This test ensures that the heap is working properly - i.e. that the timer
+  // which is next to pop is at the top of the heap.
+  std::unordered_set<TimerPair> next_timers;
+
+  // Set the timers (with IDs 1, 2 and 3) up so that:
+  //  - the timer with ID 2 is the first one to pop
+  //  - the timer with ID 3 is the next one to pop
+  //  - the timer with ID 1 is the last one to pop
+  //
+  //  This avoids bugs where the timers are ordered by ID instead of pop time.
+  TestFixture::timers[0]->interval_ms = (3600 * 1000 * 10) + (TIMER_GRANULARITY_MS * 2);
+  TestFixture::timers[1]->interval_ms = (3600 * 1000) + (TIMER_GRANULARITY_MS * 4);
+  TestFixture::timers[2]->interval_ms = (3600 * 1000 * 5) + (TIMER_GRANULARITY_MS * 6);
+
+  TestFixture::ts_insert_helper(TestFixture::timers[0]);
+  TestFixture::ts_insert_helper(TestFixture::timers[1]);
+  TestFixture::ts_insert_helper(TestFixture::timers[2]);
+
+  // Advance time to when the timer with ID 2 should pop, and ask for the next
+  // timer to pop. We should get one and it should be the timer with ID 2.
+
+  cwtest_advance_time_ms(TestFixture::timers[1]->interval_ms + TIMER_GRANULARITY_MS);
+  TestFixture::ts->fetch_next_timers(next_timers);
+  
+  ASSERT_EQ(1u, next_timers.size()) << "Bucket should have 1 timer";
+  const Timer* t = (*next_timers.begin()).active_timer;
+  EXPECT_EQ(2u, t->id);
+}
+
 
 TYPED_TEST(TestTimerStore, ReallyLongTimer)
 {

--- a/src/ut/test_timer_store.cpp
+++ b/src/ut/test_timer_store.cpp
@@ -395,8 +395,13 @@ TYPED_TEST(TestTimerStore, HeapPropertyTest)
   //  - the timer with ID 1 is the last one to pop
   //
   //  This avoids bugs where the timers are ordered by ID instead of pop time.
+  //
+  //  Make sure all of these are >2 hours - otherwise the Overflow2h case wraps
+  //  one of them and causes unexpected behaviour. (This is probably the case
+  //  for all tests, but this uses three long timers so it's most noticeable
+  //  here.)
   TestFixture::timers[0]->interval_ms = (3600 * 1000 * 10) + (TIMER_GRANULARITY_MS * 2);
-  TestFixture::timers[1]->interval_ms = (3600 * 1000) + (TIMER_GRANULARITY_MS * 4);
+  TestFixture::timers[1]->interval_ms = (3600 * 1000 * 3) + (TIMER_GRANULARITY_MS * 4);
   TestFixture::timers[2]->interval_ms = (3600 * 1000 * 5) + (TIMER_GRANULARITY_MS * 6);
 
   TestFixture::ts_insert_helper(TestFixture::timers[0]);


### PR DESCRIPTION
This switches to the timer heap from https://github.com/Metaswitch/cpp-common/pull/517, which fixes #257, #258 and #259.

One question I'd particularly like your view on: I've made the heap store a `Timer*` (the active timer) rather than a TimerPair. is this right? I didn't quite understand the connection between active and information timers - I think if a timer's in the store it's always an active timer, and information timers are just how we track timers that have been resynced away, but I wasn't sure.

(I previously also asked "I hit a UT issue relating to overflow, where I had timers for 1 hour, 5 hours and 10 hours and the 5-hour one popped first in the Overflow2h case. I fixed this by using a 3-hour timer rather than a 1-hour one. I think this is working as designed - I think any timers below 2h overflow and appear very large - but wanted a second opinion." @bossmc pointed out that this was definitely wrong, and I needed to make the heap overflow-aware.)