### PR TITLE
[Reviewer: Ellie] Staying nodes shouldn't include localhost by default

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -61,9 +61,9 @@ Globals::Globals(std::string config_file,
   _desc.add_options()
     ("http.bind-address", po::value<std::string>()->default_value("0.0.0.0"), "Address to bind the HTTP server to")
     ("http.bind-port", po::value<int>()->default_value(7253), "Port to bind the HTTP server to")
-    ("cluster.localhost", po::value<std::string>()->default_value("localhost:7253"), "The address of the local host")
+    ("cluster.localhost", po::value<std::string>()->default_value("127.0.0.1:7253"), "The address of the local host")
     ("cluster.joining", po::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(), "HOST"), "The addresses of nodes in the cluster that are joining")
-    ("cluster.node", po::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(1, "localhost:7253"), "HOST"), "The addresses of nodes in the cluster that are staying")
+    ("cluster.node", po::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(), "HOST"), "The addresses of nodes in the cluster that are staying")
     ("cluster.leaving", po::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(), "HOST"), "The addresses of nodes in the cluster that are leaving")
     ("identity.instance_id", po::value<uint32_t>()->default_value(0), "A number between 0 and 127. The combination of instance ID and deployment ID should uniquely identify this node in the cluster, to remove the risk of timer collisions.")
     ("identity.deployment_id", po::value<uint32_t>()->default_value(0), "A number between 0 and 7. The combination of instance ID and deployment ID should uniquely identify this node in the cluster, to remove the risk of timer collisions.")
@@ -221,11 +221,21 @@ void Globals::update_config()
   std::vector<std::string> cluster_joining_addresses = conf_map["cluster.joining"].as<std::vector<std::string>>();
   set_cluster_joining_addresses(cluster_joining_addresses);
 
-  std::vector<std::string> cluster_staying_addresses = conf_map["cluster.node"].as<std::vector<std::string>>();
-  set_cluster_staying_addresses(cluster_staying_addresses);
-
   std::vector<std::string> cluster_leaving_addresses = conf_map["cluster.leaving"].as<std::vector<std::string>>();
   set_cluster_leaving_addresses(cluster_leaving_addresses);
+
+  std::vector<std::string> cluster_staying_addresses = conf_map["cluster.node"].as<std::vector<std::string>>();
+
+  // If there are no joining, staying or leaving addresses, add the local node
+  // to the staying nodes
+  if (cluster_staying_addresses.empty() &&
+      cluster_leaving_addresses.empty() &&
+      cluster_joining_addresses.empty())
+  {
+    cluster_staying_addresses.push_back(cluster_local_address);
+  }
+
+  set_cluster_staying_addresses(cluster_staying_addresses);
 
   // Figure out the new cluster by combining the nodes that are staying and the
   // nodes that are joining.

--- a/src/ut/test_globals.cpp
+++ b/src/ut/test_globals.cpp
@@ -80,12 +80,12 @@ TEST_F(TestGlobals, ParseGlobalsDefaults)
 
   std::string cluster_local_address;
   test_global->get_cluster_local_ip(cluster_local_address);
-  EXPECT_EQ(cluster_local_address, "localhost:7253");
+  EXPECT_EQ(cluster_local_address, "127.0.0.1:7253");
 
   std::vector<std::string> cluster_addresses;
   test_global->get_cluster_staying_addresses(cluster_addresses);
   EXPECT_EQ(cluster_addresses.size(), (unsigned)1);
-  EXPECT_EQ(cluster_addresses[0], "localhost:7253");
+  EXPECT_EQ(cluster_addresses[0], "127.0.0.1:7253");
 
   std::vector<std::string> cluster_joining_addresses;
   test_global->get_cluster_joining_addresses(cluster_joining_addresses);


### PR DESCRIPTION
rather, we should include the local node only if there are no other staying,
joining or leaving nodes

also, use loopback IP not localhost to remove the requirement for a localhost
DNS entry

Fixes #315

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/metaswitch/chronos/324)
<!-- Reviewable:end -->
