### PR TITLE
[Reviewer: Sathiyan] Use bind port if there's no port specified

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -294,10 +294,13 @@ void Globals::update_config()
     }
     else
     {
-      TRC_STATUS("Configured remote site: %s", it->c_str());
-      remote_sites[site_details[0]] = site_details[1];
+      std::string remote_uri = Utils::uri_address(site_details[1], bind_port);
+      TRC_STATUS("Configured remote site: %s=%s",
+                 site_details[0].c_str(),
+                 remote_uri.c_str());
+      remote_sites[site_details[0]] = remote_uri;
       remote_site_names.push_back(site_details[0]);
-      remote_site_dns_records.push_back(site_details[1]);
+      remote_site_dns_records.push_back(remote_uri);
     }
   }
 

--- a/src/ut/test_globals.cpp
+++ b/src/ut/test_globals.cpp
@@ -205,10 +205,11 @@ TEST_F(TestGlobals, ParseGlobalsNotDefaults)
 
   // Site C will be stripped as it doesn't have an address, so we only expect
   // to see two entries. Site mysite will be stripped as it's the same as the
-  // local site.
+  // local site. Site b with have the bind port added to its URI as there's no
+  // existing port.
   EXPECT_EQ(remote_sites.size(), 2);
   EXPECT_EQ(remote_sites["a"], "foo.com:800");
-  EXPECT_EQ(remote_sites["b"], "bar.com");
+  EXPECT_EQ(remote_sites["b"], "bar.com:7254");
   EXPECT_EQ(remote_site_names.size(), 2);
   std::vector<std::string> expected_remote_site_names;
   expected_remote_site_names.push_back("a");
@@ -217,7 +218,7 @@ TEST_F(TestGlobals, ParseGlobalsNotDefaults)
   EXPECT_EQ(remote_site_dns_records.size(), 2);
   std::vector<std::string> expected_remote_site_dns_records;
   expected_remote_site_dns_records.push_back("foo.com:800");
-  expected_remote_site_dns_records.push_back("bar.com");
+  expected_remote_site_dns_records.push_back("bar.com:7254");
   EXPECT_THAT(expected_remote_site_dns_records, UnorderedElementsAreArray(remote_site_dns_records));
 
   delete test_global; test_global = NULL;


### PR DESCRIPTION
When parsing the remote site, add the bind port to the URI if there's no port there already

Fixes #298

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metaswitch/chronos/299)
<!-- Reviewable:end -->
