### PR TITLE
[Reviewer: Sathiyan] Remove dead code

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -50,9 +50,6 @@ The shared configuration file has the following format:
     servers = 127.0.0.1                      # DNS servers to use (up to three allowed)
     timeout = 200                            # Amount of time to wait for a DNS response
 
-    [timers]
-    id-format = with_replicas                # The format of the timer ID. We recommend that users do not set this configuration option.
-
     [sites]
     local_site = local-site-name             # The name of the local site
     remote_site = site-b=bar.foo.com:8000    # The name of a remote site, and a DNS name resolving to

--- a/include/globals.h
+++ b/include/globals.h
@@ -48,11 +48,6 @@ public:
   ~Globals();
   Globals(const Globals& copy) = delete;
 
-  enum struct TimerIDFormat
-  {
-    WITH_REPLICAS, WITHOUT_REPLICAS
-  };
-
   // Per node configuration
   GLOBAL(bind_address, std::string);
   GLOBAL(bind_port, int);
@@ -79,7 +74,6 @@ public:
   GLOBAL(max_tokens, int);
   GLOBAL(initial_token_rate, int);
   GLOBAL(min_token_rate, int);
-  GLOBAL(timer_id_format, TimerIDFormat);
   GLOBAL(local_site_name, std::string);
   GLOBAL(remote_sites, std::map<std::string, std::string>);
   GLOBAL(remote_site_names, std::vector<std::string>);
@@ -89,7 +83,6 @@ public:
   void update_config();
   void lock() { pthread_rwlock_wrlock(&_lock); }
   void unlock() { pthread_rwlock_unlock(&_lock); }
-  TimerIDFormat default_id_format() { return TimerIDFormat::WITHOUT_REPLICAS; }
 
 private:
   uint64_t generate_bloom_filter(std::string);
@@ -101,10 +94,6 @@ private:
   pthread_rwlock_t _lock; 
   Updater<void, Globals>* _updater;
   boost::program_options::options_description _desc;
-
-  std::map<TimerIDFormat, std::string> _timer_id_format_parser =
-      {{TimerIDFormat::WITH_REPLICAS, "with_replicas"},
-       {TimerIDFormat::WITHOUT_REPLICAS, "without_replicas"}};
 };
 
 extern Globals* __globals;

--- a/src/ut/base.cpp
+++ b/src/ut/base.cpp
@@ -45,9 +45,6 @@ void Base::SetUp()
   int bind_port = 9999;
   __globals->set_bind_port(bind_port);
 
-  Globals::TimerIDFormat timer_id_format = __globals->default_id_format();
-  __globals->set_timer_id_format(timer_id_format);
-
   uint32_t instance_id = 42;
   uint32_t deployment_id = 3;
   __globals->set_instance_id(instance_id);

--- a/src/ut/chronos_shared.conf
+++ b/src/ut/chronos_shared.conf
@@ -7,9 +7,6 @@ servers = 2.2.2.2
 servers = 3.3.3.3
 timeout = 500
 
-[timers]
-id-format = without_replicas
-
 [sites]
 local_site=mysite
 remote_site=a=foo.com:800

--- a/src/ut/chronos_unknown_options.conf
+++ b/src/ut/chronos_unknown_options.conf
@@ -1,0 +1,5 @@
+[http]
+bind-address = 1.2.3.4
+
+[unknown]
+option = true

--- a/src/ut/test_globals.cpp
+++ b/src/ut/test_globals.cpp
@@ -83,10 +83,6 @@ TEST_F(TestGlobals, ParseGlobalsDefaults)
   test_global->get_old_cluster_hashes(old_cluster_hashes);
   EXPECT_EQ(new_cluster_hashes, old_cluster_hashes);
 
-  Globals::TimerIDFormat timer_id_format;
-  test_global->get_timer_id_format(timer_id_format);
-  EXPECT_EQ(timer_id_format, Globals::TimerIDFormat::WITHOUT_REPLICAS);
-
   std::string local_site_name;
   test_global->get_local_site_name(local_site_name);
   EXPECT_EQ(local_site_name, "site1");
@@ -171,10 +167,6 @@ TEST_F(TestGlobals, ParseGlobalsNotDefaults)
   test_global->get_old_cluster_hashes(old_cluster_hashes);
   EXPECT_NE(new_cluster_hashes, old_cluster_hashes);
 
