### PR TITLE
[Reviewer: Ellie] Don't treat HTTP error codes on callbacks as success

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,3 +47,4 @@ deb: build deb-only
 .PHONY: fv_test
 fv_test: build/bin/chronos
 	./scripts/chronos_resync.py
+	./scripts/chronos_pop.py

--- a/Makefile
+++ b/Makefile
@@ -47,4 +47,4 @@ deb: build deb-only
 .PHONY: fv_test
 fv_test: build/bin/chronos
 	./scripts/chronos_resync.py
-	./scripts/chronos_pop.py
+	./scripts/chronos_pop_errors.py

--- a/scripts/chronos_fv_test.py
+++ b/scripts/chronos_fv_test.py
@@ -70,9 +70,11 @@ chronos_nodes = [
     Node(ip='127.0.0.14', port='7256'),
 ]
 
-receiveCount = 0
+successReceiveCount = 0
+failureReceiveCount = 0
 processes = []
-timerCounts = []
+successTimerCounts = []
+failureTimerCounts = []
 
 # Create log folders for each Chronos process. These are useful for
 # debugging any problems. Running the tests deletes the logs from the
@@ -101,11 +103,30 @@ app = Flask(__name__)
 
 @app.route('/pop', methods=['POST'])
 def pop():
-    global receiveCount
-    receiveCount += 1
-    global timerCounts
-    timerCounts.append(request.data)
+    global successReceiveCount
+    successReceiveCount += 1
+    global successTimerCounts
+    successTimerCounts.append(request.data)
     return 'success'
+
+
+@app.route('/pop-with-errors', methods=['POST'])
+def pop_with_errors():
+    # The first time a timer pops, it fails with 503. Any other replicas will
+    # succeed
+    global successTimerCounts
+    global failureTimerCounts
+    global successReceiveCount
+    global failureReceiveCount
+
+    if request.data in failureTimerCounts:
+        successReceiveCount += 1
+        successTimerCounts.append(request.data)
+        return 'success'
+    else:
+        failureReceiveCount += 1
+        failureTimerCounts.append(request.data)
+        return flask.make_response("failure", 503)
 
 
 def run_app():
@@ -153,7 +174,7 @@ def node_trigger_scaling(lower, upper):
     sleep(2)
 
 
-def create_timers(target, num):
+def create_timers(target, num, path="pop", replicas=2):
     # Create and send timer requests. These are all sent to the first Chronos
     # process which will replicate the timers out to the other Chronos processes
     body_dict = {
@@ -163,9 +184,12 @@ def create_timers(target, num):
         },
         'callback': {
             'http': {
-                'uri': 'http://%s:%s/pop' % (flask_server.ip, flask_server.port),
+                'uri': 'http://%s:%s/%s' % (flask_server.ip, flask_server.port, path),
                 'opaque': 'REPLACE',
             }
+        },
+        'reliability': {
+            'replication-factor': replicas
         }
     }
 
@@ -228,12 +252,16 @@ class ChronosFVTest(unittest.TestCase):
 
     def setUp(self):
         # Track the Chronos processes and timer pops
-        global receiveCount
+        global successReceiveCount
+        global failureReceiveCount
         global processes
-        global timerCounts
-        receiveCount = 0
+        global successTimerCounts
+        global failureTimerCounts
+        successReceiveCount = 0
+        failureReceiveCount = 0
         processes = []
-        timerCounts = []
+        successTimerCounts = []
+        failureTimerCounts = []
 
     def tearDown(self):
         # Kill all the Chronos processes
@@ -245,13 +273,26 @@ class ChronosFVTest(unittest.TestCase):
         # Ideally, we'd be checking where the timers popped from, but that's
         # not possible with these tests (as everything looks like it comes
         # from 127.0.0.1)
-        self.assertEqual(receiveCount,
+        self.assertEqual(successReceiveCount,
                          expected_number,
                          ('Incorrect number of popped timers: received %i, expected exactly %i' %
-                         (receiveCount, expected_number)))
+                         (successReceiveCount, expected_number)))
 
         for i in range(expected_number):
-            assert str(i) in timerCounts, "Missing timer pop for %i" % i
+            assert str(i) in successTimerCounts, "Missing timer pop for %i" % i
+
+
+    def assert_correct_timers_failed(self, expected_number):
+        # Check that the expected number of timers failed.
+        # This should be as many as were added in the first place if using the
+        # "pop-with-errors" path.
+        self.assertEqual(failureReceiveCount,
+                         expected_number,
+                         ('Incorrect number of popped timers failed: actual %i, expected exactly %i' %
+                         (failureReceiveCount, expected_number)))
+
+        for i in range(expected_number):
+            assert str(i) in failureTimerCounts, "Missing timer failure for %i" % i
 
     def write_config_for_nodes(self, staying, joining=[], leaving=[]):
         # Write configuration files for the nodes

--- a/scripts/chronos_pop.py
+++ b/scripts/chronos_pop.py
@@ -42,12 +42,15 @@ sys.path.append(path.dirname(path.abspath(__file__)))
 from chronos_fv_test import ChronosFVTest, start_nodes, create_timers, chronos_nodes, node_reload_config
 
 # Test that Chronos correctly handles responses to its timer pops
