### PR TITLE
[Reviewer: Ellie] Ensure we're using the correct libs when running the FV tests

### DIFF
--- a/scripts/chronos_fv_test.py
+++ b/scripts/chronos_fv_test.py
@@ -56,6 +56,7 @@ import unittest
 # perform scaling operations, and check that the correct number of
 # timers still pop
 CHRONOS_BINARY = 'build/bin/chronos'
+CHRONOS_LIBS = 'usr/lib/'
 PID_PATTERN = 'scripts/pid/chronos.fvtest.%i.pid'
 CONFIG_FILE_PATTERN = 'scripts/log/chronos.fvtest.conf%i'
 CLUSTER_CONFIG_FILE_PATTERN = 'scripts/log/chronos.cluster.fvtest.conf%i'
@@ -138,13 +139,16 @@ def run_app():
 
 # Helper functions for the Chronos tests
 def start_nodes(lower, upper):
+    environment = os.environ.copy()
+    environment["LD_LIBRARY_PATH"] = CHRONOS_LIBS
+
     # Start nodes with indexes [lower, upper) and allow them time to start
     for i in range(lower, upper):
         Popen([CHRONOS_BINARY, '--daemon', '--pidfile', PID_PATTERN % i,
               '--config-file', CONFIG_FILE_PATTERN % i,
               '--cluster-config-file', CLUSTER_CONFIG_FILE_PATTERN % i,
               '--gr-config-file', GR_CONFIG_FILE_PATTERN % i],
-              stdout=FNULL, stderr=FNULL)
+              stdout=FNULL, stderr=FNULL, env=environment)
         sleep(2)
 
         f = open(PID_PATTERN % i)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -366,15 +366,6 @@ int main(int argc, char** argv)
                                            scalar_timers_table);
   callback->start(handler);
 
-  // Create a Chronos internal connection class for resynchronization operations.
-  ChronosInternalConnection* chronos_internal_connection =
-            new ChronosInternalConnection(http_resolver,
-                                          handler,
-                                          handler_rep,
-                                          resync_operation_alarm,
-                                          remaining_nodes_scalar,
-                                          timers_processed_table,
-                                          invalid_timers_processed_table);
 
 
   int target_latency;
@@ -392,7 +383,7 @@ int main(int argc, char** argv)
                                               initial_token_rate,
                                               min_token_rate);
 
-  // Finally, set up the HTTPStack and handlers
+  // Set up the HTTPStack and handlers
   int bind_port;
   int http_threads;
   __globals->get_bind_port(bind_port);
@@ -425,6 +416,17 @@ int main(int argc, char** argv)
   }
 
   CL_CHRONOS_HTTP_SERVICE_AVAILABLE.log();
+
+  // Create a Chronos internal connection class for resynchronization operations.
+  // We do this after creating the HTTPStack as it triggers a resync operation.
+  ChronosInternalConnection* chronos_internal_connection =
+            new ChronosInternalConnection(http_resolver,
+                                          handler,
+                                          handler_rep,
+                                          resync_operation_alarm,
+                                          remaining_nodes_scalar,
+                                          timers_processed_table,
+                                          invalid_timers_processed_table);
 
   // Wait here until the quit semaphore is signaled.
   sem_wait(&term_sem);


### PR DESCRIPTION
We want to ensure the FV tests use the same ones as would be used by an actual Chronos process installed via debian package.