-  Globals::TimerIDFormat timer_id_format;
-  test_global->get_timer_id_format(timer_id_format);
-  EXPECT_EQ(timer_id_format, Globals::TimerIDFormat::WITHOUT_REPLICAS);
-
   std::string local_site_name;
   test_global->get_local_site_name(local_site_name);
   EXPECT_EQ(local_site_name, "mysite");
@@ -231,6 +223,25 @@ TEST_F(TestGlobals, LocalConfigOverridesSharedConfig)
   int ttl;
   test_global->get_max_ttl(ttl);
   EXPECT_EQ(ttl, 1000);
+
+  delete test_global; test_global = NULL;
+}
+
+TEST_F(TestGlobals, UnknownOptions)
+{
+  // Initialize the global configuration.
+  Globals* test_global = new Globals(std::string(UT_DIR).append("/chronos_unknown_options.conf"),
+                                     std::string(UT_DIR).append("/chronos_cluster.conf"),
+                                     std::string(UT_DIR).append("/chronos_shared.conf"));
+
+  // Read all global entries
+  test_global->update_config();
+
+  // This test has succeeded if we've got to this point and not crashed.
+  // We also check that we can read the file that had an unknown option.
+  std::string bind_address;
+  test_global->get_bind_address(bind_address);
+  EXPECT_EQ(bind_address, "1.2.3.4");
 
   delete test_global; test_global = NULL;
 }

