### PR TITLE
[Reviewer: Ellie] Replicator uses HTTPClient

### DIFF
--- a/include/http_callback.h
+++ b/include/http_callback.h
@@ -18,6 +18,7 @@
 #include "timer.h"
 #include "httpresolver.h"
 #include "httpconnection.h"
+#include "exception_handler.h"
 
 #include <string>
 #include <curl/curl.h>
@@ -27,7 +28,8 @@
 class HTTPCallback : public Callback
 {
 public:
-  HTTPCallback(HttpResolver* resolver);
+  HTTPCallback(HttpResolver* resolver,
+               ExceptionHandler* exception_handler);
   ~HTTPCallback();
 
   void start(TimerHandler*);
@@ -40,11 +42,11 @@ public:
   void worker_thread_entry_point();
 
 private:
-  // Resolver to use to resolve callback URL server FQDNs to IP addresses.
-  HttpResolver* _resolver;
-
   pthread_t _worker_threads[HTTPCALLBACK_THREAD_COUNT];
   eventq<Timer*> _q;
+  ExceptionHandler* _exception_handler;
+  // Resolver to use to resolve callback URL server FQDNs to IP addresses.
+  HttpResolver* _resolver;
 
   bool _running;
   TimerHandler* _handler;

--- a/include/replicator.h
+++ b/include/replicator.h
@@ -17,6 +17,8 @@
 #include "timer.h"
 #include "exception_handler.h"
 #include "eventq.h"
+#include "httpresolver.h"
+#include "httpconnection.h"
 
 #define REPLICATOR_THREAD_COUNT 50
 
@@ -31,7 +33,8 @@ struct ReplicationRequest
 class Replicator
 {
 public:
-  Replicator(ExceptionHandler* exception_handler);
+  Replicator(HttpResolver* resolver,
+             ExceptionHandler* exception_handler);
   virtual ~Replicator();
 
   void worker_thread_entry_point();
@@ -47,6 +50,8 @@ private:
   pthread_t _worker_threads[REPLICATOR_THREAD_COUNT];
   struct curl_slist* _headers;
   ExceptionHandler* _exception_handler;
+  HttpResolver* _resolver;
+  HttpClient _http_client;
 };
 
 #endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -63,6 +63,7 @@ chronos_test_SOURCES := ${COMMON_SOURCES} \
                         timer_helper.cpp \
                         test_interposer.cpp \
                         test_chronos_internal_connection.cpp \
+                        test_replicator.cpp \
                         test_gr_replicator.cpp \
                         test_http_callback.cpp \
                         fakelogger.cpp \

--- a/src/http_callback.cpp
+++ b/src/http_callback.cpp
@@ -108,7 +108,9 @@ void HTTPCallback::worker_thread_entry_point()
       _handler->return_timer(timer);
       timer = NULL; // We relinquish control of the timer when we give it back to the store.
 
-      //TODO The send_post function doesn't even HAVE a function to add headers on the request, and the store for response headers is helpfully just called headers. All round, it's pretty dumb
+      //TODO The send_post function currently has no method for sending headers
+      // on the request. Should fix this up soon, but we default the Content-Type
+      // header, and aren't using Sequence Number, so not a huge issue atm.
       // Send the request.
       HTTPCode http_rc = _http_client.send_post(callback_url,
                                                 headers,

--- a/src/http_callback.cpp
+++ b/src/http_callback.cpp
@@ -103,6 +103,7 @@ void HTTPCallback::worker_thread_entry_point()
     _handler->return_timer(timer);
     timer = NULL; // We relinquish control of the timer when we give it back to the store.
 
+    //TODO The send_post function doesn't even HAVE a function to add headers on the request, and the store for response headers is helpfully just called headers. All round, it's pretty dumb
     // Send the request.
     HTTPCode http_rc = _http_client.send_post(callback_url,
                                               headers,

--- a/src/http_callback.cpp
+++ b/src/http_callback.cpp
@@ -14,9 +14,12 @@
 
 #include <cstring>
 
-HTTPCallback::HTTPCallback(HttpResolver* resolver) :
-  _resolver(resolver),
+HTTPCallback::HTTPCallback(HttpResolver* resolver,
+                           ExceptionHandler* exception_handler) :
+
   _q(),
+  _exception_handler(exception_handler),
+  _resolver(resolver),
   _running(false),
   _handler(NULL),
   _http_client(false,
@@ -85,45 +88,55 @@ void HTTPCallback::worker_thread_entry_point()
   Timer* timer = NULL;
   while (_q.pop(timer))
   {
-    // Pull out the timer details for use in the CURL request.
-    TimerID timer_id = timer->id;
-    std::string callback_url = timer->callback_url;
-    std::string callback_body = timer->callback_body;
-
-    // Set up the headers.
-    std::map<std::string, std::string> headers;
-    headers.insert(std::make_pair("X-Sequence-Number",
-                                  std::to_string(timer->sequence_number)));
-    headers.insert(std::make_pair("Content-Type", "application/octet-stream"));
-
-    // Return the timer to the store. This avoids the error case where the client
-    // attempts to update the timer based on the pop, finds nothing in the store,
-    // inserts a new timer rather than updating the timer that popped, and the popped
-    // timer then tombstoning and overwriting the newer timer, leading to leaked statistics.
-    _handler->return_timer(timer);
-    timer = NULL; // We relinquish control of the timer when we give it back to the store.
-
-    //TODO The send_post function doesn't even HAVE a function to add headers on the request, and the store for response headers is helpfully just called headers. All round, it's pretty dumb
-    // Send the request.
-    HTTPCode http_rc = _http_client.send_post(callback_url,
-                                              headers,
-                                              callback_body,
-                                              0L);
-
-    if (http_rc == HTTP_OK)
+    CW_TRY
     {
-      // The callback succeeded, so we need to re-find the timer, and replicate it.
-      TRC_DEBUG("Callback for timer \"%lu\" was successful", timer_id);
-      _handler->handle_successful_callback(timer_id);
-    }
-    else
-    {
-      TRC_DEBUG("Failed to process callback for %lu: URL %s, HTTP rc %ld", timer_id,
-                callback_url.c_str(), http_rc);
+      // Pull out the timer details for use in the CURL request.
+      TimerID timer_id = timer->id;
+      std::string callback_url = timer->callback_url;
+      std::string callback_body = timer->callback_body;
 
-      // The callback failed, and so we need to remove the timer from the store.
-      _handler->handle_failed_callback(timer_id);
+      // Set up the headers.
+      std::map<std::string, std::string> headers;
+      headers.insert(std::make_pair("X-Sequence-Number",
+                                    std::to_string(timer->sequence_number)));
+      headers.insert(std::make_pair("Content-Type", "application/octet-stream"));
+
+      // Return the timer to the store. This avoids the error case where the client
+      // attempts to update the timer based on the pop, finds nothing in the store,
+      // inserts a new timer rather than updating the timer that popped, and the popped
+      // timer then tombstoning and overwriting the newer timer, leading to leaked statistics.
+      _handler->return_timer(timer);
+      timer = NULL; // We relinquish control of the timer when we give it back to the store.
+
+      //TODO The send_post function doesn't even HAVE a function to add headers on the request, and the store for response headers is helpfully just called headers. All round, it's pretty dumb
+      // Send the request.
+      HTTPCode http_rc = _http_client.send_post(callback_url,
+                                                headers,
+                                                callback_body,
+                                                0L);
+
+      if (http_rc == HTTP_OK)
+      {
+        // The callback succeeded, so we need to re-find the timer, and replicate it.
+        TRC_DEBUG("Callback for timer \"%lu\" was successful", timer_id);
+        _handler->handle_successful_callback(timer_id);
+      }
+      else
+      {
+        TRC_DEBUG("Failed to process callback for %lu: URL %s, HTTP rc %ld", timer_id,
+                  callback_url.c_str(), http_rc);
+
+        // The callback failed, and so we need to remove the timer from the store.
+        _handler->handle_failed_callback(timer_id);
+      }
     }
+    //LCOV_EXCL_START - No exception testing in UT
+    CW_EXCEPT(_exception_handler)
+    {
+      // No recovery behaviour needed
+    }
+    CW_END
+    // LCOV_EXCL_STOP
   }
 
   return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -342,8 +342,10 @@ int main(int argc, char** argv)
   __globals->get_gr_threads(gr_threads);
 
   TimerStore* store = new TimerStore(hc);
-  Replicator* controller_rep = new Replicator(exception_handler);
-  Replicator* handler_rep = new Replicator(exception_handler);
+  Replicator* controller_rep = new Replicator(http_resolver,
+                                              exception_handler);
+  Replicator* handler_rep = new Replicator(http_resolver,
+                                           exception_handler);
   GRReplicator* gr_rep = new GRReplicator(http_resolver,
                                           exception_handler,
                                           gr_threads,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -350,7 +350,8 @@ int main(int argc, char** argv)
                                           exception_handler,
                                           gr_threads,
                                           remote_chronos_comm_monitor);
-  HTTPCallback* callback = new HTTPCallback(http_resolver);
+  HTTPCallback* callback = new HTTPCallback(http_resolver,
+                                            exception_handler);
   TimerHandler* handler = new TimerHandler(store,
                                            callback,
                                            handler_rep,

--- a/src/replicator.cpp
+++ b/src/replicator.cpp
@@ -132,7 +132,6 @@ void Replicator::worker_thread_entry_point()
     }
     //LCOV_EXCL_START - No exception testing in UT
     CW_EXCEPT(_exception_handler)
-
     {
       // No recovery behaviour needed
     }

--- a/src/replicator.cpp
+++ b/src/replicator.cpp
@@ -15,10 +15,15 @@
 #include <cstring>
 #include <pthread.h>
 
-Replicator::Replicator(ExceptionHandler* exception_handler) :
+Replicator::Replicator(HttpResolver* resolver,
+                       ExceptionHandler* exception_handler) :
   _q(),
-  _headers(NULL),
-  _exception_handler(exception_handler)
+  _exception_handler(exception_handler),
+  _resolver(resolver),
+  _http_client(false,
+               _resolver,
+               SASEvent::HttpLogLevel::NONE,
+               NULL)
 {
   // Create a pool of replicator threads
   for (int ii = 0; ii < REPLICATOR_THREAD_COUNT; ++ii)
@@ -37,9 +42,6 @@ Replicator::Replicator(ExceptionHandler* exception_handler) :
 
     _worker_threads[ii] = thread;
   }
-
-  // Set up a content type header descriptor to use for our requests.
-  _headers = curl_slist_append(_headers, "Content-Type: application/json");
 }
 
 Replicator::~Replicator()
@@ -49,7 +51,6 @@ Replicator::~Replicator()
   {
     pthread_join(_worker_threads[ii], NULL);
   }
-  curl_slist_free_all(_headers);
 }
 
 /*****************************************************************************/
@@ -107,59 +108,39 @@ void Replicator::replicate_timer_to_node(Timer* timer,
 
 // The replication worker thread.  This loops, receiving cURL handles off a queue
 // and handling them synchronously.  We run a pool of these threads to mitigate
-// starvation.
+// starvation
 void Replicator::worker_thread_entry_point()
 {
-  CURL* curl = curl_easy_init();
-
-  // Tell cURL to perform a POST but to call it a PUT, this allows
-  // us to easily pass a JSON body as a string.
-  //
-  // http://curl.haxx.se/mail/lib-2009-11/0001.html
-  curl_easy_setopt(curl, CURLOPT_POST, 1);
-  curl_easy_setopt(curl, CURLOPT_CUSTOMREQUEST, "PUT");
-
-  // Set up the content type (as POSTFIELDS doesn't)
-  curl_easy_setopt(curl, CURLOPT_HTTPHEADER, _headers);
-
   ReplicationRequest* replication_request;
   while(_q.pop(replication_request))
   {
     CW_TRY
     {
-      // The customized bits of this request.
-      curl_easy_setopt(curl, CURLOPT_URL, replication_request->url.c_str());
-      curl_easy_setopt(curl, CURLOPT_POSTFIELDS, replication_request->body.data());
-      curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, replication_request->body.length());
-
+      std::string replication_url = replication_request->url.c_str();
+      std::string replication_body = replication_request->body.data();
       // Send the request.
-      CURLcode rc = curl_easy_perform(curl);
-      if (rc == CURLE_HTTP_RETURNED_ERROR)
+      HTTPCode http_rc = _http_client.send_put(replication_url,
+                                               replication_body,
+                                               0L); // SAS trail
+
+      if (http_rc != HTTP_OK)
       {
-        long http_rc;
-        curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_rc);
-        TRC_WARNING("Failed to replicate timer to %s, HTTP error was %d %s",
-                    replication_request->url.c_str(),
-                    http_rc,
-                    curl_easy_strerror(rc));
-      }
-      else if (rc != CURLE_OK)
-      {
-        TRC_DEBUG("%s failed at server. %s(%d). fatal", replication_request->url.c_str(),
-                                                          curl_easy_strerror(rc), rc);
+        TRC_DEBUG("Failed to process replication for %s. HTTP rc %ld",
+                  replication_url.c_str(),
+                  http_rc);
       }
     }
+    //LCOV_EXCL_START - No exception testing in UT
     CW_EXCEPT(_exception_handler)
+
     {
       // No recovery behaviour needed
     }
     CW_END
-
+    // LCOV_EXCL_STOP
     // Clean up
     delete replication_request;
   }
-
-  curl_easy_cleanup(curl);
 }
 
 /*****************************************************************************/

--- a/src/ut/coverage-not-yet
+++ b/src/ut/coverage-not-yet
@@ -4,9 +4,5 @@
 # New files should have 100% code coverage (by lines); it may
 # be acceptable to use exclusion markers to achieve this.
 
-# Currently untested Chronos files. These should only be in
-# here temporarily
-#replicator.cpp
-
 # Murmur hash not covered by UTs
 murmur/MurmurHash3.cpp

--- a/src/ut/coverage-not-yet
+++ b/src/ut/coverage-not-yet
@@ -6,7 +6,7 @@
 
 # Currently untested Chronos files. These should only be in
 # here temporarily
-replicator.cpp
+#replicator.cpp
 
 # Murmur hash not covered by UTs
 murmur/MurmurHash3.cpp

--- a/src/ut/mock_replicator.h
+++ b/src/ut/mock_replicator.h
@@ -19,7 +19,7 @@
 class MockReplicator : public Replicator
 {
 public:
-  MockReplicator() : Replicator(NULL) {}
+  MockReplicator() : Replicator(NULL, NULL) {}
 
   MOCK_METHOD1(replicate, void(Timer*));
   MOCK_METHOD2(replicate_timer_to_node, void(Timer*, std::string));

--- a/src/ut/test_http_callback.cpp
+++ b/src/ut/test_http_callback.cpp
@@ -27,7 +27,7 @@ protected:
 
     _resolver = new FakeHttpResolver("10.42.42.42");
     _th = new MockTimerHandler();
-    _callback = new HTTPCallback(_resolver);
+    _callback = new HTTPCallback(_resolver, NULL);
     _callback->start(_th);
 
     fakecurl_responses.clear();

--- a/src/ut/test_replicator.cpp
+++ b/src/ut/test_replicator.cpp
@@ -1,0 +1,269 @@
+/**
+ * @file test_replicator.cpp
+ *
+ * Copyright (C) Metaswitch Networks 2017
+ * If license terms are provided to you in a COPYING file in the root directory
+ * of the source code repository by which you are accessing this code, then
+ * the license outlined in that COPYING file applies to your use.
+ * Otherwise no rights are granted except for those provided to you by
+ * Metaswitch Networks in a separate written agreement.
+ */
+
+#include "globals.h"
+#include "replicator.h"
+#include "base.h"
+#include "fakecurl.hpp"
+#include "fakehttpresolver.hpp"
+#include "mockcommunicationmonitor.h"
+#include "timer_helper.h"
+
+using ::testing::_;
+
+/// Fixture for ReplicatorTest.
+class TestReplicator : public Base
+{
+protected:
+  void SetUp()
+  {
+    Base::SetUp();
+
+    _resolver = new FakeHttpResolver("10.42.42.42");
+    _replicator = new Replicator(_resolver, NULL);
+
+    fakecurl_responses.clear();
+    fakecurl_requests.clear();
+  }
+
+  void TearDown()
+  {
+    delete _replicator;
+    delete _resolver;
+
+    Base::TearDown();
+  }
+
+  FakeHttpResolver* _resolver;
+  Replicator* _replicator;
+};
+
+// Test that a local-only timer replica is not replicated
+TEST_F(TestReplicator, LocalReplica)
+{
+  Timer* timer1 = default_timer(1);
+  EXPECT_TRUE(timer1->replicas.size() == 1);
+  fakecurl_responses["http://10.0.0.1:9999/timers/0000000000000001-2"] = CURLE_OK;
+
+  _replicator->replicate(timer1);
+
+  // We are expecting no timer to be sent, but want to sleep a little, just in
+  // case we actually send one, then check fakecurl. We don't want to wait the
+  // full 10 seconds the other tests can, as we would always hit that here.
+  sleep(3);
+  std::map<std::string, Request>::iterator it =
+      fakecurl_requests.find("http://10.0.0.1:9999/timers/0000000000000001-2");
+
+  // Assert that the replicator didn't send any requests out
+  ASSERT_TRUE(it == fakecurl_requests.end());
+
+  delete timer1; timer1 = NULL;
+}
+
+// Test that a non-local timer replica is replicated successfully
+TEST_F(TestReplicator, StandardReplica)
+{
+  Timer* timer1 = default_timer(1);
+  timer1->_replication_factor = 2;
+  timer1->replicas.push_back("10.0.0.2:9999");
+  EXPECT_TRUE(timer1->replicas.size() == 2);
+  fakecurl_responses["http://10.0.0.2:9999/timers/0000000000000001-2"] = CURLE_OK;
+
+  _replicator->replicate(timer1);
+
+  // The timer's been sent when fakecurl records the request. Sleep until then.
+  std::map<std::string, Request>::iterator it =
+      fakecurl_requests.find("http://10.0.0.2:9999/timers/0000000000000001-2");
+  int count = 0;
+  while (it == fakecurl_requests.end() && count < 10)
+  {
+    // Don't wait for more than 10 seconds
+    count++;
+    sleep(1);
+    it = fakecurl_requests.find("http://10.0.0.2:9999/timers/0000000000000001-2");
+  }
+
+  if (count >= 10)
+  {
+    printf("No request was sent that matched the expected timer\n");
+  }
+  ASSERT_TRUE(it != fakecurl_requests.end());
+
+  // Look at the body sent on the request. Check that it doesn't have any
+  // replica information, and that it makes a valid timer
+  Request& request = it->second;
+  rapidjson::Document doc;
+  doc.Parse<0>(request._body.c_str());
+  EXPECT_FALSE(doc.HasParseError());
+  ASSERT_TRUE(doc.HasMember("reliability"));
+  EXPECT_TRUE(doc["reliability"].HasMember("replicas"));
+
+  std::string error;
+  bool replicated;
+  bool gr_replicated;
+
+  Timer* timer2 = Timer::from_json(1, 1, 0, request._body, error, replicated, gr_replicated);
+  EXPECT_TRUE(timer2);
+
+  delete timer1; timer1 = NULL;
+  delete timer2; timer2 = NULL;
+}
+
+// Test that timer extra-replicas are replicated successfully
+TEST_F(TestReplicator, ExtraReplica)
+{
+  Timer* timer1 = default_timer(1);
+  timer1->_replication_factor = 2;
+  timer1->extra_replicas.push_back("10.0.0.3:9999");
+  EXPECT_TRUE(timer1->replicas.size() == 1);
+  EXPECT_TRUE(timer1->extra_replicas.size() == 1);
+  fakecurl_responses["http://10.0.0.3:9999/timers/0000000000000001-2"] = CURLE_OK;
+
+  _replicator->replicate(timer1);
+
+  // The timer's been sent when fakecurl records the request. Sleep until then.
+  std::map<std::string, Request>::iterator it =
+      fakecurl_requests.find("http://10.0.0.3:9999/timers/0000000000000001-2");
+  int count = 0;
+  while (it == fakecurl_requests.end() && count < 10)
+  {
+    // Don't wait for more than 10 seconds
+    count++;
+    sleep(1);
+    it = fakecurl_requests.find("http://10.0.0.3:9999/timers/0000000000000001-2");
+  }
+
+  if (count >= 10)
+  {
+    printf("No request was sent that matched the expected timer\n");
+  }
+  ASSERT_TRUE(it != fakecurl_requests.end());
+
+  // Look at the body sent on the request. Check that it doesn't have any
+  // replica information, and that it makes a valid timer
+  Request& request = it->second;
+  rapidjson::Document doc;
+  doc.Parse<0>(request._body.c_str());
+  EXPECT_FALSE(doc.HasParseError());
+  ASSERT_TRUE(doc.HasMember("reliability"));
+  EXPECT_TRUE(doc["reliability"].HasMember("replicas"));
+
+  std::string error;
+  bool replicated;
+  bool gr_replicated;
+
+  Timer* timer2 = Timer::from_json(1, 1, 0, request._body, error, replicated, gr_replicated);
+  EXPECT_TRUE(timer2);
+
+  delete timer1; timer1 = NULL;
+  delete timer2; timer2 = NULL;
+}
+
+// Test that replication failure is handled correctly
+TEST_F(TestReplicator, FailedReplica)
+{
+  Timer* timer1 = default_timer(1);
+  timer1->_replication_factor = 2;
+  timer1->replicas.push_back("10.0.0.2:9999");
+  EXPECT_TRUE(timer1->replicas.size() == 2);
+  fakecurl_responses["http://10.0.0.2:9999/timers/0000000000000001-2"] = CURLE_HTTP_RETURNED_ERROR;
+
+  _replicator->replicate(timer1);
+
+  // The timer's been sent when fakecurl records the request. Sleep until then.
+  std::map<std::string, Request>::iterator it =
+      fakecurl_requests.find("http://10.0.0.2:9999/timers/0000000000000001-2");
+  int count = 0;
+  while (it == fakecurl_requests.end() && count < 10)
+  {
+    // Don't wait for more than 10 seconds
+    count++;
+    sleep(1);
+    it = fakecurl_requests.find("http://10.0.0.2:9999/timers/0000000000000001-2");
+  }
+
+  if (count >= 10)
+  {
+    printf("No request was sent that matched the expected timer\n");
+  }
+  ASSERT_TRUE(it != fakecurl_requests.end());
+
+  // Look at the body sent on the request. Check that it doesn't have any
+  // replica information, and that it makes a valid timer
+  Request& request = it->second;
+  rapidjson::Document doc;
+  doc.Parse<0>(request._body.c_str());
+  EXPECT_FALSE(doc.HasParseError());
+  ASSERT_TRUE(doc.HasMember("reliability"));
+  EXPECT_TRUE(doc["reliability"].HasMember("replicas"));
+
+  std::string error;
+  bool replicated;
+  bool gr_replicated;
+
+  Timer* timer2 = Timer::from_json(1, 1, 0, request._body, error, replicated, gr_replicated);
+  EXPECT_TRUE(timer2);
+
+  delete timer1; timer1 = NULL;
+  delete timer2; timer2 = NULL;
+}
+
+// Test that a non-local timer replica is replicated successfully
+TEST_F(TestReplicator, ReplicateToNode)
+{
+  Timer* timer1 = default_timer(1);
+  timer1->_replication_factor = 1;
+  EXPECT_TRUE(timer1->replicas.size() == 1);
+  fakecurl_responses["http://ReplicateToNode:9999/timers/0000000000000001-1"] = CURLE_OK;
+  // TODO get fakecurl to recognise ReplicateToNode, rather than seeing it as 10.42.42.42 
+  fakecurl_responses["http://10.42.42.42:9999/timers/0000000000000001-1"] = CURLE_OK;
+
+  _replicator->replicate_timer_to_node(timer1,"ReplicateToNode:9999");
+
+  // The timer's been sent when fakecurl records the request. Sleep until then.
+  std::map<std::string, Request>::iterator it =
+      fakecurl_requests.find("http://ReplicateToNode:9999/timers/0000000000000001-1");
+  int count = 0;
+  while (it == fakecurl_requests.end() && count < 10)
+  {
+    // Don't wait for more than 10 seconds
+    count++;
+    sleep(1);
+    it = fakecurl_requests.find("http://ReplicateToNode:9999/timers/0000000000000001-1");
+  }
+
+  if (count >= 10)
+  {
+    printf("No request was sent that matched the expected timer\n");
+  }
+  ASSERT_TRUE(it != fakecurl_requests.end());
+
+  // Look at the body sent on the request. Check that it doesn't have any
+  // replica information, and that it makes a valid timer
+  Request& request = it->second;
+  rapidjson::Document doc;
+  doc.Parse<0>(request._body.c_str());
+  EXPECT_FALSE(doc.HasParseError());
+  ASSERT_TRUE(doc.HasMember("reliability"));
+  EXPECT_TRUE(doc["reliability"].HasMember("replicas"));
+
+  std::string error;
+  bool replicated;
+  bool gr_replicated;
+
+  Timer* timer2 = Timer::from_json(1, 1, 0, request._body, error, replicated, gr_replicated);
+  EXPECT_TRUE(timer2);
+
+  delete timer1; timer1 = NULL;
+  delete timer2; timer2 = NULL;
+}
+
+

--- a/src/ut/test_replicator.cpp
+++ b/src/ut/test_replicator.cpp
@@ -222,8 +222,6 @@ TEST_F(TestReplicator, ReplicateToNode)
   Timer* timer1 = default_timer(1);
   timer1->_replication_factor = 1;
   EXPECT_TRUE(timer1->replicas.size() == 1);
-  fakecurl_responses["http://ReplicateToNode:9999/timers/0000000000000001-1"] = CURLE_OK;
-  // TODO get fakecurl to recognise ReplicateToNode, rather than seeing it as 10.42.42.42 
   fakecurl_responses["http://10.42.42.42:9999/timers/0000000000000001-1"] = CURLE_OK;
 
   _replicator->replicate_timer_to_node(timer1,"ReplicateToNode:9999");


### PR DESCRIPTION
Moves us over to using the httpclient in all Chronos, which is good.
I've also added the exception handler to the http_callback code.

There's a couple of things marked as TODO in my changes, which are obviously not the final thing. The first one is about send_post in http_callback, where i think we just need to re-work the httpclient to get done nively, so i'm tracking that elsewhere, and will probably just remove the comment. 
The second i'd like to chat about once you've had a look, as i don't really understand why it isn't 'just working'.
Also, Replicator is now fully UT covered :champagne: 