### PR TITLE
[Reviewer: Ellie] Don't update info timer if there's an out of date active timer

### DIFF
--- a/include/timer_handler.h
+++ b/include/timer_handler.h
@@ -111,6 +111,13 @@ private:
   // Check to see if these two timestamps are within NETWORK_DELAY of each other
   bool near_time(uint32_t a, uint32_t b);
 
+  // For a given TimerPair, return:
+  // - the active timer if it doesn't match the cluster view id; else
+  // - the informational timer if it exists and doesn't match the cluster view id; else
+  // - NULL
+  // If a timer is returned, active_timer is set to true if it was the active
+  // timer of the TimerPair
+  Timer* get_out_of_date_timer(const TimerPair &pair, const std::string &cluster_view_id, bool &active_timer);
 
   TimerStore* _store;
   Callback* _callback;

--- a/include/timer_handler.h
+++ b/include/timer_handler.h
@@ -113,11 +113,14 @@ private:
 
   // For a given TimerPair, return:
   // - the active timer if it doesn't match the cluster view id; else
-  // - the informational timer if it exists and doesn't match the cluster view id; else
+  // - the informational timer if it exists and doesn't match the cluster view
+  //   id; else
   // - NULL
   // If a timer is returned, active_timer is set to true if it was the active
   // timer of the TimerPair
-  Timer* get_out_of_date_timer(const TimerPair &pair, const std::string &cluster_view_id, bool &active_timer);
+  Timer* get_out_of_date_timer(const TimerPair& pair,
+                               const std::string& cluster_view_id,
+                               bool& active_timer);
 
   TimerStore* _store;
   Callback* _callback;

--- a/src/timer_handler.cpp
+++ b/src/timer_handler.cpp
@@ -367,6 +367,28 @@ void TimerHandler::handle_failed_callback(TimerID timer_id)
   delete failed_pair.information_timer; failed_pair.information_timer = NULL;
 }
 
