### PR TITLE
[Reviewer: Ellie] Fix issue 276 - timers with interval 0 never get tombstoned

### DIFF
--- a/src/timer_handler.cpp
+++ b/src/timer_handler.cpp
@@ -294,7 +294,7 @@ void TimerHandler::add_timer(Timer* timer, bool update_stats)
 void TimerHandler::return_timer(Timer* timer)
 {
   // We may need to tombstone the timer
-  if ((timer->sequence_number + 1) * timer->interval_ms > timer->repeat_for)
+  if (((timer->sequence_number + 1) * timer->interval_ms > timer->repeat_for) || (timer->interval_ms == 0 && timer->repeat_for == 0))
   {
     // This timer won't pop again, so tombstone it and update statistics
     timer->become_tombstone();

--- a/src/timer_handler.cpp
+++ b/src/timer_handler.cpp
@@ -294,7 +294,12 @@ void TimerHandler::add_timer(Timer* timer, bool update_stats)
 void TimerHandler::return_timer(Timer* timer)
 {
   // We may need to tombstone the timer
-  if (((timer->sequence_number + 1) * timer->interval_ms > timer->repeat_for) || (timer->interval_ms == 0 && timer->repeat_for == 0))
+  // We also need to check for timers with a zero interval and repeat_for value.
+  // This would be for when a customer wants some information back from Chronos
+  // immediately and only once, hence we should tombstone the timer after use.
+  if (((timer->sequence_number + 1) * timer->interval_ms > timer->repeat_for) ||
+      ((timer->interval_ms == 0) && 
+       (timer->repeat_for == 0)))
   {
     // This timer won't pop again, so tombstone it and update statistics
     timer->become_tombstone();


### PR DESCRIPTION
Changed the logic to the if statement for deciding whether to tombstone timers and added a UT.
Fixes https://github.com/Metaswitch/chronos/issues/276