### PR TITLE
[Reviewer: Ellie] Merge handler_replicator and controller_replicator into one

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -360,10 +360,8 @@ int main(int argc, char** argv)
   __globals->get_gr_threads(gr_threads);
 
   TimerStore* store = new TimerStore(hc);
-  Replicator* controller_rep = new Replicator(http_resolver,
-                                              exception_handler);
-  Replicator* handler_rep = new Replicator(http_resolver,
-                                           exception_handler);
+  Replicator* local_rep = new Replicator(http_resolver,
+                                         exception_handler);
   GRReplicator* gr_rep = new GRReplicator(http_resolver,
                                           exception_handler,
                                           gr_threads,
@@ -372,7 +370,7 @@ int main(int argc, char** argv)
                                             exception_handler);
   TimerHandler* handler = new TimerHandler(store,
                                            callback,
-                                           handler_rep,
+                                           local_rep,
                                            gr_rep,
                                            all_timers_table,
                                            total_timers_table,
@@ -409,7 +407,7 @@ int main(int argc, char** argv)
                                         load_monitor,
                                         NULL);
   HttpStackUtils::PingHandler ping_handler;
-  ControllerTask::Config controller_config(controller_rep, gr_rep, handler);
+  ControllerTask::Config controller_config(local_rep, gr_rep, handler);
   HttpStackUtils::SpawningHandler<ControllerTask, ControllerTask::Config> controller_handler(&controller_config,
                                                                                              &HttpStack::NULL_SAS_LOGGER);
 
@@ -436,7 +434,7 @@ int main(int argc, char** argv)
   ChronosInternalConnection* chronos_internal_connection =
             new ChronosInternalConnection(http_resolver,
                                           handler,
-                                          handler_rep,
+                                          local_rep,
                                           resync_operation_alarm,
                                           remaining_nodes_scalar,
                                           timers_processed_table,
@@ -461,8 +459,7 @@ int main(int argc, char** argv)
   delete handler; handler = NULL;
   // Callback is deleted by the handler
   delete gr_rep; gr_rep = NULL;
-  delete handler_rep; handler_rep = NULL;
-  delete controller_rep; controller_rep = NULL;
+  delete local_rep; local_rep = NULL;
   delete store; store = NULL;
   delete http_resolver; http_resolver = NULL;
   delete dns_updater; dns_updater = NULL;


### PR DESCRIPTION
As raised in https://github.com/Metaswitch/chronos/pull/367#discussion_r153578364 , chronos shouldn't really have multiple replicators. We didn't want to make the change at that time in case it was destabilising, but should be good to go now. 

We still pass full_test and fv_test. For live testing i used Rob's script as from https://github.com/Metaswitch/clearwater-issues/issues/2375#issuecomment-349085546, and modified it to send in 1 million timers. Pointed it at one vellum in a 2 vellum deployment in EC2, and all seems to be working as expected. Timers are popping on both nodes, and Chronos isn't dead. 