### PR TITLE
[Reviewer: Ellie] Move from curl and HttpConnection to HttpClient

### DIFF
--- a/doc/Development.md
+++ b/doc/Development.md
@@ -63,4 +63,4 @@ Chronos uses our common infrastructure to run the unit tests. How to run the UTs
 
 ## Running Functional Tests
 
-To run the tests of Chronos resynchronization, run `make resync_test`.
+To run the Chronos FV tests, run `make fv_test`.

--- a/include/chronos_internal_connection.h
+++ b/include/chronos_internal_connection.h
@@ -37,7 +37,7 @@
 #ifndef CHRONOSINTERNALCONNECTION_H__
 #define CHRONOSINTERNALCONNECTION_H__
 
-#include "httpconnection.h"
+#include "httpclient.h"
 #include "timer.h"
 #include "timer_handler.h"
 #include "replicator.h"
@@ -65,7 +65,7 @@ public:
   virtual void resynchronize();
 
 private:
-  HttpConnection* _http;
+  HttpClient* _http;
   TimerHandler* _handler;
   Replicator* _replicator;
   Alarm* _alarm;

--- a/include/http_callback.h
+++ b/include/http_callback.h
@@ -41,6 +41,8 @@
 #include "eventq.h"
 #include "timer_handler.h"
 #include "timer.h"
+#include "httpresolver.h"
+#include "httpconnection.h"
 
 #include <string>
 #include <curl/curl.h>
@@ -50,7 +52,7 @@
 class HTTPCallback : public Callback
 {
 public:
-  HTTPCallback();
+  HTTPCallback(HttpResolver* resolver);
   ~HTTPCallback();
 
   void start(TimerHandler*);
@@ -63,11 +65,16 @@ public:
   void worker_thread_entry_point();
 
 private:
+  // Resolver to use to resolve callback URL server FQDNs to IP addresses.
+  HttpResolver* _resolver;
+
   pthread_t _worker_threads[HTTPCALLBACK_THREAD_COUNT];
   eventq<Timer*> _q;
 
   bool _running;
   TimerHandler* _handler;
+
+  HttpClient _http_client;
 };
 
 #endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -22,7 +22,9 @@ COMMON_SOURCES := chronos_internal_connection.cpp \
                   utils.cpp \
                   health_checker.cpp \
                   exception_handler.cpp \
+                  httpclient.cpp \
                   httpconnection.cpp \
+                  http_connection_pool.cpp \
                   statistic.cpp \
                   baseresolver.cpp \
                   dnscachedresolver.cpp \

--- a/src/Makefile
+++ b/src/Makefile
@@ -63,6 +63,7 @@ chronos_test_SOURCES := ${COMMON_SOURCES} \
                         test_interposer.cpp \
                         test_chronos_internal_connection.cpp \
                         test_gr_replicator.cpp \
+                        test_http_callback.cpp \
                         fakelogger.cpp \
                         mock_sas.cpp \
                         fakecurl.cpp \

--- a/src/chronos_internal_connection.cpp
+++ b/src/chronos_internal_connection.cpp
@@ -59,11 +59,10 @@ ChronosInternalConnection::ChronosInternalConnection(HttpResolver* resolver,
                                                      SNMP::U32Scalar* remaining_nodes_scalar,
                                                      SNMP::CounterTable* timers_processed_table,
                                                      SNMP::CounterTable* invalid_timers_processed_table) :
-  _http(new HttpConnection("",
-                           false,
-                           resolver,
-                           SASEvent::HttpLogLevel::NONE,
-                           NULL)),
+  _http(new HttpClient(false,
+                       resolver,
+                       SASEvent::HttpLogLevel::NONE,
+                       NULL)),
   _handler(handler),
   _replicator(replicator),
   _alarm(alarm),
@@ -477,7 +476,7 @@ HTTPCode ChronosInternalConnection::send_delete(const std::string& server,
                                                 const std::string& body)
 {
   std::string path = "/timers/references";
-  HTTPCode rc = _http->send_delete(path, 0, body, server);
+  HTTPCode rc = _http->send_delete("http://" + server + path, 0, body);
   return rc;
 }
 
@@ -498,7 +497,7 @@ HTTPCode ChronosInternalConnection::send_get(const std::string& server,
   std::vector<std::string> headers;
   headers.push_back(range_header);
 
-  return _http->send_get(path, response, headers, server, 0);
+  return _http->send_get("http://" + server + path, response, headers, 0);
 }
 
 std::string ChronosInternalConnection::create_delete_body(std::map<TimerID, int> delete_map)

