### PR TITLE
[No reviewer] Move retrieve timer increment to the correct place

### DIFF
--- a/src/chronos_internal_connection.cpp
+++ b/src/chronos_internal_connection.cpp
@@ -117,12 +117,6 @@ void ChronosInternalConnection::resynchronize()
   // all the other nodes at the same time) and remove the local node
   srand(time(NULL));
   std::random_shuffle(cluster_nodes.begin(), cluster_nodes.end());
-  std::string localhost;
-  __globals->get_cluster_local_ip(localhost);
-  cluster_nodes.erase(std::remove(cluster_nodes.begin(),
-                                  cluster_nodes.end(),
-                                  localhost),
-                      cluster_nodes.end());
 
   // Start the scaling operation. Update the logs/stats/alarms
   if (_alarm)
@@ -136,6 +130,8 @@ void ChronosInternalConnection::resynchronize()
   int nodes_remaining = cluster_nodes.size();
   int default_port;
   __globals->get_bind_port(default_port);
+  std::string localhost;
+  __globals->get_cluster_local_ip(localhost);
 
   for (std::vector<std::string>::iterator it = cluster_nodes.begin();
                                           it != cluster_nodes.end();

--- a/src/timer_handler.cpp
+++ b/src/timer_handler.cpp
@@ -513,9 +513,9 @@ HTTPCode TimerHandler::get_timers_for_node(std::string request_node,
           timer_copy->to_json_obj(&writer);
         }
         writer.EndObject();
-      }
 
-      retrieved_timers++;
+        retrieved_timers++;
+      }
     }
 
     // Tidy up the copy

--- a/src/ut/test_chronos_internal_connection.cpp
+++ b/src/ut/test_chronos_internal_connection.cpp
@@ -226,8 +226,11 @@ TEST_F(TestChronosInternalConnection, ResynchronizeWithTimers)
   EXPECT_CALL(*_th, add_timer(_,_)).Times(0);
   // There are no calls to replicate to 10.0.0.3 as it is lower in the replica list
   EXPECT_CALL(*_replicator, replicate_timer_to_node(_, "10.0.0.3:9999")).Times(0);
-  // There are three calls to replicate to 10.0.0.2 as it is lower/equal in the old/new replica lists
-  EXPECT_CALL(*_replicator, replicate_timer_to_node(IsNotTombstone(), "10.0.0.2:9999")).Times(3);
+  // There are four calls to replicate to 10.0.0.2 as it is lower/equal in the
+  // old/new replica lists. (Note, you wouldn't expect to call this four times
+  // in the real code, this is just because each of the four resync calls returned
+  // the same timer).
+  EXPECT_CALL(*_replicator, replicate_timer_to_node(IsNotTombstone(), "10.0.0.2:9999")).Times(4);
   _chronos->resynchronize();
 
   _cluster_addresses.pop_back();

--- a/src/ut/test_timer_handler.cpp
+++ b/src/ut/test_timer_handler.cpp
@@ -1263,9 +1263,11 @@ TEST_F(TestTimerHandlerRealStore, SelectTimersNoMatchesReqNode)
   __globals->unlock();
 
   // Now just call get_timers_for_node (as if someone had done a resync without
-  // changing the cluster configuration). No timers should be returned
+  // changing the cluster configuration). No timers should be returned. Use
+  // a maximum timer count of 1, so that if this does pick up the single timer
+  // it would return 206, so we can detect that error in this UT as well.
   std::string get_response;
-  int rc = _th->get_timers_for_node("10.0.0.4:9999", 2, updated_cluster_view_id, 0, get_response);
+  int rc = _th->get_timers_for_node("10.0.0.4:9999", 1, updated_cluster_view_id, 0, get_response);
   std::string exp_rsp = "\\\{\"Timers\":\\\[]}";
   EXPECT_THAT(get_response, MatchesRegex(exp_rsp));
   EXPECT_EQ(rc, 200);


### PR DESCRIPTION
Only count a timer if we're going to send it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metaswitch/chronos/319)
<!-- Reviewable:end -->
