### PR TITLE
[Reviewer: Rob] Check for multiple timers

### DIFF
--- a/include/timer_handler.h
+++ b/include/timer_handler.h
@@ -72,7 +72,7 @@ public:
   virtual void handle_successful_callback(TimerID id);
   virtual void handle_failed_callback(TimerID id);
   virtual HTTPCode get_timers_for_node(std::string node,
-                                       int max_responses,
+                                       int max_rsps_with_unique_pop_time,
                                        std::string cluster_view_id,
                                        uint32_t time_from,
                                        std::string& get_response);

--- a/include/timer_store.h
+++ b/include/timer_store.h
@@ -116,15 +116,6 @@ public:
     uint32_t _time_from;
   };
 
-  class TSOverdueIterator : public TSOrderedTimerIterator
-  {
-  public:
-    TSOverdueIterator(TimerStore* ts, uint32_t time_from);
-    TSOverdueIterator& operator++();
-    Timer* operator*();
-    bool end() const;
-  };
-
   class TSShortWheelIterator : public TSOrderedTimerIterator
   {
   public:
@@ -176,7 +167,6 @@ class TSHeapIterator
   private:
     TimerStore* _ts;
     uint32_t _time_from;
-    TSOverdueIterator _overdue_it;
     TSShortWheelIterator _short_wheel_it;
     TSLongWheelIterator _long_wheel_it;
     TSHeapIterator _heap_it;

--- a/src/chronos_internal_connection.cpp
+++ b/src/chronos_internal_connection.cpp
@@ -292,7 +292,7 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
             }
 
             // Update our view of the newest timer we've processed
-            time_from = timer->next_pop_time() - current_time;
+            time_from = timer->next_pop_time() - current_time + 1;
 
             // Decide what we're going to do with this timer.
             int old_level = 0;

