### PR TITLE
[Reviewer: Rob] Add time-from parameter parsing

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -182,11 +182,14 @@ Resynchronizing timers between nodes is carried out by each Chronos node sending
 
 This URL requests information about timers that are on the receiving node that the requesting node will be a replica for under new cluster configuration.
 
-It takes three mandatory parameters
+It takes two mandatory parameters
 
 * `node-for-replicas=<address>` - The address of the node to check for replica status (typically the requesting node). This must match a node in the Chronos cluster
-* `sync-mode=<sync-mode>` - The synchronization mode. The only currently supported value is SCALE.
 * `cluster-view-id=<cluster-view-id>` - The requesting node's view of the current cluster configuration.
+
+There is one optional parameter
+
+* `time-from=<time-from>` - The receiving node should only send information about timers that are due to pop after this time (absolute time, in microseconds since the epoch).
 
 The request should also include a `Range` header, holding how many timers should be returned in one response, e.g.:
 
@@ -198,7 +201,6 @@ If the GET is missing any of the mandatory parameters or any of the mandatory pa
 
 * Any of the mandatory parameters are missing - `400 Bad Request`
 * The requesting-node address doesn't correspond to a Chronos node in the cluster - `404 Not Found`
-* The sync-mode requested is isn't a supported mode - `400 Bad Request`
 * The cluster-view-id supplied by the requesting node doesn't match the receiving node's view of the cluster ID - `400 Bad Request`
 
 The response to a valid GET request is a `200 OK` or a `206 Partial Content`, with a JSON body containing timer information. A `206` is sent instead of a `200` if there are more timers that could be sent, but aren't because of the maximum timer limit. The 206 response includes a `Content-Range` header that shows how many timers were included (e.g. `Content-Range: 100`)

--- a/include/chronos_internal_connection.h
+++ b/include/chronos_internal_connection.h
@@ -98,8 +98,8 @@ private:
   // Sends a get request
   virtual HTTPCode send_get(const std::string& server,
                             const std::string& requesting_node,
-                            const std::string& sync_mode,
                             std::string cluster_view_id,
+                            uint64_t time_from,
                             int max_timers,
                             std::string& response);
 

--- a/include/constants.h
+++ b/include/constants.h
@@ -52,6 +52,7 @@ static const char* const JSON_OLD_REPLICAS = "OldReplicas";
 // Parameters
 static const char* const PARAM_NODE_FOR_REPLICAS = "node-for-replicas";
 static const char* const PARAM_SYNC_MODE = "sync-mode";
+static const char* const PARAM_TIME_FROM = "time-from";
 static const char* const PARAM_CLUSTER_VIEW_ID = "cluster-view-id";
 
 // Parameter values

--- a/include/timer_handler.h
+++ b/include/timer_handler.h
@@ -74,6 +74,7 @@ public:
   virtual HTTPCode get_timers_for_node(std::string node,
                                        int max_responses,
                                        std::string cluster_view_id,
+                                       uint64_t time_from,
                                        std::string& get_response);
   void run();
 

--- a/src/chronos_internal_connection.cpp
+++ b/src/chronos_internal_connection.cpp
@@ -188,6 +188,7 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
   std::string cluster_view_id;
   __globals->get_cluster_view_id(cluster_view_id);
 
+  uint64_t time_from = 0;
   std::string response;
   HTTPCode rc;
 
@@ -198,8 +199,8 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
 
     rc = send_get(server_to_sync,
                   localhost,
-                  PARAM_SYNC_MODE_VALUE_SCALE,
                   cluster_view_id,
+                  time_from,
                   MAX_TIMERS_IN_RESPONSE,
                   response);
 
@@ -282,6 +283,9 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
               delete timer; timer = NULL;
               continue;
             }
+
+            // Update our view of the newest timer we've processed
+            time_from = timer->next_pop_time();
 
             // Decide what we're going to do with this timer.
             int old_level = 0;