--- a/src/http_callback.cpp
+++ b/src/http_callback.cpp
@@ -39,10 +39,15 @@
 
 #include <cstring>
 
-HTTPCallback::HTTPCallback() :
+HTTPCallback::HTTPCallback(HttpResolver* resolver) :
+  _resolver(resolver),
   _q(),
   _running(false),
-  _handler(NULL)
+  _handler(NULL),
+  _http_client(false,
+               _resolver,
+               SASEvent::HttpLogLevel::NONE,
+               NULL)
 {
 }
 
@@ -102,11 +107,7 @@ void* HTTPCallback::worker_thread_entry_point(void* arg)
 
 void HTTPCallback::worker_thread_entry_point()
 {
-  CURL* curl = curl_easy_init();
-  curl_easy_setopt(curl, CURLOPT_POST, 1);
-  curl_easy_setopt(curl, CURLOPT_VERBOSE, 1);
-
-  Timer* timer;
+  Timer* timer = NULL;
   while (_q.pop(timer))
   {
     // Pull out the timer details for use in the CURL request.
@@ -114,17 +115,11 @@ void HTTPCallback::worker_thread_entry_point()
     std::string callback_url = timer->callback_url;
     std::string callback_body = timer->callback_body;
 
-    // Set up the request details.
-    curl_easy_setopt(curl, CURLOPT_URL, callback_url.c_str());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDS, callback_body.data());
-    curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, callback_body.length());
-
-    // Include the sequence number header.
-    struct curl_slist* headers = NULL;
-    headers = curl_slist_append(headers, (std::string("X-Sequence-Number: ") +
-                                          std::to_string(timer->sequence_number)).c_str());
-    headers = curl_slist_append(headers, "Content-Type: application/octet-stream");
-    curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+    // Set up the headers.
+    std::map<std::string, std::string> headers;
+    headers.insert(std::make_pair("X-Sequence-Number",
+                                  std::to_string(timer->sequence_number)));
+    headers.insert(std::make_pair("Content-Type", "application/octet-stream"));
 
     // Return the timer to the store. This avoids the error case where the client
     // attempts to update the timer based on the pop, finds nothing in the store,
@@ -133,10 +128,13 @@ void HTTPCallback::worker_thread_entry_point()
     _handler->return_timer(timer);
     timer = NULL; // We relinquish control of the timer when we give it back to the store.
 
-    // Send the request
-    CURLcode curl_rc = curl_easy_perform(curl);
+    // Send the request.
+    HTTPCode http_rc = _http_client.send_post(callback_url,
+                                              headers,
+                                              callback_body,
+                                              0L);
 
-    if (curl_rc == CURLE_OK)
+    if (http_rc == HTTP_OK)
     {
       // The callback succeeded, so we need to re-find the timer, and replicate it.
       TRC_DEBUG("Callback for timer \"%lu\" was successful", timer_id);
@@ -144,28 +142,13 @@ void HTTPCallback::worker_thread_entry_point()
     }
     else
     {
-      if (curl_rc == CURLE_HTTP_RETURNED_ERROR)
-      {
-        long http_rc = 0;
-        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_rc);
-        TRC_DEBUG("Got HTTP error %d from %s", http_rc, callback_url.c_str());
-      }
-
-      TRC_DEBUG("Failed to process callback for %lu: URL %s, curl error was: %s", timer_id,
-                callback_url.c_str(),
-                curl_easy_strerror(curl_rc));
+      TRC_DEBUG("Failed to process callback for %lu: URL %s, HTTP rc %ld", timer_id,
+                callback_url.c_str(), http_rc);
 
       // The callback failed, and so we need to remove the timer from the store.
       _handler->handle_failed_callback(timer_id);
     }
-
-    // Tidy up request-speciifc objects
-    curl_slist_free_all(headers);
-    headers = NULL;
   }
-
-  // Tidy up thread-specific objects
-  curl_easy_cleanup(curl);
 
   return;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -300,7 +300,8 @@ int main(int argc, char** argv)
                                            false,
                                            hc);
 
-  // Create the resolvers
+  // We're going to need an HttpResolver both for our HTTP callbacks and for
+  // our internal connections.  Create one.
   std::vector<std::string> dns_servers;
   __globals->get_dns_servers(dns_servers);
 