+Timer* TimerHandler::get_out_of_date_timer(const TimerPair &pair,
+                                           const std::string &cluster_view_id,
+                                           bool &active_timer)
+{
+  Timer* timer = NULL;
+
+  if ((pair.active_timer != NULL) &&
+      (!pair.active_timer->is_matching_cluster_view_id(cluster_view_id)))
+  {
+    timer = pair.active_timer;
+    active_timer = true;
+  }
+  else if ((pair.information_timer != NULL) &&
+      (!pair.information_timer->is_matching_cluster_view_id(cluster_view_id)))
+  {
+    timer = pair.information_timer;
+    active_timer = false;
+  }
+
+  return timer;
+}
+
 void TimerHandler::update_replica_tracker_for_timer(TimerID id,
                                                     int replica_index)
 {
@@ -376,26 +398,15 @@ void TimerHandler::update_replica_tracker_for_timer(TimerID id,
 
   if (timer_found)
   {
-    Timer* timer;
-    bool timer_in_wheel = true;
-
     std::string cluster_view_id;
     __globals->get_cluster_view_id(cluster_view_id);
 
-    if ((store_timers.information_timer == NULL) ||
-        (!store_timers.active_timer->is_matching_cluster_view_id(cluster_view_id)))
-    {
-      timer = store_timers.active_timer;
-    }
-    else
-    {
-      timer = store_timers.information_timer;
-      timer_in_wheel = false;
-    }
+    bool timer_in_wheel = true;
+    Timer* timer = get_out_of_date_timer(store_timers, cluster_view_id, timer_in_wheel);
 
-    if (!timer->is_matching_cluster_view_id(cluster_view_id))
+    if (timer != NULL)
     {
-      // The cluster view ID is out of date, so update the tracker.
+      // We have an out of date timer, so update the tracker.
       int remaining_replicas = timer->update_replica_tracker(replica_index);
 
       if (remaining_replicas == 0)
@@ -418,6 +429,7 @@ void TimerHandler::update_replica_tracker_for_timer(TimerID id,
       }
     }
 
+    // Put the timer back in the store
     uint32_t next_pop_time = store_timers.active_timer->next_pop_time();
 
     std::vector<std::string> cluster_view_id_vector;
@@ -465,14 +477,12 @@ HTTPCode TimerHandler::get_timers_for_node(std::string request_node,
   {
     Timer* timer_copy;
     TimerPair pair = *it;
+    bool active;
+    Timer* out_of_date = get_out_of_date_timer(pair, cluster_view_id, active);
 
-    if (!pair.active_timer->is_matching_cluster_view_id(cluster_view_id))
+    if (out_of_date != NULL)
     {
-      timer_copy = new Timer(*(pair.active_timer));
-    }
-    else if (pair.information_timer)
-    {
-      timer_copy = new Timer(*(pair.information_timer));
+      timer_copy = new Timer(*(out_of_date));
     }
     else
     {

--- a/src/timer_handler.cpp
+++ b/src/timer_handler.cpp
@@ -226,12 +226,12 @@ void TimerHandler::add_timer(Timer* timer, bool update_stats)
     TRC_DEBUG("Adding new timer");
   }
 
-  // Would be good in future work to pull all statistics logic out into a 
+  // Would be good in future work to pull all statistics logic out into a
   // separate statistics module, passing in new and old tags, and what is
   // happening to the timer (add, update, delete), to keep the timer_handler
   // scope of responsibility clear.
 
-  // Update statistics 
+  // Update statistics
   if (update_stats)
   {
     std::map<std::string, uint32_t> tags_to_add = std::map<std::string, uint32_t>();
@@ -299,7 +299,7 @@ void TimerHandler::return_timer(Timer* timer)
   // This would be for when a customer wants some information back from Chronos
   // immediately and only once, hence we should tombstone the timer after use.
   if (((timer->sequence_number + 1) * timer->interval_ms > timer->repeat_for) ||
-      ((timer->interval_ms == 0) && 
+      ((timer->interval_ms == 0) &&
        (timer->repeat_for == 0)))
   {
     // This timer won't pop again, so tombstone it and update statistics
@@ -379,7 +379,11 @@ void TimerHandler::update_replica_tracker_for_timer(TimerID id,
     Timer* timer;
     bool timer_in_wheel = true;
 
-    if (store_timers.information_timer == NULL)
+    std::string cluster_view_id;
+    __globals->get_cluster_view_id(cluster_view_id);
+
+    if ((store_timers.information_timer == NULL) ||
+        (!store_timers.active_timer->is_matching_cluster_view_id(cluster_view_id)))
     {
       timer = store_timers.active_timer;
     }
@@ -388,9 +392,6 @@ void TimerHandler::update_replica_tracker_for_timer(TimerID id,
       timer = store_timers.information_timer;
       timer_in_wheel = false;
     }
-
-    std::string cluster_view_id;
-    __globals->get_cluster_view_id(cluster_view_id);
 
     if (!timer->is_matching_cluster_view_id(cluster_view_id))
     {

--- a/src/ut/test_timer_handler.cpp
+++ b/src/ut/test_timer_handler.cpp
@@ -936,7 +936,7 @@ TEST_F(TestTimerHandlerAddAndReturn, ReturnTimerWontPopAgain)
 // Return a timer to the handler as if it has been passed back from
 // HTTPCallback and wont pop again. Give the timer an interval and
 // repeat_for value of 0. The timer should be tombstoned before
-// being put back into the store. 
+// being put back into the store.
 TEST_F(TestTimerHandlerAddAndReturn, TombstoneZeroIntervalAndRepeatForTimer)
 {
   Timer* timer = default_timer(1);
@@ -1160,6 +1160,34 @@ TEST_F(TestTimerHandlerAddAndReturn, UpdateReplicaTrackerValueForInformationTime
   // Delete the timer (this is normally done by the insert call, but this
   // is mocked out)
   delete insert_pair.active_timer;
+}
+
+// Test that if there's an out-of-date active timer, that's updated in
+// preferecnce to any informational timer.
+TEST_F(TestTimerHandlerAddAndReturn, UpdateReplicaTrackerValueForOldActiveTimerWithInfoTimer)
+{
+  // Set up the timers
+  Timer* timer_active = default_timer(1);
+  timer_active->_replica_tracker = 15;
+  timer_active->cluster_view_id = "different-id";
+  Timer* timer_info = default_timer(1);
+  timer_info->cluster_view_id = "different-id";
+  TimerPair insert_pair;
+  insert_pair.active_timer = timer_active;
+  insert_pair.information_timer = timer_info;
+
+  // Update the replica tracker. This should update the active timer.
+  EXPECT_CALL(*_store, fetch(timer_active->id, _)).
+                       WillOnce(DoAll(SetArgReferee<1>(insert_pair),Return(true)));
+  EXPECT_CALL(*_store, insert(_, timer_active->id, timer_active->next_pop_time(), _)).
+                       WillOnce(SaveArg<0>(&insert_pair));
+  _th->update_replica_tracker_for_timer(1u, 0);
+  ASSERT_EQ(0u, insert_pair.active_timer->_replica_tracker);
+
+  // Delete the timers (this is normally done by the insert call, but this
+  // is mocked out)
+  delete insert_pair.active_timer;
+  delete insert_pair.information_timer;
 }
 
 // Timer handler tests with a real timer store. This allows better tests of resync

--- a/src/ut/test_timer_handler.cpp
+++ b/src/ut/test_timer_handler.cpp
@@ -1178,7 +1178,7 @@ TEST_F(TestTimerHandlerAddAndReturn, UpdateReplicaTrackerValueForOldActiveTimerW
   insert_pair.information_timer = timer_info;
 
   // Update the replica tracker. This should update the active timer.
-  EXPECT_CALL(*_store, fetch(timer_active->id, _)).
+  EXPECT_CALL(*_store, fetch(_, _)).
                        WillOnce(DoAll(SetArgReferee<1>(insert_pair),Return(true)));
   EXPECT_CALL(*_store, insert(_, _, _, _)).
                        WillOnce(SaveArg<0>(&insert_pair));

--- a/src/ut/test_timer_handler.cpp
+++ b/src/ut/test_timer_handler.cpp
@@ -1163,7 +1163,7 @@ TEST_F(TestTimerHandlerAddAndReturn, UpdateReplicaTrackerValueForInformationTime
 }
 
 // Test that if there's an out-of-date active timer, that's updated in
-// preferecnce to any informational timer.
+// preference to any informational timer.
 TEST_F(TestTimerHandlerAddAndReturn, UpdateReplicaTrackerValueForOldActiveTimerWithInfoTimer)
 {
   // Set up the timers
@@ -1171,6 +1171,7 @@ TEST_F(TestTimerHandlerAddAndReturn, UpdateReplicaTrackerValueForOldActiveTimerW
   timer_active->_replica_tracker = 15;
   timer_active->cluster_view_id = "different-id";
   Timer* timer_info = default_timer(1);
+  timer_info->_replica_tracker = 15;
   timer_info->cluster_view_id = "different-id";
   TimerPair insert_pair;
   insert_pair.active_timer = timer_active;
@@ -1179,10 +1180,11 @@ TEST_F(TestTimerHandlerAddAndReturn, UpdateReplicaTrackerValueForOldActiveTimerW
   // Update the replica tracker. This should update the active timer.
   EXPECT_CALL(*_store, fetch(timer_active->id, _)).
                        WillOnce(DoAll(SetArgReferee<1>(insert_pair),Return(true)));
-  EXPECT_CALL(*_store, insert(_, timer_active->id, timer_active->next_pop_time(), _)).
+  EXPECT_CALL(*_store, insert(_, _, _, _)).
                        WillOnce(SaveArg<0>(&insert_pair));
   _th->update_replica_tracker_for_timer(1u, 0);
   ASSERT_EQ(0u, insert_pair.active_timer->_replica_tracker);
+  ASSERT_EQ(15u, insert_pair.information_timer->_replica_tracker);
 
   // Delete the timers (this is normally done by the insert call, but this
   // is mocked out)


### PR DESCRIPTION
When selecting a timer for updating the replica tracker, always choose an
out-of-date active timer in preference to any informational timer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metaswitch/chronos/316)
<!-- Reviewable:end -->
