### PR TITLE
[Reviewer: Ellie] More helpful error message if unable to parse config file

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -138,6 +138,17 @@ void Globals::update_config()
     file.close();
   }
 
+  // If we hit an error, log it to stderr and exit
+  if (error != "")
+  {
+    // LCOV_EXCL_START
+    fprintf(stderr, "Error parsing config file: %s \n %s",
+            error_config_file.c_str(),
+            error.c_str());
+    exit(1);
+    // LCOV_EXCL_STOP
+  }
+
   lock();
 
   // Set up the per node configuration. Set up logging early so we can
@@ -146,17 +157,6 @@ void Globals::update_config()
   Log::setLogger(new Logger(conf_map["logging.folder"].as<std::string>(), "chronos"));
   Log::setLoggingLevel(conf_map["logging.level"].as<int>());
 #endif
-
-  // We do error checking after trying to set up the logger, so that we have
-  // somewhere to log the error.
-  if (error != "")
-  {
-    // LCOV_EXCL_START
-    TRC_ERROR("Error parsing config file: %s", error_config_file.c_str());
-    TRC_ERROR(error.c_str());
-    exit(1);
-    // LCOV_EXCL_STOP
-  }
 
   std::string bind_address = conf_map["http.bind-address"].as<std::string>();
   set_bind_address(bind_address);


### PR DESCRIPTION
If we hit an exception trying to parse on of the config files, catch it and try to log a helpful error message to make it easier to diagnose what went wrong, then exit.

(If the problem was with logging config, we can't write a log)

Fixes #266 

Testing done:
- verified the live tests still pass 
- verified we get a helpful log message if there's a problem. The ouput we see is like:
> 24-11-2016 12:51:43.631 UTC Error globals.cpp:155: Error parsing config file: /etc/chronos/chronos.conf
> 24-11-2016 12:51:43.631 UTC Error globals.cpp:156: the argument ('7253A') for option 'port' is invalid

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metaswitch/chronos/322)
<!-- Reviewable:end -->
