### PR TITLE
[Reviewer: Adam] Use default port on deletes

### DIFF
--- a/src/chronos_internal_connection.cpp
+++ b/src/chronos_internal_connection.cpp
@@ -437,11 +437,15 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
       if (!delete_map.empty())
       {
         std::string delete_body = create_delete_body(delete_map);
+        int default_port;
+        __globals->get_bind_port(default_port);
+
         for (std::vector<std::string>::iterator it = cluster_nodes.begin();
                                                 it != cluster_nodes.end();
                                                 ++it)
         {
-          HTTPCode delete_rc = send_delete(*it, delete_body);
+          std::string delete_server = Utils::uri_address(*it, default_port);
+          HTTPCode delete_rc = send_delete(delete_server, delete_body);
           if (delete_rc != HTTP_ACCEPTED)
           {
             // We've received an error response to the DELETE request. There's

--- a/src/ut/base.cpp
+++ b/src/ut/base.cpp
@@ -51,14 +51,14 @@ void Base::SetUp()
   __globals->set_bind_address(localhost);
   std::vector<std::string> cluster_addresses;
   cluster_addresses.push_back("10.0.0.1:9999");
-  cluster_addresses.push_back("10.0.0.2:9999");
-  cluster_addresses.push_back("10.0.0.3:9999");
+  cluster_addresses.push_back("10.0.0.2");
+  cluster_addresses.push_back("10.0.0.3");
   __globals->set_cluster_staying_addresses(cluster_addresses);
   std::map<std::string, uint64_t> cluster_bloom_filters;
 
   cluster_bloom_filters["10.0.0.1:9999"] = 0x00010000010001;
-  cluster_bloom_filters["10.0.0.2:9999"] = 0x10001000001000;
-  cluster_bloom_filters["10.0.0.3:9999"] = 0x01000100000100;
+  cluster_bloom_filters["10.0.0.2"] = 0x10001000001000;
+  cluster_bloom_filters["10.0.0.3"] = 0x01000100000100;
   __globals->set_cluster_bloom_filters(cluster_bloom_filters);
   std::vector<uint32_t> cluster_rendezvous_hashes = __globals->generate_hashes(cluster_addresses);
   __globals->set_new_cluster_hashes(cluster_rendezvous_hashes);

--- a/src/ut/test_timer.cpp
+++ b/src/ut/test_timer.cpp
@@ -477,7 +477,7 @@ TEST_F(TestTimer, URLWithReplicas)
   __globals->get_timer_id_format(stored_timer_id);
 
   __globals->set_timer_id_format(new_timer_id);
-  EXPECT_EQ("http://hostname:9999/timers/00000001000000090010011000011001", t1->url("hostname:9999"));
+  EXPECT_EQ("http://hostname:9999/timers/00000001000000090000010000010001", t1->url("hostname:9999"));
   __globals->set_timer_id_format(stored_timer_id);
 }
 


### PR DESCRIPTION
Add the default port on deletes if the server doesn't have a default port. 

Tested in UTs - I've changed the default cluster addresses to a mix of with/without ports, and fixed up the UTs to accept this.

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metaswitch/chronos/309)

<!-- Reviewable:end -->
