### PR TITLE
[Reviewer: Sathiyan] Make number of GR threads configurable

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -16,7 +16,7 @@ The per-node configuration file has the following format:
     bind-address = 1.2.3.4         # Address to bind the HTTP server to
     bind-port = 7253               # Port to bind the HTTP server to
     threads = 50                   # Number of HTTP threads (for incoming requests) to create
-    gr_threads = 1000              # Number of HTTP threads (for GR replication) to create
+    gr_threads = 50                # Number of HTTP threads (for GR replication) to create
 
     [logging]
     folder = /var/log/chronos      # Location to output logs to

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -15,7 +15,8 @@ The per-node configuration file has the following format:
     [http]
     bind-address = 1.2.3.4         # Address to bind the HTTP server to
     bind-port = 7253               # Port to bind the HTTP server to
-    threads = 50                   # Number of HTTP threads to create
+    threads = 50                   # Number of HTTP threads (for incoming requests) to create
+    gr_threads = 1000              # Number of HTTP threads (for GR replication) to create
 
     [logging]
     folder = /var/log/chronos      # Location to output logs to

--- a/include/globals.h
+++ b/include/globals.h
@@ -52,6 +52,7 @@ public:
   GLOBAL(bind_address, std::string);
   GLOBAL(bind_port, int);
   GLOBAL(threads, int);
+  GLOBAL(gr_threads, int);
 
   // Clustering configuration
   GLOBAL(cluster_local_ip, std::string);

--- a/include/gr_replicator.h
+++ b/include/gr_replicator.h
@@ -17,8 +17,6 @@
 #include "exception_handler.h"
 #include "eventq.h"
 
