### PR TITLE
[Reviewer EM] Raise file handle headroom to 10-20 per thread

### DIFF
--- a/debian/chronos.init.d
+++ b/debian/chronos.init.d
@@ -44,6 +44,11 @@ setup_environment()
   # Allow chronos to write out core files.
   ulimit -c unlimited
 
+  # Give chronos sofficient headroom to allow for order of 10 to 20 file handles 
+  # per thread
+  ulimit -Hn 10000
+  ulimit -Sn 10000
+
   # Include the libraries that come with chronos.
   export LD_LIBRARY_PATH=/usr/share/chronos/lib:$LD_LIBRARY_PATH
 }


### PR DESCRIPTION
Hi Ellie

This is the change to increase the file handle limit to 10,000 to head off any future FH-related terminations that we discussed a few days back.  This should allow order of 10 FHs to be opened per chronos thread before we hit terminations.

I've checked that this setting addresses the terminations we were seeing on the fielded v10 system. 