### PR TITLE
[Reviewer EM] Tweak DNS cached resolver constructor parameters

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -302,6 +302,7 @@ int main(int argc, char** argv)
   __globals->get_dns_servers(dns_servers);
 
   DnsCachedResolver* dns_resolver = new DnsCachedResolver(dns_servers,
+                                                          DnsCachedResolver::DEFAULT_TIMEOUT,
                                                           options.dns_config_file);
 
 


### PR DESCRIPTION
Hi Ellie

Can you sign off on the tweak to the DnsCachedResolver constructor for my DNS timeout enhancement?  I decided to stick with the regular default (rather than the anomalous 1 second override we discussed) in the interests of simplicity.