### PR TITLE
[Reviewer: Ellie] Fix incorrect use of 'replacing' in comment

### DIFF
--- a/src/timer_handler.cpp
+++ b/src/timer_handler.cpp
@@ -184,7 +184,8 @@ void TimerHandler::add_timer(Timer* timer, bool update_stats)
       }
     }
 
-    // We're adding the new timer (not just replacing an existing timer)
+    // We're adding the new timer (rather than discarding it and putting the
+    // existing timer back in the store)
     if (will_add_timer)
     {
       // If the new timer is a tombstone, make sure its interval is long enough


### PR DESCRIPTION
I got confused by this comment in #284 - on reflection, 'replacing' is the wrong word to use here. How's this wording?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metaswitch/chronos/287)
<!-- Reviewable:end -->