@@ -472,15 +476,16 @@ HTTPCode ChronosInternalConnection::send_delete(const std::string& server,
 
 HTTPCode ChronosInternalConnection::send_get(const std::string& server,
                                              const std::string& node_for_replicas_param,
-                                             const std::string& sync_mode_param,
                                              std::string cluster_view_id_param,
+                                             uint64_t time_from_param,
                                              int max_timers,
                                              std::string& response)
 {
   std::string path = std::string("/timers?") +
                      PARAM_NODE_FOR_REPLICAS + "="  + node_for_replicas_param + ";" +
-                     PARAM_SYNC_MODE + "=" + sync_mode_param + ";" +
-                     PARAM_CLUSTER_VIEW_ID + "="  + cluster_view_id_param;
+                     PARAM_SYNC_MODE + "=" + PARAM_SYNC_MODE_VALUE_SCALE + ";" +
+                     PARAM_CLUSTER_VIEW_ID + "="  + cluster_view_id_param + ";" +
+                     PARAM_TIME_FROM + "=" + std::to_string(time_from_param);
 
   std::string range_header = std::string(HEADER_RANGE) + ":" +
                              std::to_string(MAX_TIMERS_IN_RESPONSE);

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -240,18 +240,15 @@ void ControllerTask::handle_delete()
 
 void ControllerTask::handle_get()
 {
-  // Check the request is valid. It must have the node-for-replicas,
-  // sync-mode and cluster-view-id parameters set, the sync-mode parameter
-  // must be SCALE (this will be extended later), the request-node
+  // Check the request is valid. It must have the node-for-replicas
+  // and cluster-view-id parameters set, the request-node
   // must correspond to a node in the Chronos cluster (it can be a
   // leaving node), and the cluster-view-id request must correspond to
   // the receiving nodes view of the cluster configuration
   std::string node_for_replicas = _req.param(PARAM_NODE_FOR_REPLICAS);
-  std::string sync_mode = _req.param(PARAM_SYNC_MODE);
   std::string cluster_view_id = _req.param(PARAM_CLUSTER_VIEW_ID);
 
   if ((node_for_replicas == "") ||
-      (sync_mode == "") ||
       (cluster_view_id == ""))
   {
     TRC_INFO("GET request doesn't have mandatory parameters");
@@ -279,31 +276,28 @@ void ControllerTask::handle_get()
     return;
   }
 
-  if (sync_mode == PARAM_SYNC_MODE_VALUE_SCALE)
+  std::string max_timers_from_req = _req.header(HEADER_RANGE);
+  int max_timers_to_get = atoi(max_timers_from_req.c_str());
+  TRC_DEBUG("Range value is %d", max_timers_to_get);
+
+  std::string time_from_str = _req.param(PARAM_TIME_FROM);
+  uint64_t time_from = atoi(time_from_str.c_str());
+  TRC_DEBUG("Time-from value is %d", time_from);
+
+  std::string get_response;
+  HTTPCode rc = _cfg->_handler->get_timers_for_node(node_for_replicas,
+                                                    max_timers_to_get,
+                                                    cluster_view_id,
+                                                    time_from,
+                                                    get_response);
+  _req.add_content(get_response);
+
+  if (rc == HTTP_PARTIAL_CONTENT)
   {
-    std::string max_timers_from_req = _req.header(HEADER_RANGE);
-    int max_timers_to_get = atoi(max_timers_from_req.c_str());
-    TRC_DEBUG("Range value is %d", max_timers_to_get);
-
-    std::string get_response;
-    HTTPCode rc = _cfg->_handler->get_timers_for_node(node_for_replicas,
-                                                      max_timers_to_get,
-                                                      cluster_view_id,
-                                                      get_response);
-    _req.add_content(get_response);
-
-    if (rc == HTTP_PARTIAL_CONTENT)
-    {
-      _req.add_header(HEADER_CONTENT_RANGE, max_timers_from_req);
-    }
-
-    send_http_reply(rc);
+    _req.add_header(HEADER_CONTENT_RANGE, max_timers_from_req);
   }
-  else
-  {
-    TRC_DEBUG("Sync mode is unsupported: %s", sync_mode.c_str());
-    send_http_reply(HTTP_BAD_REQUEST);
-  }
+
+  send_http_reply(rc);
 }
 
 bool ControllerTask::node_is_in_cluster(std::string node_for_replicas)

--- a/src/timer_handler.cpp
+++ b/src/timer_handler.cpp
@@ -437,8 +437,13 @@ void TimerHandler::update_replica_tracker_for_timer(TimerID id,
 HTTPCode TimerHandler::get_timers_for_node(std::string request_node,
                                            int max_responses,
                                            std::string cluster_view_id,
+                                           uint64_t time_from,
                                            std::string& get_response)
 {
+  // We pass in the time_from parameter from the handlers. We will use this
+  // parameter in the future to help with resynchronisation operations. We
+  // pass it into the timer handler now to help with UTing the handler code
+
   pthread_mutex_lock(&_mutex);
 
   // Create the JSON doc for the Timer information

--- a/src/ut/mock_timer_handler.h
+++ b/src/ut/mock_timer_handler.h
@@ -49,9 +49,10 @@ public:
   MOCK_METHOD1(handle_successful_callback,void(TimerID));
   MOCK_METHOD1(handle_failed_callback,void(TimerID));
   MOCK_METHOD2(update_replica_tracker_for_timer, void(TimerID, int));
-  MOCK_METHOD4(get_timers_for_node, HTTPCode(std::string request_node,
+  MOCK_METHOD5(get_timers_for_node, HTTPCode(std::string request_node,
                                              int max_responses,
                                              std::string cluster_view_id,
+                                             uint64_t time_from,
                                              std::string& get_response));
 };
 

--- a/src/ut/test_chronos_internal_connection.cpp
+++ b/src/ut/test_chronos_internal_connection.cpp
@@ -116,22 +116,22 @@ TEST_F(TestChronosInternalConnection, SendDelete)
 
 TEST_F(TestChronosInternalConnection, SendGet)
 {
-  fakecurl_responses["http://10.42.42.42:80/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = CURLE_OK;
+  fakecurl_responses["http://10.42.42.42:80/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id;time-from=10000"] = CURLE_OK;
   std::string response;
-  HTTPCode status = _chronos->send_get("10.42.42.42:80", "10.0.0.1:9999", "SCALE", "cluster-view-id", 0, response);
+  HTTPCode status = _chronos->send_get("10.42.42.42:80", "10.0.0.1:9999", "cluster-view-id", 10000, 0, response);
   EXPECT_EQ(status, 200);
 }
 
 TEST_F(TestChronosInternalConnection, SendTriggerNoResults)
 {
-  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = "{\"Timers\":[]}";
+  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id;time-from=0"] = "{\"Timers\":[]}";
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(status, 200);
 }
 
 TEST_F(TestChronosInternalConnection, SendTriggerOneTimer)
 {
-  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.3:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}";
+  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id;time-from=0"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.3:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}";
   fakecurl_responses["http://10.42.42.42:9999/timers/references"] = HTTP_ACCEPTED;
   Timer* added_timer;
 
@@ -154,7 +154,7 @@ TEST_F(TestChronosInternalConnection, SendTriggerOneTimerWithTombstoneAndLeaving
   __globals->set_cluster_leaving_addresses(leaving_cluster_addresses);
   _cluster_addresses.push_back("10.0.0.4:9999");
 
-  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.4:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}";
+  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id;time-from=0"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.4:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}";
   fakecurl_responses["http://10.42.42.42:9999/timers/references"] = HTTP_ACCEPTED;
   Timer* added_timer;
 
@@ -182,7 +182,7 @@ TEST_F(TestChronosInternalConnection, ResynchronizeWithTimers)
 
   // Timers from 10.0.0.2/10.0.0.3/10.0.0.4 - One timer that's having its replica list reordered.
   // This isn't a valid response (as it should be different for .2/.3/.4), but it's sufficient
-  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.1:9999\", \"10.0.0.2:9999\", \"10.0.0.3:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.3:9999\", \"10.0.0.1:9999\", \"10.0.0.2:9999\" ] }}}]}";
+  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id;time-from=0"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.1:9999\", \"10.0.0.2:9999\", \"10.0.0.3:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.3:9999\", \"10.0.0.1:9999\", \"10.0.0.2:9999\" ] }}}]}";
 
   // Delete response
   fakecurl_responses["http://10.42.42.42:9999/timers/references"] = HTTP_SERVER_UNAVAILABLE;
@@ -204,7 +204,7 @@ TEST_F(TestChronosInternalConnection, ResynchronizeWithTimers)
 TEST_F(TestChronosInternalConnection, ResynchronizeWithInvalidGetResponse)
 {
   // Response has invalid JSON
-  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = "{\"Timers\":}";
+  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id;time-from=0"] = "{\"Timers\":}";
 
   // There should be no calls to add/replicate a timer
   EXPECT_CALL(*_th, add_timer(_,_)).Times(0);
@@ -215,7 +215,7 @@ TEST_F(TestChronosInternalConnection, ResynchronizeWithInvalidGetResponse)
 TEST_F(TestChronosInternalConnection, ResynchronizeWithGetRequestFailed)
 {
   // GET request fails
-  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = HTTP_BAD_REQUEST;
+  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id;time-from=0"] = HTTP_BAD_REQUEST;
 
   // There should be no calls to add/replicate a timer
   EXPECT_CALL(*_th, add_timer(_,_)).Times(0);
@@ -225,42 +225,42 @@ TEST_F(TestChronosInternalConnection, ResynchronizeWithGetRequestFailed)
 
 TEST_F(TestChronosInternalConnection, SendTriggerInvalidResultsInvalidJSON)
 {
-  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = "{\"Timers\":]}";
+  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id;time-from=0"] = "{\"Timers\":]}";
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(status, 400);
 }
 
 TEST_F(TestChronosInternalConnection, SendTriggerInvalidResultsNoTimers)
 {
-  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = "{\"Timer\":[]}";
+  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id;time-from=0"] = "{\"Timer\":[]}";
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(status, 400);
 }
 
 TEST_F(TestChronosInternalConnection, SendTriggerInvalidEntryNoTimerObject)
 {
-  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = "{\"Timers\":[\"Timer\"]}";
+  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id;time-from=0"] = "{\"Timers\":[\"Timer\"]}";
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(status, 400);
 }
 
 TEST_F(TestChronosInternalConnection, SendTriggerInvalidEntryNoReplicas)
 {
-  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = "{\"Timers\":[{\"TimerID\":4}]}";
+  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id;time-from=0"] = "{\"Timers\":[{\"TimerID\":4}]}";
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(status, 400);
 }
 
 TEST_F(TestChronosInternalConnection, SendTriggerInvalidResultNoTimer)
 {
-  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"]}]}";
+  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id;time-from=0"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"]}]}";
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(status, 400);
 }
 
 TEST_F(TestChronosInternalConnection, SendTriggerInvalidResultInvalidTimers)
 {
-  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"], \"Timer\": {}}, {\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": {}}}]}";
+  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;sync-mode=SCALE;cluster-view-id=cluster-view-id;time-from=0"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"], \"Timer\": {}}, {\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": {}}}]}";
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(status, 400);
 }

--- a/src/ut/test_timer_handler.cpp
+++ b/src/ut/test_timer_handler.cpp
@@ -1236,7 +1236,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNode)
 
   // There should be one returned timer. We check this by matching the JSON
   std::string get_response;