-#define GR_REPLICATOR_THREAD_COUNT 20
-
 struct GRReplicationRequest
 {
   GRReplicationRequest(ChronosGRConnection* connection,
@@ -43,7 +41,8 @@ class GRReplicator
 {
 public:
   GRReplicator(HttpResolver* http_resolver,
-               ExceptionHandler* exception_handler);
+               ExceptionHandler* exception_handler,
+               int gr_threads);
   virtual ~GRReplicator();
 
   void worker_thread_entry_point();
@@ -52,9 +51,10 @@ public:
 
 private:
   eventq<GRReplicationRequest *> _q;
-  pthread_t _worker_threads[GR_REPLICATOR_THREAD_COUNT];
+  std::vector<pthread_t> _worker_threads;
   std::vector<ChronosGRConnection*> _connections;
   ExceptionHandler* _exception_handler;
+  int _gr_threads;
 };
 
 #endif

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -47,7 +47,8 @@ Globals::Globals(std::string local_config_file,
     ("identity.deployment_id", po::value<uint32_t>()->default_value(0), "A number between 0 and 7. The combination of instance ID and deployment ID should uniquely identify this node in the cluster, to remove the risk of timer collisions.")
     ("logging.folder", po::value<std::string>()->default_value("/var/log/chronos"), "Location to output logs to")
     ("logging.level", po::value<int>()->default_value(2), "Logging level: 1(lowest) - 5(highest)")
-    ("http.threads", po::value<int>()->default_value(50), "Number of HTTP threads to create")
+    ("http.threads", po::value<int>()->default_value(50), "Number of HTTP threads (for incoming requests) to create")
+    ("http.gr_threads", po::value<int>()->default_value(1000), "Number of HTTP threads (for GR replication) to create")
     ("exceptions.max_ttl", po::value<int>()->default_value(600), "Maximum time before the process exits after hitting an exception")
     ("sites.local_site", po::value<std::string>()->default_value("site1"), "The name of the local site")
     ("sites.remote_site", po::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(), "SITE"), "The name and address of the remote sites in the cluster")
@@ -140,6 +141,10 @@ void Globals::update_config()
   int threads = conf_map["http.threads"].as<int>();
   set_threads(threads);
   TRC_STATUS("HTTP Threads: %d", threads);
+
+  int gr_threads = conf_map["http.gr_threads"].as<int>();
+  set_gr_threads(gr_threads);
+  TRC_STATUS("HTTP GR Threads: %d", gr_threads);
 
   int ttl = conf_map["exceptions.max_ttl"].as<int>();
   set_max_ttl(ttl);

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -48,7 +48,7 @@ Globals::Globals(std::string local_config_file,
     ("logging.folder", po::value<std::string>()->default_value("/var/log/chronos"), "Location to output logs to")
     ("logging.level", po::value<int>()->default_value(2), "Logging level: 1(lowest) - 5(highest)")
     ("http.threads", po::value<int>()->default_value(50), "Number of HTTP threads (for incoming requests) to create")
-    ("http.gr_threads", po::value<int>()->default_value(1000), "Number of HTTP threads (for GR replication) to create")
+    ("http.gr_threads", po::value<int>()->default_value(50), "Number of HTTP threads (for GR replication) to create")
     ("exceptions.max_ttl", po::value<int>()->default_value(600), "Maximum time before the process exits after hitting an exception")
     ("sites.local_site", po::value<std::string>()->default_value("site1"), "The name of the local site")
     ("sites.remote_site", po::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(), "SITE"), "The name and address of the remote sites in the cluster")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -329,10 +329,15 @@ int main(int argc, char** argv)
   HttpResolver* http_resolver = new HttpResolver(dns_resolver, af);
 
   // Create the timer store, handlers, replicators...
+  int gr_threads;
+  __globals->get_gr_threads(gr_threads);
+
   TimerStore* store = new TimerStore(hc);
   Replicator* controller_rep = new Replicator(exception_handler);
   Replicator* handler_rep = new Replicator(exception_handler);
-  GRReplicator* gr_rep = new GRReplicator(http_resolver, exception_handler);
+  GRReplicator* gr_rep = new GRReplicator(http_resolver,
+                                          exception_handler,
+                                          gr_threads);
   HTTPCallback* callback = new HTTPCallback(http_resolver);
   TimerHandler* handler = new TimerHandler(store,
                                            callback,
@@ -343,8 +348,6 @@ int main(int argc, char** argv)
                                            scalar_timers_table);
   callback->start(handler);
 
-
-
   int target_latency;
   int max_tokens;
   int initial_token_rate;
@@ -353,7 +356,6 @@ int main(int argc, char** argv)
   __globals->get_max_tokens(max_tokens);
   __globals->get_initial_token_rate(initial_token_rate);
   __globals->get_min_token_rate(min_token_rate);
-
 
   LoadMonitor* load_monitor = new LoadMonitor(target_latency,
                                               max_tokens,

--- a/src/ut/chronos.conf
+++ b/src/ut/chronos.conf
@@ -2,3 +2,4 @@
 bind-address = 1.2.3.4
 bind-port = 7254
 threads = 40
+gr_threads = 500

--- a/src/ut/chronos.conf
+++ b/src/ut/chronos.conf
@@ -2,4 +2,4 @@
 bind-address = 1.2.3.4
 bind-port = 7254
 threads = 40
-gr_threads = 500
+gr_threads = 30

--- a/src/ut/mock_gr_replicator.h
+++ b/src/ut/mock_gr_replicator.h
@@ -19,7 +19,7 @@
 class MockGRReplicator : public GRReplicator
 {
 public:
-  MockGRReplicator() : GRReplicator(NULL, NULL) {}
+  MockGRReplicator() : GRReplicator(NULL, NULL, 2) {}
 
   MOCK_METHOD1(replicate, void(Timer*));
 };

--- a/src/ut/test_globals.cpp
+++ b/src/ut/test_globals.cpp
@@ -49,7 +49,7 @@ TEST_F(TestGlobals, ParseGlobalsDefaults)
 
   int gr_threads;
   test_global->get_gr_threads(gr_threads);
-  EXPECT_EQ(gr_threads, 1000);
+  EXPECT_EQ(gr_threads, 50);
 
   int ttl;
   test_global->get_max_ttl(ttl);
@@ -130,7 +130,7 @@ TEST_F(TestGlobals, ParseGlobalsNotDefaults)
 
   int gr_threads;
   test_global->get_gr_threads(gr_threads);
-  EXPECT_EQ(gr_threads, 500);
+  EXPECT_EQ(gr_threads, 30);
 
   int ttl;
   test_global->get_max_ttl(ttl);

--- a/src/ut/test_globals.cpp
+++ b/src/ut/test_globals.cpp
@@ -47,6 +47,10 @@ TEST_F(TestGlobals, ParseGlobalsDefaults)
   test_global->get_threads(threads);
   EXPECT_EQ(threads, 50);
 
+  int gr_threads;
+  test_global->get_gr_threads(gr_threads);
+  EXPECT_EQ(gr_threads, 1000);
+
   int ttl;
   test_global->get_max_ttl(ttl);
   EXPECT_EQ(ttl, 600);
@@ -123,6 +127,10 @@ TEST_F(TestGlobals, ParseGlobalsNotDefaults)
   int threads;
   test_global->get_threads(threads);
   EXPECT_EQ(threads, 40);
+
+  int gr_threads;
+  test_global->get_gr_threads(gr_threads);
+  EXPECT_EQ(gr_threads, 500);
 
   int ttl;
   test_global->get_max_ttl(ttl);

--- a/src/ut/test_gr_replicator.cpp
+++ b/src/ut/test_gr_replicator.cpp
@@ -25,7 +25,7 @@ protected:
     Base::SetUp();
 
     _resolver = new FakeHttpResolver("10.42.42.42");
-    _gr = new GRReplicator(_resolver, NULL);
+    _gr = new GRReplicator(_resolver, NULL, 2);
 
     fakecurl_responses.clear();
     fakecurl_requests.clear();


### PR DESCRIPTION
This PR makes the number of GR threads a config option rather than defaulting to 20. I had set the number of GR threads to be large, but I think it's better to keep it a low number by default - what do you think?

Tested in UTs/FVs only.