### PR TITLE
[Reviewer: AJH] Log basic stack trace unless aborting

### DIFF
--- a/debian/chronos.logrotate
+++ b/debian/chronos.logrotate
@@ -1,0 +1,11 @@
+/var/log/chronos/chronos_err.log {
+        rotate 4
+        weekly
+        minsize 1M
+        missingok
+        create 640 root adm
+        notifempty
+        compress
+        delaycompress
+        copytruncate
+}

--- a/include/globals.h
+++ b/include/globals.h
@@ -53,6 +53,7 @@ public:
   GLOBAL(bind_port, int);
   GLOBAL(threads, int);
   GLOBAL(gr_threads, int);
+  GLOBAL(logging_folder, std::string);
 
   // Clustering configuration
   GLOBAL(cluster_local_ip, std::string);

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -126,8 +126,12 @@ void Globals::update_config()
 
   // Set up the per node configuration. Set up logging early so we can
   // log the other settings
+  std::string logging_folder = conf_map["logging.folder"].as<std::string>();
+  set_logging_folder(logging_folder);
+  TRC_STATUS("Logging folder: %s", logging_folder.c_str());
+
 #ifndef UNIT_TEST
-  Log::setLogger(new Logger(conf_map["logging.folder"].as<std::string>(), "chronos"));
+  Log::setLogger(new Logger(logging_folder, "chronos"));
   Log::setLoggingLevel(conf_map["logging.level"].as<int>());
 #endif
 

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -128,7 +128,6 @@ void Globals::update_config()
   // log the other settings
   std::string logging_folder = conf_map["logging.folder"].as<std::string>();
   set_logging_folder(logging_folder);
-  TRC_STATUS("Logging folder: %s", logging_folder.c_str());
 
 #ifndef UNIT_TEST
   Log::setLogger(new Logger(logging_folder, "chronos"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -151,17 +151,24 @@ void signal_handler(int sig)
   signal(SIGABRT, SIG_DFL);
   signal(SIGSEGV, signal_handler);
 
-  // Log the signal, along with a backtrace.
+  // Log the signal, along with a simple backtrace.
   TRC_BACKTRACE("Signal %d caught", sig);
-
-  // Ensure the log files are complete - the core file created by abort() below
-  // will trigger the log files to be copied to the diags bundle
-  TRC_COMMIT();
 
   // Check if there's a stored jmp_buf on the thread and handle if there is
   exception_handler->handle_exception();
 
+  //
+  // If we get here it means we didn't handle the exception so we need to exit.
+  //
+
   CL_CHRONOS_CRASHED.log(strsignal(sig));
+
+  // Log a full backtrace to make debugging easier.
+  TRC_BACKTRACE_ADV();
+
+  // Ensure the log files are complete - the core file created by abort() below
+  // will trigger the log files to be copied to the diags bundle
+  TRC_COMMIT();
 
   // Dump a core.
   abort();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -243,6 +243,17 @@ int main(int argc, char** argv)
                           options.cluster_config_file,
                           options.shared_config_file);
 
+  // Redirect stderr to chronos_err.log. This is done here and not in the call
+  // to daemonize because we need to have __globals to know the logging folder.
+  std::string logging_folder;
+  __globals->get_logging_folder(logging_folder);
+  std::string err = logging_folder + "/chronos_err.log";
+  if (freopen(err.c_str(), "a", stderr) == NULL)
+  {
+    TRC_ERROR("Failed to redirect stderr");
+    exit(0);
+  }
+
   AlarmManager* alarm_manager = NULL;
   Alarm* resync_operation_alarm = NULL;
   CommunicationMonitor* remote_chronos_comm_monitor = NULL;


### PR DESCRIPTION
Make the corresponding changes from Metaswitch/sprout#2025 to chronos.

I needed to make a few more changes to get this to work with chronos since it has a different config model:
 - Chronos needs to call `daemonize()` before creating `__globals` to hold the configuration since globals creates an updater thread, and we can't do that before daemonizing. I need the config in hand to know Chronos's logging direcroty so I've called `freopen` manually after `__globals` is set up to redirect stderr to `chronos_err.log`
- I added a logrotate file for `chronos_err.log`.

Tested by sending signal 11 into chronos and checking that stuff gets written to `chronos_err.log`.