--- a/src/timer_handler.cpp
+++ b/src/timer_handler.cpp
@@ -329,12 +329,27 @@ HTTPCode TimerHandler::get_timers_for_node(std::string request_node,
   TRC_DEBUG("Get timers for %s", request_node.c_str());
 
   int retrieved_timers = 0;
+  uint32_t last_time_from = 0;
+  uint32_t current_time_from = 0;
 
   for (TimerStore::TSIterator it = _store->begin(time_from);
        !(it.end());
        ++it)
   {
     Timer* timer_copy = new Timer(**it);
+    current_time_from = timer_copy->next_pop_time();
+
+    // Break out of the for loop once we hit the maximum number of
+    // timers to collect, and we know that the next timer doesn't
+    // have the same pop time as our last timer
+    if ((retrieved_timers >= max_responses) &&
+        (last_time_from != 0) &&
+        (last_time_from != current_time_from))
+    {
+      TRC_DEBUG("Reached the max number of timers to collect");
+      delete timer_copy;
+      break;
+    }
 
     if (!timer_copy->is_tombstone())
     {
@@ -370,18 +385,12 @@ HTTPCode TimerHandler::get_timers_for_node(std::string request_node,
         writer.EndObject();
         retrieved_timers++;
       }
+
+      last_time_from = current_time_from;
     }
 
     // Tidy up the copy
     delete timer_copy;
-
-    // Break out of the for loop once we hit the maximum number of
-    // timers to collect
-    if (retrieved_timers == max_responses)
-    {
-      TRC_DEBUG("Reached the max number of timers to collect");
-      break;
-    }
   }
 
   writer.EndArray();
@@ -390,7 +399,7 @@ HTTPCode TimerHandler::get_timers_for_node(std::string request_node,
   pthread_mutex_unlock(&_mutex);
 
   TRC_DEBUG("Retrieved %d timers", retrieved_timers);
-  return (retrieved_timers == max_responses) ? HTTP_PARTIAL_CONTENT : HTTP_OK;
+  return (retrieved_timers >= max_responses) ? HTTP_PARTIAL_CONTENT : HTTP_OK;
 }
 
 bool TimerHandler::timer_is_on_node(std::string request_node,

--- a/src/timer_handler.cpp
+++ b/src/timer_handler.cpp
@@ -343,7 +343,6 @@ HTTPCode TimerHandler::get_timers_for_node(std::string request_node,
     // timers to collect, and we know that the next timer doesn't
     // have the same pop time as our last timer
     if ((retrieved_timers >= max_responses) &&
-        (last_time_from != 0) &&
         (last_time_from != current_time_from))
     {
       TRC_DEBUG("Reached the max number of timers to collect");

--- a/src/timer_handler.cpp
+++ b/src/timer_handler.cpp
@@ -307,7 +307,7 @@ void TimerHandler::handle_failed_callback(TimerID timer_id)
 }
 
 HTTPCode TimerHandler::get_timers_for_node(std::string request_node,
-                                           int max_responses,
+                                           int max_rsps_with_unique_pop_time,
                                            std::string cluster_view_id,
                                            uint32_t time_from,
                                            std::string& get_response)
@@ -342,7 +342,7 @@ HTTPCode TimerHandler::get_timers_for_node(std::string request_node,
     // Break out of the for loop once we hit the maximum number of
     // timers to collect, and we know that the next timer doesn't
     // have the same pop time as our last timer
-    if ((retrieved_timers >= max_responses) &&
+    if ((retrieved_timers >= max_rsps_with_unique_pop_time) &&
         (last_time_from != current_time_from))
     {
       TRC_DEBUG("Reached the max number of timers to collect");
@@ -398,7 +398,9 @@ HTTPCode TimerHandler::get_timers_for_node(std::string request_node,
   pthread_mutex_unlock(&_mutex);
 
   TRC_DEBUG("Retrieved %d timers", retrieved_timers);
-  return (retrieved_timers >= max_responses) ? HTTP_PARTIAL_CONTENT : HTTP_OK;
+  return (retrieved_timers >= max_rsps_with_unique_pop_time) ?
+                                        HTTP_PARTIAL_CONTENT :
+                                        HTTP_OK;
 }
 
 bool TimerHandler::timer_is_on_node(std::string request_node,

--- a/src/ut/test_chronos_internal_connection.cpp
+++ b/src/ut/test_chronos_internal_connection.cpp
@@ -188,7 +188,7 @@ TEST_F(TestChronosInternalConnection, RepeatedTimers)
   // The time-from in the second request should be based on the time of the
   // timer we received before. Use an empty body as we don't care about any
   // other timers in this test
-  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id;time-from=" + std::to_string(100000 - 235)] = Response(HTTP_OK, "{\"Timers\":[]}");
+  fakecurl_responses["http://10.42.42.42:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id;time-from=" + std::to_string(100000 - 235 + 1)] = Response(HTTP_OK, "{\"Timers\":[]}");
   fakecurl_responses["http://10.42.42.42:9999/timers/references"] = HTTP_ACCEPTED;
 
   // Save off the added timer so we can delete it (the add_timer call normally

--- a/src/ut/test_timer_handler.cpp
+++ b/src/ut/test_timer_handler.cpp
@@ -1080,6 +1080,8 @@ protected:
 // Test that getting timers for a node returns the set of timers
 TEST_F(TestTimerHandlerRealStore, GetTimersForNode)
 {
+  uint32_t current_time = Utils::get_time();
+
   // Add a single timer to the store
   Timer* timer1 = default_timer(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
@@ -1098,7 +1100,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNode)
 
   // There should be one returned timer. We check this by matching the JSON
   std::string get_response;
-  int rc = _th->get_timers_for_node("10.0.0.1:9999", 2, updated_cluster_view_id, 0, get_response);
+  int rc = _th->get_timers_for_node("10.0.0.1:9999", 2, updated_cluster_view_id, current_time, get_response);
  std::string exp_rsp = "\\\{\"Timers\":\\\[\\\{\"TimerID\":1,\"OldReplicas\":\\\[\"10.0.0.1:9999\"],\"Timer\":\\\{\"timing\":\\\{\"start-time\".*,\"start-time-delta\".*,\"sequence-number\":0,\"interval\":100,\"repeat-for\":100},\"callback\":\\\{\"http\":\\\{\"uri\":\"http://localhost:80/callback1\",\"opaque\":\"stuff stuff stuff\"}},\"reliability\":\\\{\"cluster-view-id\":\"updated-cluster-view-id\",\"replicas\":\\\[\"10.0.0.1:9999\"],\"sites\":\\\[\"local_site_name\",\"remote_site_1_name\"]},\"statistics\":\\\{\"tag-info\":\\\[\\\{\"type\":\"TAG1\",\"count\":1}]}}}]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
   EXPECT_EQ(rc, 200);
@@ -1108,6 +1110,8 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNode)
 // that trying to get the timers returns an empty list
 TEST_F(TestTimerHandlerRealStore, SelectTimersNoMatchesReqNode)
 {
+  uint32_t current_time = Utils::get_time();
+
   // Add a single timer to the store
   Timer* timer1 = default_timer(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
@@ -1127,7 +1131,7 @@ TEST_F(TestTimerHandlerRealStore, SelectTimersNoMatchesReqNode)
   // Now just call get_timers_for_node (as if someone had done a resync without
   // changing the cluster configuration). No timers should be returned
   std::string get_response;
-  int rc = _th->get_timers_for_node("10.0.0.4:9999", 2, updated_cluster_view_id, 0, get_response);
+  int rc = _th->get_timers_for_node("10.0.0.4:9999", 2, updated_cluster_view_id, current_time, get_response);
   std::string exp_rsp = "\\\{\"Timers\":\\\[]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
   EXPECT_EQ(rc, 200);
@@ -1137,6 +1141,8 @@ TEST_F(TestTimerHandlerRealStore, SelectTimersNoMatchesReqNode)
 // (up to the maximum requested)
 TEST_F(TestTimerHandlerRealStore, GetTimersForNodeNoClusterChange)
 {
+  uint32_t current_time = Utils::get_time();
+
   // Add a single timer to the store
   Timer* timer1 = default_timer(1);
   timer1->interval_ms = 100;
@@ -1148,7 +1154,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeNoClusterChange)
   // Now just call get_timers_for_node (as if someone had done a resync without
   // changing the cluster configuration). No timers should be returned
   std::string get_response;
-  int rc = _th->get_timers_for_node("10.0.0.1:9999", 2, "cluster-view-id", 0, get_response);
+  int rc = _th->get_timers_for_node("10.0.0.1:9999", 2, "cluster-view-id", current_time, get_response);
   std::string exp_rsp = "\\\{\"Timers\":\\\[]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
   EXPECT_EQ(rc, 200);
@@ -1158,6 +1164,8 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeNoClusterChange)
 // (up to the maximum requested)
 TEST_F(TestTimerHandlerRealStore, GetTimersForNodeHitMaxResponses)
 {
+  uint32_t current_time = Utils::get_time();
+
   // Add two timers to the store. Extend the length of the first timer
   // to ensure that we should always pick the second timer
   Timer* timer1 = default_timer(1);
@@ -1183,7 +1191,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeHitMaxResponses)
   __globals->unlock();
 
   std::string get_response;
-  int rc = _th->get_timers_for_node("10.0.0.1:9999", 1, updated_cluster_view_id, 0, get_response);
+  int rc = _th->get_timers_for_node("10.0.0.1:9999", 1, updated_cluster_view_id, current_time, get_response);
   std::string exp_rsp = "\\\{\"Timers\":\\\[\\\{\"TimerID\":2,\"OldReplicas\":\\\[\"10.0.0.1:9999\"],\"Timer\":\\\{\"timing\":\\\{\"start-time\".*,\"start-time-delta\".*,\"sequence-number\":0,\"interval\":100,\"repeat-for\":100},\"callback\":\\\{\"http\":\\\{\"uri\":\"http://localhost:80/callback2\",\"opaque\":\"stuff stuff stuff\"}},\"reliability\":\\\{\"cluster-view-id\":\"updated-cluster-view-id\",\"replicas\":\\\[\"10.0.0.1:9999\"],\"sites\":\\\[\"local_site_name\",\"remote_site_1_name\"]},\"statistics\":\\\{\"tag-info\":\\\[\\\{\"type\":\"TAG2\",\"count\":1}]}}}]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
   EXPECT_EQ(rc, 206);
@@ -1194,6 +1202,8 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeHitMaxResponses)
 // getting stuck in a loop).
 TEST_F(TestTimerHandlerRealStore, GetTimersForNodeMaxResponsesAndSamePopTime)
 {
+  uint32_t current_time = Utils::get_time();
+
   // Add three timers to the store with the same pop time, three that have
   // different pop times, and three tombstones.
   Timer* same_timer1 = default_timer(1);
@@ -1244,7 +1254,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeMaxResponsesAndSamePopTime)
   // same pop time. It shouldn't return any tombstones, even though they have
   // the same pop time.
   std::string get_response;
-  int rc = _th->get_timers_for_node("10.0.0.1:9999", 1, updated_cluster_view_id, 0, get_response);
+  int rc = _th->get_timers_for_node("10.0.0.1:9999", 1, updated_cluster_view_id, current_time, get_response);
 
   // Parse the response
   rapidjson::Document doc;
@@ -1274,6 +1284,8 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeMaxResponsesAndSamePopTime)
 // Test that getting timers from the long wheel orders by time correctly
 TEST_F(TestTimerHandlerRealStore, GetMultipleTimersFromLongWheel)
 {
+  uint32_t current_time = Utils::get_time();
+
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
 
@@ -1307,7 +1319,7 @@ TEST_F(TestTimerHandlerRealStore, GetMultipleTimersFromLongWheel)
   // There should be three timers - they should be ordered by the time to pop
   // (3,2,1), not ordered by time they were added.
   std::string get_response;
-  int rc = _th->get_timers_for_node("10.0.0.1:9999", 7, "cluster_view_id", 0, get_response);
+  int rc = _th->get_timers_for_node("10.0.0.1:9999", 7, "cluster_view_id", current_time, get_response);
 
   // We don't check the contents of the timers in this test - only check the
   // timer IDs so we can be sure that the timers were returned in the right
@@ -1327,6 +1339,8 @@ TEST_F(TestTimerHandlerRealStore, GetMultipleTimersFromLongWheel)
 // timers are spread out over all the data structures
 TEST_F(TestTimerHandlerRealStore, GetTimersForNodeFromAllStructures)
 {
+  uint32_t current_time = Utils::get_time();
+
   // Add a single timer that will end up in the long wheel
   Timer* timer1 = default_timer(1);
   EXPECT_CALL(*_mock_increment_table, increment(1)).Times(1);
@@ -1381,7 +1395,7 @@ TEST_F(TestTimerHandlerRealStore, GetTimersForNodeFromAllStructures)
   // There should be five timers - they should be ordered by the time to pop
   // (2,1,5,3,4), not ordered by time they were added.
   std::string get_response;
-  int rc = _th->get_timers_for_node("10.0.0.1:9999", 7, "cluster_view_id", 0, get_response);
+  int rc = _th->get_timers_for_node("10.0.0.1:9999", 7, "cluster_view_id", current_time, get_response);
 
   // We don't check the contents of the timers in this test - only check the
   // timer IDs so we can be sure that the timers were returned in the right


### PR DESCRIPTION
This PR
- Removes the overdue iterator as we no longer check for out of date timers.
- Checks if there are multiple timers with the same pop time, and returning all those timers even if we're over the maximum requested number of timers, to avoid getting stuck in a loop
- Fixes the UTs to use the current time rather than 0 when requesting timers. 

Tested live and in UTs.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metaswitch/chronos/308)

<!-- Reviewable:end -->
