### PR TITLE
[Reviewer: RJW2] Decide address family from local IP

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -340,10 +340,10 @@ int main(int argc, char** argv)
 
   int af = AF_INET;
   struct in6_addr dummy_addr;
-  std::string bind_address;
-  __globals->get_bind_address(bind_address);
+  std::string local_ip;
+  __globals->get_cluster_local_ip(local_ip);
 
-  if (inet_pton(AF_INET6, bind_address.c_str(), &dummy_addr) == 1)
+  if (inet_pton(AF_INET6, local_ip.c_str(), &dummy_addr) == 1)
   {
     TRC_DEBUG("Local host is an IPv6 address");
     af = AF_INET6;
@@ -384,8 +384,10 @@ int main(int argc, char** argv)
                                               min_token_rate);
 
   // Set up the HTTPStack and handlers
+  std::string bind_address;
   int bind_port;
   int http_threads;
+  __globals->get_bind_address(bind_address);
   __globals->get_bind_port(bind_port);
   __globals->get_threads(http_threads);
 


### PR DESCRIPTION
The previous fix broke timers because we decide the address family based on the bind address so we always chose IPv6. The fix is to use the local IP like sprout does. This should be IPv4/6 address depending on what the user wants so we should create the right sort of HTTP resolver.

Tested that the live tests pass now.