-  int rc = _th->get_timers_for_node("10.0.0.1:9999", 2, updated_cluster_view_id, get_response);
+  int rc = _th->get_timers_for_node("10.0.0.1:9999", 2, updated_cluster_view_id, 0, get_response);
   std::string exp_rsp = "\\\{\"Timers\":\\\[\\\{\"TimerID\":1,\"OldReplicas\":\\\[\"10.0.0.1:9999\"],\"Timer\":\\\{\"timing\":\\\{\"start-time\".*,\"start-time-delta\".*,\"sequence-number\":0,\"interval\":100,\"repeat-for\":100},\"callback\":\\\{\"http\":\\\{\"uri\":\"localhost:80/callback1\",\"opaque\":\"stuff stuff stuff\"}},\"reliability\":\\\{\"cluster-view-id\":\"updated-cluster-view-id\",\"replicas\":\\\[\"10.0.0.1:9999\"]},\"statistics\":\\\{\"tag-info\":\\\[\\\{\"type\":\"TAG1\",\"count\":1}]}}}]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
   EXPECT_EQ(rc, 200);
@@ -1265,7 +1265,7 @@ TEST_F(TestTimerHandlerRealStore, SelectTimersNoMatchesReqNode)
   // Now just call get_timers_for_node (as if someone had done a resync without
   // changing the cluster configuration). No timers should be returned
   std::string get_response;
