### PR TITLE
[Reviewer: Seb] Add replica and site info to tombstones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,3 +49,4 @@ fv_test: build/bin/chronos
 	./scripts/chronos_gr.py
 	./scripts/chronos_resync.py
 	./scripts/chronos_pop_errors.py
+	./scripts/chronos_delete_timers.py

--- a/include/timer.h
+++ b/include/timer.h
@@ -160,7 +160,7 @@ private:
   // Class functions
 public:
   static TimerID generate_timer_id();
-  static Timer* create_tombstone(TimerID, uint64_t);
+  static Timer* create_tombstone(TimerID, uint64_t, uint32_t);
   static Timer* from_json(TimerID id,
                           uint32_t replication_factor,
                           uint64_t replica_hash,

--- a/scripts/chronos_delete_timers.py
+++ b/scripts/chronos_delete_timers.py
@@ -1,0 +1,64 @@
+#! /usr/bin/python2.7
+
+# @file chronos_delete_timers.py
+#
+# Project Clearwater - IMS in the Cloud
+# Copyright (C) 2017  Metaswitch Networks Ltd
+#
+# This program is free software: you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation, either version 3 of the License, or (at your
+# option) any later version, along with the "Special Exception" for use of
+# the program along with SSL, set forth below. This program is distributed
+# in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+# A PARTICULAR PURPOSE.  See the GNU General Public License for more
+# details. You should have received a copy of the GNU General Public
+# License along with this program.  If not, see
+# <http://www.gnu.org/licenses/>.
+#
+# The author can be reached by email at clearwater@metaswitch.com or by
+# post at Metaswitch Networks Ltd, 100 Church St, Enfield EN2 6BQ, UK
+#
+# Special Exception
+# Metaswitch Networks Ltd  grants you permission to copy, modify,
+# propagate, and distribute a work formed by combining OpenSSL with The
+# Software, or a work derivative of such a combination, even if such
+# copying, modification, propagation, or distribution would otherwise
+# violate the terms of the GPL. You must comply with the GPL in all
+# respects for all of the code used other than OpenSSL.
+# "OpenSSL" means OpenSSL toolkit software distributed by the OpenSSL
+# Project and licensed under the OpenSSL Licenses, or a work based on such
+# software and licensed under the OpenSSL Licenses.
+# "OpenSSL Licenses" means the OpenSSL License and Original SSLeay License
+# under which the OpenSSL Project distributes the OpenSSL toolkit software,
+# as those licenses appear in the file LICENSE-OPENSSL.
+
+import unittest
+from time import sleep
+
+from os import sys, path
+sys.path.append(path.dirname(path.abspath(__file__)))
+from chronos_fv_test import ChronosFVTest, start_nodes, create_timers, chronos_nodes, delete_timers
+
+# Test that Chronos correctly deletes timers if requested by the client
+class ChronosDeleteTimers(ChronosFVTest):
+
+    def test_deletes(self):
+        # Test that Chronos replicates deletes from a client. This test creates 3 Chronos
+        # nodes, adds 100 timers, then deletes the 100 timers again.
+        # The test checks that we get 0 timer pops
+
+        # Start initial nodes and add timers
+        self.write_config_for_nodes([0,1,2])
+        start_nodes(0, 3)
+        create_timers(chronos_nodes[0], 0, 100, "pop", 3)
+        delete_timers(chronos_nodes[0], 100) 
+
+        # Check that no timer pops are recieved
+        sleep(16)
+        self.assert_correct_timers_received(0)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -126,7 +126,7 @@ void ControllerTask::add_or_update_timer(TimerID timer_id,
     // Replicated deletes are implemented as replicated tombstones so no DELETE
     // can be a replication request - it must have come from the client so we
     // should replicate it ourselves (both within site and cross-site).
-    timer = Timer::create_tombstone(timer_id, replica_hash);
+    timer = Timer::create_tombstone(timer_id, replica_hash, replication_factor);
   }
   else
   {

--- a/src/timer.cpp
+++ b/src/timer.cpp
@@ -714,11 +714,15 @@ TimerID Timer::generate_timer_id()
 // default expires of 10 seconds, if they're found to be
 // deleting an existing tombstone, they'll use that timer's
 // interval as an expiry.
-Timer* Timer::create_tombstone(TimerID id, uint64_t replica_hash)
+Timer* Timer::create_tombstone(TimerID id,
+                               uint64_t replica_hash,
+                               uint32_t replication_factor)
 {
   // Create a tombstone record that will last for 10 seconds.
   Timer* tombstone = new Timer(id, 10000, 10000);
+  tombstone->_replication_factor = replication_factor;
   tombstone->calculate_replicas(replica_hash);
+  tombstone->populate_sites();
   return tombstone;
 }
 

--- a/src/ut/test_timer.cpp
+++ b/src/ut/test_timer.cpp
@@ -37,7 +37,10 @@
 #include "test_interposer.hpp"
 
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 #include <map>
+
+using ::testing::UnorderedElementsAreArray;
 
 /*****************************************************************************/
 /* Test fixture                                                              */
@@ -553,9 +556,17 @@ TEST_F(TestTimer, IsLocal)
 
 TEST_F(TestTimer, IsTombstone)
 {
-  Timer* t2 = Timer::create_tombstone(100, 0);
+  Timer* t2 = Timer::create_tombstone(100, 0, 2);
   EXPECT_NE(0u, t2->start_time_mono_ms);
   EXPECT_TRUE(t2->is_tombstone());
+  std::vector<std::string> expected_replicas;
+  expected_replicas.push_back("10.0.0.2");
+  expected_replicas.push_back("10.0.0.3");
+  std::vector<std::string> expected_sites;
+  expected_sites.push_back("local_site_name");
+  expected_sites.push_back("remote_site_1_name");
+  EXPECT_THAT(expected_replicas, UnorderedElementsAreArray(t2->replicas));
+  EXPECT_THAT(expected_sites, UnorderedElementsAreArray(t2->sites));
   delete t2;
 }
 

--- a/src/ut/test_timer_store.cpp
+++ b/src/ut/test_timer_store.cpp
@@ -140,7 +140,7 @@ protected:
     timers[2]->interval_ms = (3600 * 1000) + 300;
 
     // Create an out of the blue tombstone for timer one.
-    tombstone = Timer::create_tombstone(1, 0);
+    tombstone = Timer::create_tombstone(1, 0, timers[1]->_replication_factor);
     tombstone->start_time_mono_ms = timers[0]->start_time_mono_ms + 50;
   }
 


### PR DESCRIPTION
This PR fixes an issue where a tombstone doesn't have any site/replica information, and so wasn't being replicated within/across sites.

Tested live and in UTs, `make full_test` and `make fv_test` pass