@@ -324,7 +325,7 @@ int main(int argc, char** argv)
   Replicator* controller_rep = new Replicator(exception_handler);
   Replicator* handler_rep = new Replicator(exception_handler);
   GRReplicator* gr_rep = new GRReplicator(http_resolver, exception_handler);
-  HTTPCallback* callback = new HTTPCallback();
+  HTTPCallback* callback = new HTTPCallback(http_resolver);
   TimerHandler* handler = new TimerHandler(store,
                                            callback,
                                            handler_rep,

--- a/src/ut/coverage-not-yet
+++ b/src/ut/coverage-not-yet
@@ -6,7 +6,6 @@
 
 # Currently untested Chronos files. These should only be in
 # here temporarily
-http_callback.cpp
 replicator.cpp
 
 # Murmur hash not covered by UTs

--- a/src/ut/test_http_callback.cpp
+++ b/src/ut/test_http_callback.cpp
@@ -1,0 +1,133 @@
+/**
+ * @file test_callback.cpp
+ *
+ * Project Clearwater - IMS in the Cloud
+ * Copyright (C) 2016  Metaswitch Networks Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version, along with the "Special Exception" for use of
+ * the program along with SSL, set forth below. This program is distributed
+ * in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+ * A PARTICULAR PURPOSE.  See the GNU General Public License for more
+ * details. You should have received a copy of the GNU General Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ *
+ * The author can be reached by email at clearwater@metaswitch.com or by
+ * post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+ *
+ * Special Exception
+ * Metaswitch Networks Ltd  grants you permission to copy, modify,
+ * propagate, and distribute a work formed by combining OpenSSL with The
+ * Software, or a work derivative of such a combination, even if such
+ * copying, modification, propagation, or distribution would otherwise
+ * violate the terms of the GPL. You must comply with the GPL in all
+ * respects for all of the code used other than OpenSSL.
+ * "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+ * Project and licensed under the OpenSSL Licenses, or a work based on such
+ * software and licensed under the OpenSSL Licenses.
+ * "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+ * under which the OpenSSL Project distributes the OpenSSL toolkit software,
+ * as those licenses appear in the file LICENSE-OPENSSL.
+ */
+
+#include "globals.h"
+#include "http_callback.h"
+#include "base.h"
+#include "fakecurl.hpp"
+#include "fakehttpresolver.hpp"
+#include "mock_timer_handler.h"
+#include "timer_helper.h"
+
+/// Fixture for HTTPCallbackTest.
+class TestHTTPCallback : public Base
+{
+protected:
+  void SetUp()
+  {
+    Base::SetUp();
+
+    _resolver = new FakeHttpResolver("10.42.42.42");
+    _th = new MockTimerHandler();
+    _callback = new HTTPCallback(_resolver);
+    _callback->start(_th);
+
+    fakecurl_responses.clear();
+    fakecurl_requests.clear();
+  }
+
+  void TearDown()
+  {
+    _callback->stop();
+    delete _callback;
+    delete _th;
+    delete _resolver;
+
+    Base::TearDown();
+  }
+
+  FakeHttpResolver* _resolver;
+  MockTimerHandler* _th;
+  HTTPCallback* _callback;
+};
+
+// Test successful timer callback
+TEST_F(TestHTTPCallback, Success)
+{
+  fakecurl_responses["http://10.42.42.42:80/callback1"] = CURLE_OK;
+  Timer* timer1 = default_timer(1);
+  EXPECT_CALL(*_th, return_timer(timer1));
+  EXPECT_CALL(*_th, handle_successful_callback(1));
+  _callback->perform(timer1);
+
+  // The timer's been sent when fakecurl records the request. Sleep until then.
+  std::map<std::string, Request>::iterator it =
+      fakecurl_requests.find("http://10.42.42.42:80/callback1");
+  int count = 0;
+  while (it == fakecurl_requests.end() && count < 10)
+  {
+    // Don't wait for more than 10 seconds
+    count++;
+    sleep(1);
+    it = fakecurl_requests.find("http://10.42.42.42:80/callback1");
+  }
+
+  EXPECT_LT(count, 10) << "No request was sent that matched the expected timer";
+
+  // Look at the body sent on the request. Check that it doesn't have any
+  // replica information, and that it makes a valid timer
+  Request& request = fakecurl_requests["http://10.42.42.42:80/callback1"];
+  rapidjson::Document doc;
+  EXPECT_EQ(request._body, "stuff stuff stuff");
+
+  delete timer1; timer1 = NULL;
+}
+
+// Test failed timer callback
+TEST_F(TestHTTPCallback, Failure)
+{
+  fakecurl_responses["http://10.42.42.42:80/callback2"] = CURLE_REMOTE_FILE_NOT_FOUND;
+  Timer* timer2 = default_timer(2);
+  EXPECT_CALL(*_th, return_timer(timer2));
+  EXPECT_CALL(*_th, handle_failed_callback(2));
+  _callback->perform(timer2);
+
+  // The timer's been sent when fakecurl records the request. Sleep until then.
+  std::map<std::string, Request>::iterator it =
+      fakecurl_requests.find("http://10.42.42.42:80/callback2");
+  int count = 0;
+  while (it == fakecurl_requests.end() && count < 10)
+  {
+    // Don't wait for more than 10 seconds
+    count++;
+    sleep(1);
+    it = fakecurl_requests.find("http://10.42.42.42:80/callback2");
+  }
+
+  EXPECT_LT(count, 10) << "No request was sent that matched the expected timer";
+
+  delete timer2; timer2 = NULL;
+}

--- a/src/ut/test_timer_handler.cpp
+++ b/src/ut/test_timer_handler.cpp
@@ -1396,7 +1396,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNode)
   // There should be one returned timer. We check this by matching the JSON
   std::string get_response;
   int rc = _th->get_timers_for_node("10.0.0.1:9999", 2, updated_cluster_view_id, get_response);