-class ChronosPopTest(ChronosFVTest):
+class ChronosPopReceivesErrorTest(ChronosFVTest):
 
     def test_replicas(self):
         # Test that Chronos replicas pop correctly. This test creates 3 Chronos
         # nodes and adds 100 timers that will get 503 errors on their first pop
         # and successes on subsequent pops.
+        # We expect that the primary replica for each timer will get a 503
+        # error, so the secondary replica will pop and succeed, which should
+        # prevent the tertiary replica from popping.
         # The test checks that we get 100 successful pops and 100 failed pops.
 
         # Start initial nodes and add timers

--- a/scripts/chronos_pop.py
+++ b/scripts/chronos_pop.py
@@ -1,0 +1,65 @@
+#! /usr/bin/python2.7
+
+# @file chronos_pop.py
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2016  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+import unittest
+from time import sleep
+
+from os import sys, path
+sys.path.append(path.dirname(path.abspath(__file__)))
+from chronos_fv_test import ChronosFVTest, start_nodes, create_timers, chronos_nodes, node_reload_config
+
+# Test that Chronos correctly handles responses to its timer pops
+class ChronosPopTest(ChronosFVTest):
+
+    def test_replicas(self):
+        # Test that Chronos replicas pop correctly. This test creates 3 Chronos
+        # nodes and adds 100 timers that will get 503 errors on their first pop
+        # and successes on subsequent pops.
+        # The test checks that we get 100 successful pops and 100 failed pops.
+
+        # Start initial nodes and add timers
+        self.write_config_for_nodes([0,1,2])
+        start_nodes(0, 3)
+        create_timers(chronos_nodes[0], 100, "pop-with-errors", 3)
+
+        # Check that all the timers have popped
+        sleep(16)
+        self.assert_correct_timers_received(100)
+        self.assert_correct_timers_failed(100)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/chronos_pop_errors.py
+++ b/scripts/chronos_pop_errors.py
@@ -1,6 +1,6 @@
 #! /usr/bin/python2.7
 
-# @file chronos_pop.py
+# @file chronos_pop_errors.py
 #
 # Project Clearwater - IMS in the Cloud
 # Copyright (C) 2016  Metaswitch Networks Ltd
@@ -42,9 +42,9 @@ sys.path.append(path.dirname(path.abspath(__file__)))
 from chronos_fv_test import ChronosFVTest, start_nodes, create_timers, chronos_nodes, node_reload_config
 
 # Test that Chronos correctly handles responses to its timer pops
-class ChronosPopReceivesErrorTest(ChronosFVTest):
+class ChronosPopErrorTest(ChronosFVTest):
 
-    def test_replicas(self):
+    def test_503_errors(self):
         # Test that Chronos replicas pop correctly. This test creates 3 Chronos
         # nodes and adds 100 timers that will get 503 errors on their first pop
         # and successes on subsequent pops.

--- a/src/http_callback.cpp
+++ b/src/http_callback.cpp
@@ -147,13 +147,10 @@ void HTTPCallback::worker_thread_entry_point()
     }
     else
     {
-      if (curl_rc == CURLE_HTTP_RETURNED_ERROR)
-      {
-        TRC_DEBUG("Got HTTP error %d from %s", http_rc, callback_url.c_str());
-      }
-
-      TRC_DEBUG("Failed to process callback for %lu: URL %s, curl error was: %s", timer_id,
+      TRC_DEBUG("Failed to process callback for %lu: URL %s, HTTP return code %d, curl error was: %s",
+                timer_id,
                 callback_url.c_str(),
+                http_rc,
                 curl_easy_strerror(curl_rc));
 
       // The callback failed, and so we need to remove the timer from the store.

--- a/src/http_callback.cpp
+++ b/src/http_callback.cpp
@@ -136,7 +136,10 @@ void HTTPCallback::worker_thread_entry_point()
     // Send the request
     CURLcode curl_rc = curl_easy_perform(curl);
 
-    if (curl_rc == CURLE_OK)
+    long http_rc = 0;
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_rc);
+
+    if ((curl_rc == CURLE_OK) && (http_rc < 400))
     {
       // The callback succeeded, so we need to re-find the timer, and replicate it.
       TRC_DEBUG("Callback for timer \"%lu\" was successful", timer_id);
@@ -146,8 +149,6 @@ void HTTPCallback::worker_thread_entry_point()
     {
       if (curl_rc == CURLE_HTTP_RETURNED_ERROR)
       {
-        long http_rc = 0;
-        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_rc);
         TRC_DEBUG("Got HTTP error %d from %s", http_rc, callback_url.c_str());
       }
 


### PR DESCRIPTION
Fixes issue #312 

Testing done:
 - FV test
 - Live testing: created 2-sprout deployment, changed sprout on one node to return 503 responses, verified that the Subscription timeout and Registration timeout live tests failed before this fix and passed after

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metaswitch/chronos/320)
<!-- Reviewable:end -->
