### PR TITLE
[Reviewer: Ellie] Fix Timer iterators

### DIFF
--- a/include/timer_store.h
+++ b/include/timer_store.h
@@ -125,6 +125,7 @@ public:
     bool end() const;
 
   private:
+    int _end_bucket;
     int _bucket;
     void next_bucket();
   };
@@ -138,6 +139,7 @@ public:
     bool end() const;
 
   private:
+    int _end_bucket;
     int _bucket;
     void next_bucket();
   };
@@ -301,6 +303,10 @@ private:
 
   // Refill the short timer wheel from the long wheel.
   void refill_short_wheel();
+
+  // Refill the short timer wheel using appropriate timers from the next bucket
+  // of the long wheel.
+  void refill_short_wheel_from_next_long_bucket();
 
   // Ensure a timer is no longer stored in the timer wheels.  This is an
   // expensive operation and should only be called when unsure of the timer

--- a/src/timer_store.cpp
+++ b/src/timer_store.cpp
@@ -342,8 +342,8 @@ void TimerStore::refill_short_wheel()
 
 // Refill the short timer wheel by distributing timers from the next bucket in
 // the long timer wheel.
-// Because not all timers in the next bucket will fit into the short wheel, we
-// check the time of each to decide if it should be moved.
+// Only timers due to pop within SHORT_WHEEL_PERIOD_MS should be moved from the
+// long bucket, so we check the time of each timer.
 void TimerStore::refill_short_wheel_from_next_long_bucket()
 {
   Bucket* long_bucket = long_wheel_bucket(_tick_timestamp + LONG_WHEEL_RESOLUTION_MS);

--- a/src/timer_store.cpp
+++ b/src/timer_store.cpp
@@ -529,6 +529,7 @@ void TimerStore::TSShortWheelIterator::next_bucket()
       if (_iterator == _ordered_timers.end())
       {
         _ordered_timers.clear();
+        _iterator = _ordered_timers.end();
         ++_bucket;
       }
       // LCOV_EXCL_STOP
@@ -609,6 +610,7 @@ void TimerStore::TSLongWheelIterator::next_bucket()
       if (_iterator == _ordered_timers.end())
       {
         _ordered_timers.clear();
+        _iterator = _ordered_timers.end();
         ++_bucket;
       }
       // LCOV_EXCL_STOP

--- a/src/ut/test_timer_store.cpp
+++ b/src/ut/test_timer_store.cpp
@@ -652,18 +652,20 @@ TYPED_TEST(TestTimerStore, IterateOverTimersInPreviousBuckets)
   std::unordered_set<Timer*> unused_set = std::unordered_set<Timer*>();
   TestFixture::ts->fetch_next_timers(unused_set);
 
-  // Add a timer that falls into the first bucket of the short wheel
+  // Add a timer that falls into the first bucket of the short wheel, "behind"
+  // the bucket we're currently pointed at.
   Timer* timer4 = default_timer(4);
   timer4->start_time_mono_ms = get_time_ms();
-  timer4->interval_ms =
-    TimerStore::SHORT_WHEEL_PERIOD_MS - TimerStore::SHORT_WHEEL_RESOLUTION_MS;
+  timer4->interval_ms = TimerStore::SHORT_WHEEL_PERIOD_MS -
+                        TimerStore::SHORT_WHEEL_RESOLUTION_MS;
   TestFixture::ts->insert(timer4);
 
-  // Add a timer that falls into the first bucket of the long wheel
+  // Add a timer that falls into the first bucket of the long wheel, "behind"
+  // the bucket we're currently pointed at.
   Timer* timer5 = default_timer(5);
   timer5->start_time_mono_ms = get_time_ms();
-  timer5->interval_ms =
-    TimerStore::LONG_WHEEL_PERIOD_MS - TimerStore::LONG_WHEEL_RESOLUTION_MS;
+  timer5->interval_ms = TimerStore::LONG_WHEEL_PERIOD_MS -
+                        TimerStore::LONG_WHEEL_RESOLUTION_MS;
   TestFixture::ts->insert(timer5);
 
   // Check that the iterator returns both timers
@@ -714,7 +716,8 @@ TYPED_TEST(TestTimerStore, IterateOverTimersRefillingWheel)
   // This once gets added directly to the short wheel.
   Timer* timer6 = default_timer(6);
   timer6->start_time_mono_ms = get_time_ms();
-  timer6->interval_ms = TimerStore::SHORT_WHEEL_PERIOD_MS - TimerStore::SHORT_WHEEL_RESOLUTION_MS * 1 / 4;
+  timer6->interval_ms = TimerStore::SHORT_WHEEL_PERIOD_MS -
+                        TimerStore::SHORT_WHEEL_RESOLUTION_MS * 1 / 4;
   TestFixture::ts->insert(timer6);
 
   // Now iterate over timers due to pop from now - should get all 3 in the order


### PR DESCRIPTION
This fixes an issue whereby the TSIterator could miss some timers, which meant that not all timers were replicated to the correct nodes when a resync happened.

### Issue
Chronos stores timers in either the short wheel, the long wheel or the heap. Each wheel is divided into buckets, and all timers in a short wheel bucket pop at once. As time advances, the short wheel is advanced. Once the end of the wheel is reached, all timers from the current bucket in the long wheel are moved into the short wheel, the short wheel starts from the beginning again and the long wheel is advanced. Once the end of the long wheel is reached, timers are moved into the long wheel from the heap and the long wheel starts from the beginning again.

The ISIterator is used to iterate through all timers, in order, from a specified point in time. TSIterator has a short wheel iterator, a long wheel iterator and a heap iterator. Before this change, for each of the wheel iterators, we would only ever iterate from the current bucket to the end of the wheel, i.e. the iterators are treating the wheels as linear, not circular (they're assuming there's nothing of value "earlier" in the wheel than where we're pointing).

When a timer is added, the following decision is made:
- if it's due to pop within the period of the short wheel from now, then add it to the appropriate bucket in the short wheel
- else if it's due to pop within the period of the long wheel from now, then add it to the appropriate bucket in the long wheel
- else add it to the heap

This means that inserting timers is (correctly) treating the wheels as circular.

The result is that, if a timer is added to the short wheel, and then we request the iterator for timers after a time which falls into a later bucket of the short wheel, then the iterator will never find that timer.

### Fix
To fix this,  when iterating through the wheels (for an iterator starting at bucket `X`, with the current time pointing at bucket `T` and the wheel having `N` buckets), instead of the old behaviour of iterating from `X` to `N`, we now iterate from `X` to `(T-1)`.

However, this leaves another problem which is that a timer `T1` may have been added at a time that it went into the long wheel, then some time later a timer `T2` is added that is due to pop after `T1` but is added to the short wheel. At this point, `T1` is still in the long wheel because we haven't yet refilled the short wheel from the long (which we will do before `T1` pops, so that's fine). In this case, if we try to iterate through the timers, we'll get `T2` ***before*** `T1`, because items in the short wheel's iterator are returned first.

To fix this problem, we refill each of the wheels when creating the iterator (which is OK from a performance perspective because we only do this on re-sync). However, the normal refill method for the short wheel assumes that everything in the current bucket of the long wheel should be moved across. This isn't true in this case, because we're refilling the wheel from a point that may be halfway through the cycle, so there may be timers in the long wheel bucket that can't fit yet. In addition, we have to fill from the ***next*** bucket of the long wheel, rather than the current bucket, because we're actually looking ahead.

For this reason, we add a new method `refill_short_wheel_from_next_long_bucket` to the store, which does exactly this and is only used when creating the iterators.

Also, there were a couple of places where we were doing overflow-unsafe comparisons of timers, which we shouldn't do, so those are fixed up to.

### Testing done
 - added UTs to test these various edge cases, that failed before this fix and pass after
 - ensured `make full_test` passed
 - ensured the fv tests pass