-  std::string exp_rsp = "\\\{\"Timers\":\\\[\\\{\"TimerID\":1,\"OldReplicas\":\\\[\"10.0.0.1:9999\"],\"Timer\":\\\{\"timing\":\\\{\"start-time\".*,\"start-time-delta\".*,\"sequence-number\":0,\"interval\":100,\"repeat-for\":100},\"callback\":\\\{\"http\":\\\{\"uri\":\"localhost:80/callback1\",\"opaque\":\"stuff stuff stuff\"}},\"reliability\":\\\{\"cluster-view-id\":\"updated-cluster-view-id\",\"replicas\":\\\[\"10.0.0.1:9999\"],\"sites\":\\\[\"local_site_name\",\"remote_site_1_name\"]},\"statistics\":\\\{\"tag-info\":\\\[\\\{\"type\":\"TAG1\",\"count\":1}]}}}]}";
+  std::string exp_rsp = "\\\{\"Timers\":\\\[\\\{\"TimerID\":1,\"OldReplicas\":\\\[\"10.0.0.1:9999\"],\"Timer\":\\\{\"timing\":\\\{\"start-time\".*,\"start-time-delta\".*,\"sequence-number\":0,\"interval\":100,\"repeat-for\":100},\"callback\":\\\{\"http\":\\\{\"uri\":\"http://localhost:80/callback1\",\"opaque\":\"stuff stuff stuff\"}},\"reliability\":\\\{\"cluster-view-id\":\"updated-cluster-view-id\",\"replicas\":\\\[\"10.0.0.1:9999\"],\"sites\":\\\[\"local_site_name\",\"remote_site_1_name\"]},\"statistics\":\\\{\"tag-info\":\\\[\\\{\"type\":\"TAG1\",\"count\":1}]}}}]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
   EXPECT_EQ(rc, 200);
 }
@@ -1478,7 +1478,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeHitMaxResponses)
 
   std::string get_response;
   int rc = _th->get_timers_for_node("10.0.0.1:9999", 1, updated_cluster_view_id, get_response);
