### PR TITLE
[Reviewer: EM] Decide address scheme from bind address

### DIFF
--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -37,7 +37,7 @@ Globals::Globals(std::string local_config_file,
 
   // Describe the configuration file format.
   _desc.add_options()
-    ("http.bind-address", po::value<std::string>()->default_value("::"), "Address to bind the HTTP server to")
+    ("http.bind-address", po::value<std::string>()->default_value("0.0.0.0"), "Address to bind the HTTP server to")
     ("http.bind-port", po::value<int>()->default_value(7253), "Port to bind the HTTP server to")
     ("cluster.localhost", po::value<std::string>()->default_value("127.0.0.1:7253"), "The address of the local host")
     ("cluster.joining", po::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(), "HOST"), "The addresses of nodes in the cluster that are joining")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -317,10 +317,10 @@ int main(int argc, char** argv)
 
   int af = AF_INET;
   struct in6_addr dummy_addr;
-  std::string local_ip;
-  __globals->get_cluster_local_ip(local_ip);
+  std::string bind_address;
+  __globals->get_bind_address(bind_address);
 
-  if (inet_pton(AF_INET6, local_ip.c_str(), &dummy_addr) == 1)
+  if (inet_pton(AF_INET6, bind_address.c_str(), &dummy_addr) == 1)
   {
     TRC_DEBUG("Local host is an IPv6 address");
     af = AF_INET6;
@@ -361,10 +361,8 @@ int main(int argc, char** argv)
                                               min_token_rate);
 
   // Set up the HTTPStack and handlers
-  std::string bind_address;
   int bind_port;
   int http_threads;
-  __globals->get_bind_address(bind_address);
   __globals->get_bind_port(bind_port);
   __globals->get_threads(http_threads);
 

--- a/src/ut/test_globals.cpp
+++ b/src/ut/test_globals.cpp
@@ -37,7 +37,7 @@ TEST_F(TestGlobals, ParseGlobalsDefaults)
   // Check that the default values are used
   std::string bind_address;
   test_global->get_bind_address(bind_address);
-  EXPECT_EQ(bind_address, "::");
+  EXPECT_EQ(bind_address, "0.0.0.0");
 
   int bind_port;
   test_global->get_bind_port(bind_port);


### PR DESCRIPTION
Now that we expect chronos.conf to be set up at start of day, it's safe to derive the address family from the bind address. I've gone back to defaulting to using an IPv4 bind address so that chef deployments still work.