-  int rc = _th->get_timers_for_node("10.0.0.4:9999", 2, updated_cluster_view_id, get_response);
+  int rc = _th->get_timers_for_node("10.0.0.4:9999", 2, updated_cluster_view_id, 0, get_response);
   std::string exp_rsp = "\\\{\"Timers\":\\\[]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
   EXPECT_EQ(rc, 200);
@@ -1286,7 +1286,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeNoClusterChange)
   // Now just call get_timers_for_node (as if someone had done a resync without
   // changing the cluster configuration). No timers should be returned
   std::string get_response;
-  int rc = _th->get_timers_for_node("10.0.0.1:9999", 2, "cluster-view-id", get_response);
+  int rc = _th->get_timers_for_node("10.0.0.1:9999", 2, "cluster-view-id", 0, get_response);
   std::string exp_rsp = "\\\{\"Timers\":\\\[]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
   EXPECT_EQ(rc, 200);
@@ -1318,7 +1318,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeHitMaxResponses)
   __globals->unlock();
 
   std::string get_response;
-  int rc = _th->get_timers_for_node("10.0.0.1:9999", 1, updated_cluster_view_id, get_response);
+  int rc = _th->get_timers_for_node("10.0.0.1:9999", 1, updated_cluster_view_id, 0, get_response);
   std::string exp_rsp = "\\\{\"Timers\":\\\[\\\{\"TimerID\":2,\"OldReplicas\":\\\[\"10.0.0.1:9999\"],\"Timer\":\\\{\"timing\":\\\{\"start-time\".*,\"start-time-delta\".*,\"sequence-number\":0,\"interval\":100,\"repeat-for\":100},\"callback\":\\\{\"http\":\\\{\"uri\":\"localhost:80/callback2\",\"opaque\":\"stuff stuff stuff\"}},\"reliability\":\\\{\"cluster-view-id\":\"updated-cluster-view-id\",\"replicas\":\\\[\"10.0.0.1:9999\"]},\"statistics\":\\\{\"tag-info\":\\\[\\\{\"type\":\"TAG2\",\"count\":1}]}}}]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
   EXPECT_EQ(rc, 206);