--- a/src/ut/test_handler.cpp
+++ b/src/ut/test_handler.cpp
@@ -473,12 +473,6 @@ TEST_F(TestHandler, TimerWithReplicasNoSites)
 // enough replicas - for a new timer
 TEST_F(TestHandler, ReplicationFactorGreaterThanReplicasNew)
 {
-  // This test is only valid when the TimerIDFormat is without replicas
-  Globals::TimerIDFormat timer_id_format = Globals::TimerIDFormat::WITHOUT_REPLICAS;
-  __globals->lock();
-  __globals->set_timer_id_format(timer_id_format);
-  __globals->unlock();
-
   Timer* added_timer;
   HttpStack::Request req(NULL, NULL);
 
@@ -503,12 +497,6 @@ TEST_F(TestHandler, ReplicationFactorGreaterThanReplicasNew)
 // enough replicas - for an already replicated timer
 TEST_F(TestHandler, ReplicationFactorGreaterThanReplicasReplicated)
 {
-  // This test is only valid when the TimerIDFormat is without replicas
-  Globals::TimerIDFormat timer_id_format = Globals::TimerIDFormat::WITHOUT_REPLICAS;
-  __globals->lock();
-  __globals->set_timer_id_format(timer_id_format);
-  __globals->unlock();
-
   Timer* added_timer;
   HttpStack::Request req(NULL, NULL);
 

--- a/src/ut/test_timer.cpp
+++ b/src/ut/test_timer.cpp
@@ -23,34 +23,16 @@ using ::testing::UnorderedElementsAreArray;
 /*****************************************************************************/
 /* Test fixture                                                              */
 /*****************************************************************************/
-class WithReplicas {
-  static void set_timer_id_format() {
-    Globals::TimerIDFormat timer_id_format = Globals::TimerIDFormat::WITH_REPLICAS;
-    __globals->set_timer_id_format(timer_id_format);
-  }
-};
-
-class WithoutReplicas {
-  static void set_timer_id_format() {
-    Globals::TimerIDFormat timer_id_format = Globals::TimerIDFormat::WITHOUT_REPLICAS;
-    __globals->set_timer_id_format(timer_id_format);
-  }
-};
-
-template <class T>
 class TestTimerIDFormats : public Base
 {
 protected:
   virtual void SetUp()
   {
     Base::SetUp();
-    T::set_timer_id_format();
   }
 
   virtual void TearDown()
   {
-    Globals::TimerIDFormat timer_id_format = __globals->default_id_format();
-    __globals->set_timer_id_format(timer_id_format);
     Base::TearDown();
   }
 
@@ -65,10 +47,7 @@ protected:
 /* Class functions                                                           */
 /*****************************************************************************/
 
-typedef ::testing::Types<WithReplicas, WithoutReplicas> TimerIDFormatTypes;
-TYPED_TEST_CASE(TestTimerIDFormats, TimerIDFormatTypes);
-
-TYPED_TEST(TestTimerIDFormats, FromJSONTests)
+TEST_F(TestTimerIDFormats, FromJSONTests)
 {
   // The following tests depend on the current time, so install the shim
   cwtest_completely_control_time();
@@ -163,7 +142,7 @@ TYPED_TEST(TestTimerIDFormats, FromJSONTests)
   EXPECT_NE((void*)NULL, timer);
   EXPECT_EQ("", err);
   EXPECT_FALSE(replicated);
-  EXPECT_EQ(2, TestFixture::get_replication_factor(timer));
+  EXPECT_EQ(2, get_replication_factor(timer));
   EXPECT_EQ(2u, timer->replicas.size());
   delete timer;
 
@@ -171,14 +150,14 @@ TYPED_TEST(TestTimerIDFormats, FromJSONTests)
   EXPECT_NE((void*)NULL, timer);
   EXPECT_EQ("", err);
   EXPECT_FALSE(replicated);
-  EXPECT_EQ(2, TestFixture::get_replication_factor(timer));
+  EXPECT_EQ(2, get_replication_factor(timer));
   EXPECT_EQ(2u, timer->replicas.size());
   delete timer;
 
   // If you do specify a replication-factor, use that.
   timer = Timer::from_json(1, 0, 0, custom_repl_factor, err, replicated, gr_replicated);
   EXPECT_NE((void*)NULL, timer); EXPECT_EQ("", err); EXPECT_FALSE(replicated);
-  EXPECT_EQ(3, TestFixture::get_replication_factor(timer));
+  EXPECT_EQ(3, get_replication_factor(timer));
   EXPECT_EQ(3u, timer->replicas.size());
   delete timer;
 
@@ -187,14 +166,14 @@ TYPED_TEST(TestTimerIDFormats, FromJSONTests)
   EXPECT_NE((void*)NULL, timer);
   EXPECT_EQ("", err);
   EXPECT_FALSE(replicated);
-  EXPECT_EQ(2, TestFixture::get_replication_factor(timer));
+  EXPECT_EQ(2, get_replication_factor(timer));
   delete timer;
 
   timer = Timer::from_json(1, 3, 0x11011100011101, custom_repl_factor, err, replicated, gr_replicated);
   EXPECT_NE((void*)NULL, timer);
   EXPECT_EQ("", err);
   EXPECT_FALSE(replicated);
-  EXPECT_EQ(3, TestFixture::get_replication_factor(timer));
+  EXPECT_EQ(3, get_replication_factor(timer));
   delete timer;
 
   // If the replication factor on the URL (in this case 2) doesn't match the
@@ -211,7 +190,7 @@ TYPED_TEST(TestTimerIDFormats, FromJSONTests)
   EXPECT_NE((void*)NULL, timer);
   EXPECT_EQ("", err);
   EXPECT_TRUE(replicated);
-  EXPECT_EQ(2, TestFixture::get_replication_factor(timer));
+  EXPECT_EQ(2, get_replication_factor(timer));
   delete timer;
 
   // If no repeat for was specifed, use the interval
@@ -442,31 +421,14 @@ TEST_F(TestTimer, GenerateTimerIDTests)
 /* Instance Functions                                                        */
 /*****************************************************************************/
 
-TEST_F(TestTimer, URLWithoutReplicas)
-{
-  Globals::TimerIDFormat new_timer_id = Globals::TimerIDFormat::WITHOUT_REPLICAS;
-  __globals->set_timer_id_format(new_timer_id);
-  EXPECT_EQ("http://hostname:9999/timers/0000000100000009-2", t1->url("hostname:9999"));
-}
-
 TEST_F(TestTimer, URLFormats)
 {
-  Globals::TimerIDFormat new_timer_id = Globals::TimerIDFormat::WITHOUT_REPLICAS;
-  __globals->set_timer_id_format(new_timer_id);
-
+  EXPECT_EQ("http://hostname:9999/timers/0000000100000009-2", t1->url("hostname:9999"));
   EXPECT_EQ("http://hostname:9999/timers/0000000100000009-2", t1->url("hostname"));
   EXPECT_EQ("http://10.0.0.1:9999/timers/0000000100000009-2", t1->url("10.0.0.1"));
   EXPECT_EQ("http://[::2]:9999/timers/0000000100000009-2", t1->url("::2"));
   EXPECT_EQ("http://[::2]:9999/timers/0000000100000009-2", t1->url("[::2]"));
   EXPECT_EQ("http://[::2]:9999/timers/0000000100000009-2", t1->url("[::2]:9999"));
-}
-
-TEST_F(TestTimer, URLWithReplicas)
-{
-  Globals::TimerIDFormat new_timer_id = Globals::TimerIDFormat::WITH_REPLICAS;
-  __globals->set_timer_id_format(new_timer_id);
-  EXPECT_EQ("http://hostname:9999/timers/00000001000000090000010000010001", t1->url("hostname:9999"));
-  EXPECT_EQ("http://hostname:9999/timers/00000001000000090000010000010001", t1->url("hostname"));
 }
 
 TEST_F(TestTimer, ToJSON)

--- a/src/ut/test_timer_replica_choosing.cpp
+++ b/src/ut/test_timer_replica_choosing.cpp
@@ -27,28 +27,12 @@ static uint32_t REPLICATION_FACTOR = 2u;
 static int MAX_TIMERS = 768;
 static Hasher normal_hasher;
 
-class WithReplicas {
-  static void set_timer_id_format() {
-    Globals::TimerIDFormat timer_id_format = Globals::TimerIDFormat::WITH_REPLICAS;
-    __globals->set_timer_id_format(timer_id_format);
-  }
-};
-
-class WithoutReplicas {
-  static void set_timer_id_format() {
-    Globals::TimerIDFormat timer_id_format = Globals::TimerIDFormat::WITHOUT_REPLICAS;
-    __globals->set_timer_id_format(timer_id_format);
-  }
-};
-
-template <class T>
 class TestTimerReplicaChoosing : public Base
 {
 protected:
   virtual void SetUp()
   {
     Base::SetUp();
-    T::set_timer_id_format();
     old_cluster = {"10.0.0.1:7253", "10.0.0.2:7253", "10.0.0.3:7253", "10.0.0.4:7253"};
     new_cluster = old_cluster;
     new_cluster.push_back("10.0.0.100:7253");
@@ -59,8 +43,6 @@ protected:
 
   virtual void TearDown()
   {
-    Globals::TimerIDFormat timer_id_format = __globals->default_id_format();
-    __globals->set_timer_id_format(timer_id_format);
     Base::TearDown();
   }
 
@@ -70,53 +52,25 @@ protected:
     old_replicas.clear();
     new_replicas.clear();
 
-    Globals::TimerIDFormat timer_id_format;
-    __globals->get_timer_id_format(timer_id_format);
+    Timer::calculate_replicas(id,
+                              old_cluster,
+                              old_cluster_rendezvous_hashes,
+                              old_cluster,
+                              old_cluster_rendezvous_hashes,
+                              REPLICATION_FACTOR,
+                              old_replicas,
+                              extra_replicas,
+                              &normal_hasher);
 
-    if (timer_id_format == Globals::TimerIDFormat::WITH_REPLICAS)
-    {
-      Timer::calculate_replicas(id,
-                                0u,
-                                cluster_bloom_filters,
-                                old_cluster,
-                                old_cluster_rendezvous_hashes,
-                                REPLICATION_FACTOR,
-                                old_replicas,
-                                extra_replicas,
-                                &normal_hasher);
-
-      Timer::calculate_replicas(id,
-                                0u,
-                                cluster_bloom_filters,
-                                new_cluster,
-                                new_cluster_rendezvous_hashes,
-                                REPLICATION_FACTOR,
-                                new_replicas,
-                                extra_replicas,
-                                &normal_hasher);
-    }
-    else
-    {
-      Timer::calculate_replicas(id,
-                                old_cluster,
-                                old_cluster_rendezvous_hashes,
-                                old_cluster,
-                                old_cluster_rendezvous_hashes,
-                                REPLICATION_FACTOR,
-                                old_replicas,
-                                extra_replicas,
-                                &normal_hasher);
-
-      Timer::calculate_replicas(id,
-                                new_cluster,
-                                new_cluster_rendezvous_hashes,
-                                old_cluster,
-                                old_cluster_rendezvous_hashes,
-                                REPLICATION_FACTOR,
-                                new_replicas,
-                                extra_replicas,
-                                &normal_hasher);
-    }
+    Timer::calculate_replicas(id,
+                              new_cluster,
+                              new_cluster_rendezvous_hashes,
+                              old_cluster,
+                              old_cluster_rendezvous_hashes,
+                              REPLICATION_FACTOR,
+                              new_replicas,
+                              extra_replicas,
+                              &normal_hasher);
   }
 
   std::vector<std::string> old_cluster;
@@ -130,12 +84,9 @@ protected:
   std::vector<std::string> extra_replicas;
 };
 
-typedef ::testing::Types<WithReplicas, WithoutReplicas> TimerIDFormatTypes;
-TYPED_TEST_CASE(TestTimerReplicaChoosing, TimerIDFormatTypes);
-
 // The algorithm used to choose replicas should balance timers fairly - e.g. in
 // cluster of 10 nodes, each should have 10% of the timers.
-TYPED_TEST(TestTimerReplicaChoosing, ClusteringIsBalanced)
+TEST_F(TestTimerReplicaChoosing, ClusteringIsBalanced)
 {
   std::map<std::string, uint32_t> cluster_counts;
 
@@ -143,15 +94,15 @@ TYPED_TEST(TestTimerReplicaChoosing, ClusteringIsBalanced)
        id < (TimerID)MAX_TIMERS;
        id++)
   {
-    TestFixture::calculate_timers_for_id(id);
-    cluster_counts[TestFixture::old_replicas[0]]++;
+    calculate_timers_for_id(id);
+    cluster_counts[old_replicas[0]]++;
   }
 
-  uint32_t expected_max = MAX_TIMERS / (TestFixture::old_cluster.size() - 1);
-  uint32_t expected_min = MAX_TIMERS / (TestFixture::old_cluster.size() + 1);
+  uint32_t expected_max = MAX_TIMERS / (old_cluster.size() - 1);
+  uint32_t expected_min = MAX_TIMERS / (old_cluster.size() + 1);
   
-  for (std::vector<std::string>::iterator ii = TestFixture::old_cluster.begin();
-      ii != TestFixture::old_cluster.end();
+  for (std::vector<std::string>::iterator ii = old_cluster.begin();
+      ii != old_cluster.end();
       ii++)
   {
     EXPECT_GT(cluster_counts[*ii], expected_min);
@@ -163,46 +114,46 @@ TYPED_TEST(TestTimerReplicaChoosing, ClusteringIsBalanced)
 // on scale-up - if we have "A, B, C" and scale up to "A, B, C, D", D needs to end
 // up with 25% of timers - so only 25% of timers should move primary, and only
 // to D (e.g. no moves from B to C).
-TYPED_TEST(TestTimerReplicaChoosing, MinimumTimersMovePrimary)
+TEST_F(TestTimerReplicaChoosing, MinimumTimersMovePrimary)
 {
   int different = 0;
   for (TimerID id = (TimerID)0;
        id < (TimerID)MAX_TIMERS;
        id++)
   {
-    TestFixture::calculate_timers_for_id(id);
+    calculate_timers_for_id(id);
     
-    if ((TestFixture::old_replicas[0] != TestFixture::new_replicas[0]))
+    if ((old_replicas[0] != new_replicas[0]))
     {
-      ASSERT_EQ(TestFixture::old_replicas[1], TestFixture::new_replicas[1]);
+      ASSERT_EQ(old_replicas[1], new_replicas[1]);
 
       // Timers should only move onto the newly-added replica
-      ASSERT_EQ(TestFixture::new_replicas[0], "10.0.0.100:7253");
+      ASSERT_EQ(new_replicas[0], "10.0.0.100:7253");
       different++;
     }
   }
 
   // To balance the cluster when we moved from N replicas to N+1, approximately
   // 1/N+1th of existing timers should have moved. Allow a 10% difference to account for randomness.
-  EXPECT_THAT(different, ::testing::Lt((MAX_TIMERS / TestFixture::new_cluster.size()) * 1.1));
+  EXPECT_THAT(different, ::testing::Lt((MAX_TIMERS / new_cluster.size()) * 1.1));
 }
 
 // Same logic as previous test, but checking backup instead of primary.
-TYPED_TEST(TestTimerReplicaChoosing, MinimumTimersMoveBackup)
+TEST_F(TestTimerReplicaChoosing, MinimumTimersMoveBackup)
 {
   int different = 0;
   for (TimerID id = (TimerID)0;
        id < (TimerID)MAX_TIMERS;
        id++)
   {
-    TestFixture::calculate_timers_for_id(id);
+    calculate_timers_for_id(id);
 
-    if ((TestFixture::old_replicas[1] != TestFixture::new_replicas[1]))
+    if ((old_replicas[1] != new_replicas[1]))
     {
-      ASSERT_EQ(TestFixture::old_replicas[0], TestFixture::new_replicas[0]);
+      ASSERT_EQ(old_replicas[0], new_replicas[0]);
 
       // Timers should only move onto the newly-added replica
-      ASSERT_EQ(TestFixture::new_replicas[1], "10.0.0.100:7253");
+      ASSERT_EQ(new_replicas[1], "10.0.0.100:7253");
       different++;
     }
   }
@@ -210,55 +161,49 @@ TYPED_TEST(TestTimerReplicaChoosing, MinimumTimersMoveBackup)
 
   // To balance the cluster when we moved from N replicas to N+1, approximately
   // 1/N+1th of existing timers should have moved. Allow a 5% difference to account for randomness.
-  EXPECT_THAT(different, ::testing::Lt((MAX_TIMERS / TestFixture::new_cluster.size()) * 1.05));
+  EXPECT_THAT(different, ::testing::Lt((MAX_TIMERS / new_cluster.size()) * 1.05));
 }
 
 // The algorithm used to distribute timers should ensure that no primary nodes
 // become backup nodes on scale-up, and that no backup nodes become primary.
-TYPED_TEST(TestTimerReplicaChoosing, NoPrimaryBackupSwap)
+TEST_F(TestTimerReplicaChoosing, NoPrimaryBackupSwap)
 {
   for (TimerID id = (TimerID)0;
        id < (TimerID)MAX_TIMERS;
        id++)
   {
-    TestFixture::calculate_timers_for_id(id);
-    ASSERT_TRUE((TestFixture::old_replicas[0] != TestFixture::new_replicas[1]));
-    ASSERT_TRUE((TestFixture::old_replicas[1] != TestFixture::new_replicas[0]));
+    calculate_timers_for_id(id);
+    ASSERT_TRUE((old_replicas[0] != new_replicas[1]));
+    ASSERT_TRUE((old_replicas[1] != new_replicas[0]));
   }
 }
 
 // Test behaviour when the hashes of two servers collide, and the collision is resolved by removing one.
-template <class T>
-class TestTimerReplicaChoosingWithCollision : public TestTimerReplicaChoosing<T>
+class TestTimerReplicaChoosingWithCollision : public TestTimerReplicaChoosing
 {
 protected:
   virtual void SetUp()
   {
     Base::SetUp();
-    T::set_timer_id_format();
-    TestTimerReplicaChoosing<T>::old_cluster = {"10.0.0.1:7253", "10.0.0.2:7253", "10.0.0.3:7253", "10.0.0.4:7253"};
-    TestTimerReplicaChoosing<T>::new_cluster = {"10.0.0.2:7253", "10.0.0.3:7253", "10.0.0.4:7253"};
+    old_cluster = {"10.0.0.1:7253", "10.0.0.2:7253", "10.0.0.3:7253", "10.0.0.4:7253"};
+    new_cluster = {"10.0.0.2:7253", "10.0.0.3:7253", "10.0.0.4:7253"};
 
     // Emulate behaviour if "10.0.0.1:7253" and "10.0.0.2:7253" both hashed to 100.
     //  - On the initial collision, "10.0.0.2:7253"'s hash would be decremented to 99.
     //  - Once "10.0.0.1:7253" was removed, "10.0.0.2:7253"'s hash would no longer need
     //    to be decremented, and would change to 100.
-    TestTimerReplicaChoosing<T>::old_cluster_rendezvous_hashes = {100, 99, 4, 5};
-    TestTimerReplicaChoosing<T>::new_cluster_rendezvous_hashes = {100, 4, 5};
+    old_cluster_rendezvous_hashes = {100, 99, 4, 5};
+    new_cluster_rendezvous_hashes = {100, 4, 5};
   }
 
   virtual void TearDown()
   {
-    Globals::TimerIDFormat timer_id_format = __globals->default_id_format();
-    __globals->set_timer_id_format(timer_id_format);
     Base::TearDown();
   }
 };
 
-TYPED_TEST_CASE(TestTimerReplicaChoosingWithCollision, TimerIDFormatTypes);
-
 // The collision algorithm should keep timers balanced across all the nodes.
-TYPED_TEST(TestTimerReplicaChoosingWithCollision, ClusteringIsBalanced)
+TEST_F(TestTimerReplicaChoosingWithCollision, ClusteringIsBalanced)
 {
   std::map<std::string, uint32_t> cluster_counts;
 
@@ -266,15 +211,15 @@ TYPED_TEST(TestTimerReplicaChoosingWithCollision, ClusteringIsBalanced)
        id < (TimerID)MAX_TIMERS;
        id++)
   {
-    TestFixture::calculate_timers_for_id(id);
-    cluster_counts[TestFixture::old_replicas[0]]++;
+    calculate_timers_for_id(id);
+    cluster_counts[old_replicas[0]]++;
   }
 
-  uint32_t expected_max = MAX_TIMERS / (TestFixture::old_cluster.size() - 1);
-  uint32_t expected_min = MAX_TIMERS / (TestFixture::old_cluster.size() + 1);
+  uint32_t expected_max = MAX_TIMERS / (old_cluster.size() - 1);
+  uint32_t expected_min = MAX_TIMERS / (old_cluster.size() + 1);
   
-  for (std::vector<std::string>::iterator ii = TestFixture::old_cluster.begin();
-      ii != TestFixture::old_cluster.end();
+  for (std::vector<std::string>::iterator ii = old_cluster.begin();
+      ii != old_cluster.end();
       ii++)
   {
     EXPECT_GT(cluster_counts[*ii], expected_min);
@@ -285,25 +230,24 @@ TYPED_TEST(TestTimerReplicaChoosingWithCollision, ClusteringIsBalanced)
 // When a collision is resolved, slightly more timers than normal will move.
 // Check that the number that move does not exceed the expectations we've
 // calculated.
-
-TYPED_TEST(TestTimerReplicaChoosingWithCollision, MinimumTimersMovePrimary)
+TEST_F(TestTimerReplicaChoosingWithCollision, MinimumTimersMovePrimary)
 {
   int different = 0;
   for (TimerID id = (TimerID)0;
        id < (TimerID)MAX_TIMERS;
        id++)
   {
-    TestFixture::calculate_timers_for_id(id);
+    calculate_timers_for_id(id);
     
-    if ((TestFixture::old_replicas[0] != TestFixture::new_replicas[0]))
+    if ((old_replicas[0] != new_replicas[0]))
     {
 
       // Timers should only move off the removed server to the server whose
       // hash has replaced it, or off the server whose hash has changed to any
       // remaining server
       
-      ASSERT_TRUE(((TestFixture::old_replicas[0] == "10.0.0.1:7253") && (TestFixture::new_replicas[0] == "10.0.0.2:7253")) ||
-                  ((TestFixture::old_replicas[0] == "10.0.0.2:7253") && (TestFixture::new_replicas[0] != "10.0.0.1:7253")));
+      ASSERT_TRUE(((old_replicas[0] == "10.0.0.1:7253") && (new_replicas[0] == "10.0.0.2:7253")) ||
+                  ((old_replicas[0] == "10.0.0.2:7253") && (new_replicas[0] != "10.0.0.1:7253")));
       different++;
     }
   }
@@ -313,14 +257,14 @@ TYPED_TEST(TestTimerReplicaChoosingWithCollision, MinimumTimersMovePrimary)
   //  - B's hash has disappeared, so all B's timers (1/N) get rehashed
   //  - Of those 1/N timers, M-1/M move to other nodes, and 1/M stay on B
   //  - Overall, 1/N + (M-1/MN) of the total timers movetimers move = (M/MN + M-1/MN) = 2M-1/MN
-  int expected_to_move = MAX_TIMERS * ((2 * TestFixture::new_cluster.size()) - 1) / (TestFixture::new_cluster.size() * TestFixture::old_cluster.size());
+  int expected_to_move = MAX_TIMERS * ((2 * new_cluster.size()) - 1) / (new_cluster.size() * old_cluster.size());
 
   // Allow a 5% deviation from the expected value (as our subset of timers won't necessarily be perfectly distributed).
   EXPECT_THAT(different, ::testing::Lt(expected_to_move * 1.05));
 }
 
 
-TYPED_TEST(TestTimerReplicaChoosingWithCollision, ServerHashesDontCollide)
+TEST_F(TestTimerReplicaChoosingWithCollision, ServerHashesDontCollide)
 {
   std::vector<std::string> cluster_with_duplicate = {"A", "A", "B"};
   std::vector<uint32_t> hashes = __globals->generate_hashes(cluster_with_duplicate);


### PR DESCRIPTION
This removes the timers:id-format and the alarms:enabled options from Chronos. I've also made it so that we ignore unknown options in the config files, to cope with any backwards compatibility issues.

Tested in UTs and FVs.