-  std::string exp_rsp = "\\\{\"Timers\":\\\[\\\{\"TimerID\":2,\"OldReplicas\":\\\[\"10.0.0.1:9999\"],\"Timer\":\\\{\"timing\":\\\{\"start-time\".*,\"start-time-delta\".*,\"sequence-number\":0,\"interval\":100,\"repeat-for\":100},\"callback\":\\\{\"http\":\\\{\"uri\":\"localhost:80/callback2\",\"opaque\":\"stuff stuff stuff\"}},\"reliability\":\\\{\"cluster-view-id\":\"updated-cluster-view-id\",\"replicas\":\\\[\"10.0.0.1:9999\"],\"sites\":\\\[\"local_site_name\",\"remote_site_1_name\"]},\"statistics\":\\\{\"tag-info\":\\\[\\\{\"type\":\"TAG2\",\"count\":1}]}}}]}";
+  std::string exp_rsp = "\\\{\"Timers\":\\\[\\\{\"TimerID\":2,\"OldReplicas\":\\\[\"10.0.0.1:9999\"],\"Timer\":\\\{\"timing\":\\\{\"start-time\".*,\"start-time-delta\".*,\"sequence-number\":0,\"interval\":100,\"repeat-for\":100},\"callback\":\\\{\"http\":\\\{\"uri\":\"http://localhost:80/callback2\",\"opaque\":\"stuff stuff stuff\"}},\"reliability\":\\\{\"cluster-view-id\":\"updated-cluster-view-id\",\"replicas\":\\\[\"10.0.0.1:9999\"],\"sites\":\\\[\"local_site_name\",\"remote_site_1_name\"]},\"statistics\":\\\{\"tag-info\":\\\[\\\{\"type\":\"TAG2\",\"count\":1}]}}}]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
   EXPECT_EQ(rc, 206);
 }
@@ -1519,7 +1519,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeInformationalTimers)
   // (so there's still a body)
   std::string get_response;
   int rc = _th->get_timers_for_node("10.0.0.1:9999", 2, updated_cluster_view_id, get_response);
-  std::string exp_rsp = "\\\{\"Timers\":\\\[\\\{\"TimerID\":1,\"OldReplicas\":\\\[\"10.0.0.1:9999\"],\"Timer\":\\\{\"timing\":\\\{\"start-time\".*,\"start-time-delta\".*,\"sequence-number\":0,\"interval\":100,\"repeat-for\":100},\"callback\":\\\{\"http\":\\\{\"uri\":\"localhost:80/callback1\",\"opaque\":\"stuff stuff stuff\"}},\"reliability\":\\\{\"cluster-view-id\":\"updated-cluster-view-id\",\"replicas\":\\\[\"10.0.0.1:9999\"],\"sites\":\\\[\"local_site_name\",\"remote_site_1_name\"]},\"statistics\":\\\{\"tag-info\":\\\[\\\{\"type\":\"TAG1\",\"count\":1}]}}}]}";
+  std::string exp_rsp = "\\\{\"Timers\":\\\[\\\{\"TimerID\":1,\"OldReplicas\":\\\[\"10.0.0.1:9999\"],\"Timer\":\\\{\"timing\":\\\{\"start-time\".*,\"start-time-delta\".*,\"sequence-number\":0,\"interval\":100,\"repeat-for\":100},\"callback\":\\\{\"http\":\\\{\"uri\":\"http://localhost:80/callback1\",\"opaque\":\"stuff stuff stuff\"}},\"reliability\":\\\{\"cluster-view-id\":\"updated-cluster-view-id\",\"replicas\":\\\[\"10.0.0.1:9999\"],\"sites\":\\\[\"local_site_name\",\"remote_site_1_name\"]},\"statistics\":\\\{\"tag-info\":\\\[\\\{\"type\":\"TAG1\",\"count\":1}]}}}]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
   EXPECT_EQ(rc, 200);
 }

--- a/src/ut/timer_helper.cpp
+++ b/src/ut/timer_helper.cpp
@@ -50,7 +50,7 @@ Timer* default_timer(TimerID id)
   timer->sites = std::vector<std::string>(1, "local_site_name");
   timer->sites.push_back("remote_site_1_name");
   timer->tags = std::map<std::string, uint32_t> {{"TAG" + std::to_string(id), 1}};
-  timer->callback_url = "localhost:80/callback" + std::to_string(id);
+  timer->callback_url = "http://localhost:80/callback" + std::to_string(id);
   timer->callback_body = "stuff stuff stuff";
   timer->_replica_tracker = 1;
   timer->_replication_factor = 1;


### PR DESCRIPTION
Ellie,

Please can you review this enhancement to make HttpCallback use HttpClient rather than curl.  This gives us better retry behavior on failure.

This pull request also includes moving the internal connection to use HttpClient, rather than HttpConnection (and it's override_server function) as we think that might be thread-unsafe.

UTs pass, but not live-tested yet.

Matt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metaswitch/chronos/288)
<!-- Reviewable:end -->