@@ -1359,7 +1359,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeInformationalTimers)
   // Now call get_timers_for_node. This returns the informational timer
   // (so there's still a body)
   std::string get_response;
-  int rc = _th->get_timers_for_node("10.0.0.1:9999", 2, updated_cluster_view_id, get_response);
+  int rc = _th->get_timers_for_node("10.0.0.1:9999", 2, updated_cluster_view_id, 0, get_response);
   std::string exp_rsp = "\\\{\"Timers\":\\\[\\\{\"TimerID\":1,\"OldReplicas\":\\\[\"10.0.0.1:9999\"],\"Timer\":\\\{\"timing\":\\\{\"start-time\".*,\"start-time-delta\".*,\"sequence-number\":0,\"interval\":100,\"repeat-for\":100},\"callback\":\\\{\"http\":\\\{\"uri\":\"localhost:80/callback1\",\"opaque\":\"stuff stuff stuff\"}},\"reliability\":\\\{\"cluster-view-id\":\"updated-cluster-view-id\",\"replicas\":\\\[\"10.0.0.1:9999\"]},\"statistics\":\\\{\"tag-info\":\\\[\\\{\"type\":\"TAG1\",\"count\":1}]}}}]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
   EXPECT_EQ(rc, 200);


### PR DESCRIPTION
Add the time-from parameter to resync operations. This isn't used yet, but means that all nodes can accept/send time-from values.

Tested in UT

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metaswitch/chronos/291)
<!-- Reviewable:end -->
