### PR TITLE
[Reviewer: Adam] Use the new HTTP interface from cpp-common

### DIFF
--- a/include/chronos_gr_connection.h
+++ b/include/chronos_gr_connection.h
@@ -32,7 +32,8 @@ public:
 
 private:
   std::string _site_name;
-  HttpConnection* _http;
+  HttpClient* _http_client;
+  HttpConnection* _http_conn;
   BaseCommunicationMonitor* _comm_monitor;
 };
 

--- a/include/chronos_internal_connection.h
+++ b/include/chronos_internal_connection.h
@@ -26,7 +26,7 @@
 class ChronosInternalConnection
 {
 public:
-  ChronosInternalConnection(HttpResolver* resolver,
+  ChronosInternalConnection(HttpClient* client,
                             TimerHandler* handler,
                             Replicator* replicator,
                             Alarm* alarm,
@@ -88,12 +88,6 @@ private:
                             const std::string& server_to_sync,
                             std::vector<std::string> cluster_nodes,
                             std::string localhost);
-
-  // Builds an HttpRequest
-  virtual HttpRequest build_request(
-                            const std::string& server,
-                            const std::string& path,
-                            HttpClient::RequestType method);
 };
 
 #endif

--- a/include/chronos_internal_connection.h
+++ b/include/chronos_internal_connection.h
@@ -90,7 +90,7 @@ private:
                             std::string localhost);
 
   // Builds an HttpRequest
-  virtual std::unique_ptr<HttpRequest> build_request(
+  virtual HttpRequest build_request(
                             const std::string& server,
                             const std::string& path,
                             HttpClient::RequestType method);

--- a/include/chronos_internal_connection.h
+++ b/include/chronos_internal_connection.h
@@ -32,7 +32,8 @@ public:
                             Alarm* alarm,
                             SNMP::U32Scalar* _remaining_nodes_scalar = NULL,
                             SNMP::CounterTable* _timers_processed_table = NULL,
-                            SNMP::CounterTable* _invalid_timers_processed_table = NULL);
+                            SNMP::CounterTable* _invalid_timers_processed_table = NULL,
+                            bool resync_on_start = true);
   virtual ~ChronosInternalConnection();
 
   // Performs a resynchronization operation
@@ -87,6 +88,12 @@ private:
                             const std::string& server_to_sync,
                             std::vector<std::string> cluster_nodes,
                             std::string localhost);
+
+  // Builds an HttpRequest
+  virtual std::unique_ptr<HttpRequest> build_request(
+                            const std::string& server,
+                            const std::string& path,
+                            HttpClient::RequestType method);
 };
 
 #endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -68,7 +68,7 @@ chronos_test_SOURCES := ${COMMON_SOURCES} \
                         test_http_callback.cpp \
                         fakelogger.cpp \
                         mock_sas.cpp \
-                        mock_http_request.cpp \
+                        mock_httpclient.cpp \
                         mockhttpstack.cpp \
                         fakecurl.cpp \
                         pthread_cond_var_helper.cpp \

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,7 +25,7 @@ COMMON_SOURCES := chronos_internal_connection.cpp \
                   exception_handler.cpp \
                   http_connection_pool.cpp \
                   httpclient.cpp \
-                  httpconnection.cpp \
+                  http_request.cpp \
                   statistic.cpp \
                   baseresolver.cpp \
                   dnscachedresolver.cpp \
@@ -68,6 +68,7 @@ chronos_test_SOURCES := ${COMMON_SOURCES} \
                         test_http_callback.cpp \
                         fakelogger.cpp \
                         mock_sas.cpp \
+                        mock_http_request.cpp \
                         mockhttpstack.cpp \
                         fakecurl.cpp \
                         pthread_cond_var_helper.cpp \

--- a/src/chronos_gr_connection.cpp
+++ b/src/chronos_gr_connection.cpp
@@ -37,7 +37,7 @@ ChronosGRConnection::ChronosGRConnection(const std::string& remote_site,
                                 bind_address);
 
   _http_conn = new HttpConnection(remote_site,
-                                  _http_client)),
+                                  _http_client);
 }
 
 ChronosGRConnection::~ChronosGRConnection()

--- a/src/chronos_gr_connection.cpp
+++ b/src/chronos_gr_connection.cpp
@@ -39,9 +39,11 @@ ChronosGRConnection::~ChronosGRConnection()
 
 void ChronosGRConnection::send_put(std::string url,
                                    std::string body)
-{/* TODO sr2sr2
-  HTTPCode rc = _http->send_put(url, body, 0);*/
-  HTTPCode rc = 100;
+{
+  std::unique_ptr<HttpRequest> req = _http_conn->create_request(HttpClient::RequestType::PUT, url);
+  req->set_req_body(body);
+  HttpResponse resp = req->send();
+  HTTPCode rc = resp.get_return_code();
 
   if (rc != HTTP_OK)
   {

--- a/src/chronos_gr_connection.cpp
+++ b/src/chronos_gr_connection.cpp
@@ -49,9 +49,9 @@ ChronosGRConnection::~ChronosGRConnection()
 void ChronosGRConnection::send_put(std::string url,
                                    std::string body)
 {
-  std::unique_ptr<HttpRequest> req = _http_conn->create_request(HttpClient::RequestType::PUT, url);
-  req->set_body(body);
-  HttpResponse resp = req->send();
+  HttpRequest req = _http_conn->create_request(HttpClient::RequestType::PUT, url);
+  req.set_body(body);
+  HttpResponse resp = req.send();
   HTTPCode rc = resp.get_rc();
 
   if (rc != HTTP_OK)

--- a/src/chronos_gr_connection.cpp
+++ b/src/chronos_gr_connection.cpp
@@ -50,9 +50,9 @@ void ChronosGRConnection::send_put(std::string url,
                                    std::string body)
 {
   std::unique_ptr<HttpRequest> req = _http_conn->create_request(HttpClient::RequestType::PUT, url);
-  req->set_req_body(body);
+  req->set_body(body);
   HttpResponse resp = req->send();
-  HTTPCode rc = resp.get_return_code();
+  HTTPCode rc = resp.get_rc();
 
   if (rc != HTTP_OK)
   {

--- a/src/chronos_gr_connection.cpp
+++ b/src/chronos_gr_connection.cpp
@@ -39,8 +39,9 @@ ChronosGRConnection::~ChronosGRConnection()
 
 void ChronosGRConnection::send_put(std::string url,
                                    std::string body)
-{
-  HTTPCode rc = _http->send_put(url, body, 0);
+{/* TODO sr2sr2
+  HTTPCode rc = _http->send_put(url, body, 0);*/
+  HTTPCode rc = 100;
 
   if (rc != HTTP_OK)
   {

--- a/src/chronos_gr_connection.cpp
+++ b/src/chronos_gr_connection.cpp
@@ -17,19 +17,24 @@ ChronosGRConnection::ChronosGRConnection(const std::string& remote_site,
                                          HttpResolver* resolver,
                                          BaseCommunicationMonitor* comm_monitor) :
   _site_name(remote_site),
-  _http(new HttpConnection(remote_site,
-                           false,
-                           resolver,
-                           SASEvent::HttpLogLevel::NONE,
-                           NULL,
-                           true)),
+  _http_client(new HttpClient(false,
+                              resolver,
+                              nullptr,
+                              nullptr,
+                              SASEvent::HttpLogLevel::NONE,
+                              nullptr,
+                              false,
+                              true)),
+  _http_conn(new HttpConnection(remote_site,
+                                _http_client)),
   _comm_monitor(comm_monitor)
 {
 }
 
 ChronosGRConnection::~ChronosGRConnection()
 {
-  delete _http; _http = NULL;
+  delete _http_conn; _http_conn = nullptr;
+  delete _http_client; _http_client = nullptr;
 }
 
 void ChronosGRConnection::send_put(std::string url,

--- a/src/chronos_gr_connection.cpp
+++ b/src/chronos_gr_connection.cpp
@@ -49,9 +49,9 @@ ChronosGRConnection::~ChronosGRConnection()
 void ChronosGRConnection::send_put(std::string url,
                                    std::string body)
 {
-  HttpRequest req = _http_conn->create_request(HttpClient::RequestType::PUT, url);
-  req.set_body(body);
-  HttpResponse resp = req.send();
+  HttpResponse resp = _http_conn->create_request(HttpClient::RequestType::PUT, url)
+    .set_body(body)
+    .send();
   HTTPCode rc = resp.get_rc();
 
   if (rc != HTTP_OK)

--- a/src/chronos_internal_connection.cpp
+++ b/src/chronos_internal_connection.cpp
@@ -452,7 +452,6 @@ HTTPCode ChronosInternalConnection::resynchronise_with_single_node(
 HTTPCode ChronosInternalConnection::send_delete(const std::string& server,
                                                 const std::string& body)
 {
-  TRC_ERROR("sr2sr2 send_delete with body %s", body.c_str());
   std::string path = "/timers/references";
   std::unique_ptr<HttpRequest> req =
     build_request(server, path, HttpClient::RequestType::DELETE);

--- a/src/chronos_internal_connection.cpp
+++ b/src/chronos_internal_connection.cpp
@@ -449,9 +449,9 @@ HTTPCode ChronosInternalConnection::send_delete(const std::string& server,
                                                 const std::string& body)
 {
   std::string path = "/timers/references";
-  HttpRequest req(server, "http", _http, HttpClient::RequestType::DELETE, path);
-  req.set_body(body);
-  HttpResponse resp = req.send();
+  HttpResponse resp = HttpRequest(server, "http", _http, HttpClient::RequestType::DELETE, path)
+    .set_body(body)
+    .send();
   HTTPCode rc = resp.get_rc();
 
   return rc;
@@ -484,9 +484,9 @@ HTTPCode ChronosInternalConnection::send_get(const std::string& server,
   std::string range_header = std::string(HEADER_RANGE) + ":" +
                              std::to_string(MAX_TIMERS_IN_RESPONSE);
 
-  HttpRequest req(server, "http", _http, HttpClient::RequestType::GET, path);
-  req.add_header(range_header);
-  HttpResponse  resp = req.send();
+  HttpResponse resp = HttpRequest(server, "http", _http, HttpClient::RequestType::GET, path)
+    .add_header(range_header)
+    .send();
   HTTPCode rc = resp.get_rc();
   response = resp.get_body();
 

--- a/src/chronos_internal_connection.cpp
+++ b/src/chronos_internal_connection.cpp
@@ -467,9 +467,9 @@ HTTPCode ChronosInternalConnection::send_delete(const std::string& server,
   std::string path = "/timers/references";
   std::unique_ptr<HttpRequest> req =
     build_request(server, path, HttpClient::RequestType::DELETE);
-  req->set_req_body(body);
+  req->set_body(body);
   HttpResponse resp = req->send();
-  HTTPCode rc = resp.get_return_code();
+  HTTPCode rc = resp.get_rc();
 
   return rc;
 }
@@ -504,10 +504,10 @@ HTTPCode ChronosInternalConnection::send_get(const std::string& server,
   std::unique_ptr<HttpRequest> req = build_request(server,
                                                    path,
                                                    HttpClient::RequestType::GET);
-  req->add_req_header(range_header);
+  req->add_header(range_header);
   HttpResponse  resp = req->send();
-  HTTPCode rc = resp.get_return_code();
-  response = resp.get_resp_body();
+  HTTPCode rc = resp.get_rc();
+  response = resp.get_body();
 
   return rc;
 }

--- a/src/chronos_internal_connection.cpp
+++ b/src/chronos_internal_connection.cpp
@@ -33,7 +33,8 @@ ChronosInternalConnection::ChronosInternalConnection(HttpResolver* resolver,
                                                      Alarm* alarm,
                                                      SNMP::U32Scalar* remaining_nodes_scalar,
                                                      SNMP::CounterTable* timers_processed_table,
-                                                     SNMP::CounterTable* invalid_timers_processed_table) :
+                                                     SNMP::CounterTable* invalid_timers_processed_table,
+                                                     bool resync_on_start) :
   _http(new HttpClient(false,
                        resolver,
                        SASEvent::HttpLogLevel::NONE,
@@ -52,7 +53,7 @@ ChronosInternalConnection::ChronosInternalConnection(HttpResolver* resolver,
                    (this,
                    std::mem_fun(&ChronosInternalConnection::resynchronize),
                    &_sigusr1_handler,
-                   true);
+                   resync_on_start);
 
   // Zero the statistic to start with
   if (_remaining_nodes_scalar)
@@ -542,3 +543,15 @@ bool ChronosInternalConnection::get_replica_level(int& index,
   return false;
 }
 
+std::unique_ptr<HttpRequest> ChronosInternalConnection::build_request(
+                                                 const std::string& server,
+                                                 const std::string& path,
+                                                 HttpClient::RequestType method)
+{
+  std::unique_ptr<HttpRequest> req(new HttpRequest(server,
+                                                   "http",
+                                                   _http,
+                                                   method,
+                                                   path));
+  return req;
+}

--- a/src/chronos_internal_connection.cpp
+++ b/src/chronos_internal_connection.cpp
@@ -465,10 +465,9 @@ HTTPCode ChronosInternalConnection::send_delete(const std::string& server,
                                                 const std::string& body)
 {
   std::string path = "/timers/references";
-  std::unique_ptr<HttpRequest> req =
-    build_request(server, path, HttpClient::RequestType::DELETE);
-  req->set_body(body);
-  HttpResponse resp = req->send();
+  HttpRequest req = build_request(server, path, HttpClient::RequestType::DELETE);
+  req.set_body(body);
+  HttpResponse resp = req.send();
   HTTPCode rc = resp.get_rc();
 
   return rc;
@@ -501,11 +500,9 @@ HTTPCode ChronosInternalConnection::send_get(const std::string& server,
   std::string range_header = std::string(HEADER_RANGE) + ":" +
                              std::to_string(MAX_TIMERS_IN_RESPONSE);
 
-  std::unique_ptr<HttpRequest> req = build_request(server,
-                                                   path,
-                                                   HttpClient::RequestType::GET);
-  req->add_header(range_header);
-  HttpResponse  resp = req->send();
+  HttpRequest req = build_request(server, path, HttpClient::RequestType::GET);
+  req.add_header(range_header);
+  HttpResponse  resp = req.send();
   HTTPCode rc = resp.get_rc();
   response = resp.get_body();
 
@@ -568,16 +565,16 @@ bool ChronosInternalConnection::get_replica_level(int& index,
 
 // LCOV_EXCL_START - In UTs, we test a subclass that overrides this method, to
 // allow us to return a MockHttpRequest
-std::unique_ptr<HttpRequest> ChronosInternalConnection::build_request(
+HttpRequest ChronosInternalConnection::build_request(
                                                  const std::string& server,
                                                  const std::string& path,
                                                  HttpClient::RequestType method)
 {
-  std::unique_ptr<HttpRequest> req(new HttpRequest(server,
-                                                   "http",
-                                                   _http,
-                                                   method,
-                                                   path));
+  HttpRequest req(server,
+                                  "http",
+                                  _http,
+                                  method,
+                                  path);
   return req;
 }
 // LCOV_EXCL_STOP

--- a/src/chronos_internal_connection.cpp
+++ b/src/chronos_internal_connection.cpp
@@ -449,7 +449,7 @@ HTTPCode ChronosInternalConnection::send_delete(const std::string& server,
                                                 const std::string& body)
 {
   std::string path = "/timers/references";
-  HttpRequest req = build_request(server, path, HttpClient::RequestType::DELETE);
+  HttpRequest req(server, "http", _http, HttpClient::RequestType::DELETE, path);
   req.set_body(body);
   HttpResponse resp = req.send();
   HTTPCode rc = resp.get_rc();
@@ -484,7 +484,7 @@ HTTPCode ChronosInternalConnection::send_get(const std::string& server,
   std::string range_header = std::string(HEADER_RANGE) + ":" +
                              std::to_string(MAX_TIMERS_IN_RESPONSE);
 
-  HttpRequest req = build_request(server, path, HttpClient::RequestType::GET);
+  HttpRequest req(server, "http", _http, HttpClient::RequestType::GET, path);
   req.add_header(range_header);
   HttpResponse  resp = req.send();
   HTTPCode rc = resp.get_rc();

--- a/src/chronos_internal_connection.cpp
+++ b/src/chronos_internal_connection.cpp
@@ -555,6 +555,8 @@ bool ChronosInternalConnection::get_replica_level(int& index,
   return false;
 }
 
+// LCOV_EXCL_START - In UTs, we test a subclass that overrides this method, to
+// allow us to return a MockHttpRequest
 std::unique_ptr<HttpRequest> ChronosInternalConnection::build_request(
                                                  const std::string& server,
                                                  const std::string& path,
@@ -567,3 +569,4 @@ std::unique_ptr<HttpRequest> ChronosInternalConnection::build_request(
                                                    path));
   return req;
 }
+// LCOV_EXCL_STOP

--- a/src/http_callback.cpp
+++ b/src/http_callback.cpp
@@ -127,15 +127,15 @@ void HTTPCallback::worker_thread_entry_point()
 
       if (valid_url)
       {
-        std::unique_ptr<HttpRequest> req(new HttpRequest(server,
-                                                         scheme,
-                                                         _http_client,
-                                                         HttpClient::RequestType::POST,
-                                                         path));
-        req->set_body(callback_body);
-        req->add_header(seq_no_hdr);
-        req->add_header(content_type_hdr);
-        HttpResponse resp = req->send();
+        HttpResponse resp = HttpRequest(server,
+                                        scheme,
+                                        _http_client,
+                                        HttpClient::RequestType::POST,
+                                        path)
+                            .set_body(callback_body)
+                            .add_header(seq_no_hdr)
+                            .add_header(content_type_hdr)
+                            .send();
         HTTPCode http_rc = resp.get_rc();
 
         if (http_rc == HTTP_OK)

--- a/src/http_callback.cpp
+++ b/src/http_callback.cpp
@@ -112,11 +112,13 @@ void HTTPCallback::worker_thread_entry_point()
       // on the request. Should fix this up soon, but we default the Content-Type
       // header, and aren't using Sequence Number, so not a huge issue atm.
       // Send the request.
+      /*TODO sr2sr2
       HTTPCode http_rc = _http_client.send_post(callback_url,
                                                 headers,
                                                 callback_body,
-                                                0L);
+                                                0L); */
 
+      HTTPCode http_rc = 100;
       if (http_rc == HTTP_OK)
       {
         // The callback succeeded, so we need to re-find the timer, and replicate it.

--- a/src/http_callback.cpp
+++ b/src/http_callback.cpp
@@ -112,12 +112,6 @@ void HTTPCallback::worker_thread_entry_point()
       // on the request. Should fix this up soon, but we default the Content-Type
       // header, and aren't using Sequence Number, so not a huge issue atm.
       // Send the request.
-      /*TODO sr2sr2
-      HTTPCode http_rc = _http_client.send_post(callback_url,
-                                                headers,
-                                                callback_body,
-                                                0L); */
-
       std::string server;
       std::string scheme;
       std::string path;

--- a/src/http_callback.cpp
+++ b/src/http_callback.cpp
@@ -132,11 +132,11 @@ void HTTPCallback::worker_thread_entry_point()
                                                          _http_client,
                                                          HttpClient::RequestType::POST,
                                                          path));
-        req->set_req_body(callback_body);
-        req->add_req_header(seq_no_hdr);
-        req->add_req_header(content_type_hdr);
+        req->set_body(callback_body);
+        req->add_header(seq_no_hdr);
+        req->add_header(content_type_hdr);
         HttpResponse resp = req->send();
-        HTTPCode http_rc = resp.get_return_code();
+        HTTPCode http_rc = resp.get_rc();
 
         if (http_rc == HTTP_OK)
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,14 +67,14 @@ enum OptionTypes
 
 const static struct option long_opt[] =
 {
-  {"local-config-file", required_argument, NULL, LOCAL_CONFIG_FILE},
-  {"cluster-config-file", required_argument, NULL, CLUSTER_CONFIG_FILE},
-  {"shared-config-file", required_argument, NULL, SHARED_CONFIG_FILE},
-  {"dns-config-file", required_argument, NULL, DNS_CONFIG_FILE},
-  {"pidfile", required_argument, NULL, PIDFILE},
-  {"daemon", no_argument, NULL, DAEMON},
-  {"help", no_argument, NULL, HELP},
-  {NULL, 0, NULL, 0},
+  {"local-config-file", required_argument, nullptr, LOCAL_CONFIG_FILE},
+  {"cluster-config-file", required_argument, nullptr, CLUSTER_CONFIG_FILE},
+  {"shared-config-file", required_argument, nullptr, SHARED_CONFIG_FILE},
+  {"dns-config-file", required_argument, nullptr, DNS_CONFIG_FILE},
+  {"pidfile", required_argument, nullptr, PIDFILE},
+  {"daemon", no_argument, nullptr, DAEMON},
+  {"help", no_argument, nullptr, HELP},
+  {nullptr, 0, nullptr, 0},
 };
 
 void usage(void)
@@ -241,7 +241,7 @@ int main(int argc, char** argv)
   }
 
   start_signal_handlers();
-  srand(time(NULL));
+  srand(time(nullptr));
 
   // Initialize the global configuration. Creating the __globals object
   // updates the global configuration. It also creates an updater thread,
@@ -255,21 +255,21 @@ int main(int argc, char** argv)
   std::string logging_folder;
   __globals->get_logging_folder(logging_folder);
   std::string err = logging_folder + "/chronos_err.log";
-  if (freopen(err.c_str(), "a", stderr) == NULL)
+  if (freopen(err.c_str(), "a", stderr) == nullptr)
   {
     TRC_ERROR("Failed to redirect stderr");
     exit(0);
   }
 
-  AlarmManager* alarm_manager = NULL;
-  Alarm* resync_operation_alarm = NULL;
-  CommunicationMonitor* remote_chronos_comm_monitor = NULL;
-  SNMP::U32Scalar* remaining_nodes_scalar = NULL;
-  SNMP::CounterTable* timers_processed_table = NULL;
-  SNMP::CounterTable* invalid_timers_processed_table = NULL;
-  SNMP::ContinuousIncrementTable* all_timers_table = NULL;
-  SNMP::InfiniteTimerCountTable* total_timers_table = NULL;
-  SNMP::InfiniteScalarTable* scalar_timers_table = NULL;
+  AlarmManager* alarm_manager = nullptr;
+  Alarm* resync_operation_alarm = nullptr;
+  CommunicationMonitor* remote_chronos_comm_monitor = nullptr;
+  SNMP::U32Scalar* remaining_nodes_scalar = nullptr;
+  SNMP::CounterTable* timers_processed_table = nullptr;
+  SNMP::CounterTable* invalid_timers_processed_table = nullptr;
+  SNMP::ContinuousIncrementTable* all_timers_table = nullptr;
+  SNMP::InfiniteTimerCountTable* total_timers_table = nullptr;
+  SNMP::InfiniteScalarTable* scalar_timers_table = nullptr;
 
   // Sets up SNMP statistics
   snmp_setup("chronos");
@@ -406,9 +406,9 @@ int main(int argc, char** argv)
 
   HttpStack* http_stack = new HttpStack(http_threads,
                                         exception_handler,
-                                        NULL,
+                                        nullptr,
                                         load_monitor,
-                                        NULL);
+                                        nullptr);
   HttpStackUtils::PingHandler ping_handler;
   ControllerTask::Config controller_config(local_rep, gr_rep, handler);
   HttpStackUtils::SpawningHandler<ControllerTask, ControllerTask::Config> controller_handler(&controller_config,
@@ -434,8 +434,21 @@ int main(int argc, char** argv)
 
   // Create a Chronos internal connection class for resynchronization operations.
   // We do this after creating the HTTPStack as it triggers a resync operation.
+  HttpClient* client = new HttpClient(false,
+                                      http_resolver,
+                                      nullptr,
+                                      nullptr,
+                                      SASEvent::HttpLogLevel::NONE,
+                                      nullptr,
+                                      false,
+                                      false,
+                                      -1,
+                                      false,
+                                      "",
+                                      bind_address);
+
   ChronosInternalConnection* chronos_internal_connection =
-            new ChronosInternalConnection(http_resolver,
+            new ChronosInternalConnection(client,
                                           handler,
                                           local_rep,
                                           resync_operation_alarm,
@@ -457,40 +470,41 @@ int main(int argc, char** argv)
     std::cerr << "Caught HttpStack::Exception" << std::endl;
   }
 
-  delete load_monitor; load_monitor = NULL;
-  delete chronos_internal_connection; chronos_internal_connection = NULL;
-  delete handler; handler = NULL;
+  delete load_monitor; load_monitor = nullptr;
+  delete chronos_internal_connection; chronos_internal_connection = nullptr;
+  delete client; client = nullptr;
+  delete handler; handler = nullptr;
   // Callback is deleted by the handler
-  delete gr_rep; gr_rep = NULL;
-  delete local_rep; local_rep = NULL;
-  delete store; store = NULL;
-  delete http_resolver; http_resolver = NULL;
-  delete dns_updater; dns_updater = NULL;
-  delete dns_resolver; dns_resolver = NULL;
+  delete gr_rep; gr_rep = nullptr;
+  delete local_rep; local_rep = nullptr;
+  delete store; store = nullptr;
+  delete http_resolver; http_resolver = nullptr;
+  delete dns_updater; dns_updater = nullptr;
+  delete dns_resolver; dns_resolver = nullptr;
 
-  delete scalar_timers_table; scalar_timers_table = NULL;
-  delete total_timers_table; total_timers_table = NULL;
-  delete all_timers_table; all_timers_table = NULL;
-  delete invalid_timers_processed_table; invalid_timers_processed_table = NULL;
-  delete timers_processed_table; timers_processed_table = NULL;
-  delete remaining_nodes_scalar; remaining_nodes_scalar = NULL;
+  delete scalar_timers_table; scalar_timers_table = nullptr;
+  delete total_timers_table; total_timers_table = nullptr;
+  delete all_timers_table; all_timers_table = nullptr;
+  delete invalid_timers_processed_table; invalid_timers_processed_table = nullptr;
+  delete timers_processed_table; timers_processed_table = nullptr;
+  delete remaining_nodes_scalar; remaining_nodes_scalar = nullptr;
 
-  delete exception_handler; exception_handler = NULL;
+  delete exception_handler; exception_handler = nullptr;
   hc->stop_thread();
-  delete hc; hc = NULL;
+  delete hc; hc = nullptr;
 
   // Delete Chronos's alarm object
   delete resync_operation_alarm;
   delete remote_chronos_comm_monitor;
   delete alarm_manager;
-  delete http_stack; http_stack = NULL;
+  delete http_stack; http_stack = nullptr;
 
   sem_destroy(&term_sem);
 
   // After this point nothing will use __globals so it's safe to delete
   // it here.
   CL_CHRONOS_ENDED.log();
-  delete __globals; __globals = NULL;
+  delete __globals; __globals = nullptr;
   curl_global_cleanup();
 
   return 0;

--- a/src/replicator.cpp
+++ b/src/replicator.cpp
@@ -139,13 +139,13 @@ void Replicator::worker_thread_entry_point()
 
       if (valid_url)
       {
-        std::unique_ptr<HttpRequest> req(new HttpRequest(server,
-                                                         scheme,
-                                                         _http_client,
-                                                         HttpClient::RequestType::PUT,
-                                                         path));
-        req->set_body(replication_body);
-        HttpResponse resp = req->send();
+        HttpResponse resp = HttpRequest(server,
+                                        scheme,
+                                        _http_client,
+                                        HttpClient::RequestType::PUT,
+                                        path)
+                            .set_body(replication_body)
+                            .send();
         HTTPCode http_rc = resp.get_rc();
 
         if (http_rc != HTTP_OK)

--- a/src/replicator.cpp
+++ b/src/replicator.cpp
@@ -144,9 +144,9 @@ void Replicator::worker_thread_entry_point()
                                                          _http_client,
                                                          HttpClient::RequestType::PUT,
                                                          path));
-        req->set_req_body(replication_body);
+        req->set_body(replication_body);
         HttpResponse resp = req->send();
-        HTTPCode http_rc = resp.get_return_code();
+        HTTPCode http_rc = resp.get_rc();
 
         if (http_rc != HTTP_OK)
         {

--- a/src/replicator.cpp
+++ b/src/replicator.cpp
@@ -142,10 +142,12 @@ void Replicator::worker_thread_entry_point()
                     http_rc);
         }
       }
+      //LCOV_EXCL_START
       else
       {
         TRC_DEBUG("Invalid URL for replication: %s", replication_url.c_str());
       }
+      // LCOV_EXCL_STOP
     }
     //LCOV_EXCL_START - No exception testing in UT
     CW_EXCEPT(_exception_handler)

--- a/src/replicator.cpp
+++ b/src/replicator.cpp
@@ -118,18 +118,33 @@ void Replicator::worker_thread_entry_point()
     {
       std::string replication_url = replication_request->url.c_str();
       std::string replication_body = replication_request->body.data();
-      // Send the request.
-      /*TODO sr2sr2
-      HTTPCode http_rc = _http_client.send_put(replication_url,
-                                               replication_body,
-                                               0L); // SAS trail */
-      HTTPCode http_rc = 100;
 
-      if (http_rc != HTTP_OK)
+      std::string server;
+      std::string scheme;
+      std::string path;
+      bool valid_url = Utils::parse_http_url(replication_url, scheme, server, path);
+
+      if (valid_url)
       {
-        TRC_DEBUG("Failed to process replication for %s. HTTP rc %ld",
-                  replication_url.c_str(),
-                  http_rc);
+        std::unique_ptr<HttpRequest> req(new HttpRequest(server,
+                                                        scheme,
+                                                        &_http_client,
+                                                        HttpClient::RequestType::PUT,
+                                                        path));
+        req->set_req_body(replication_body);
+        HttpResponse resp = req->send();
+        HTTPCode http_rc = resp.get_return_code();
+
+        if (http_rc != HTTP_OK)
+        {
+          TRC_DEBUG("Failed to process replication for %s. HTTP rc %ld",
+                    replication_url.c_str(),
+                    http_rc);
+        }
+      }
+      else
+      {
+        TRC_DEBUG("Invalid URL for replication: %s", replication_url.c_str());
       }
     }
     //LCOV_EXCL_START - No exception testing in UT

--- a/src/replicator.cpp
+++ b/src/replicator.cpp
@@ -119,9 +119,11 @@ void Replicator::worker_thread_entry_point()
       std::string replication_url = replication_request->url.c_str();
       std::string replication_body = replication_request->body.data();
       // Send the request.
+      /*TODO sr2sr2
       HTTPCode http_rc = _http_client.send_put(replication_url,
                                                replication_body,
-                                               0L); // SAS trail
+                                               0L); // SAS trail */
+      HTTPCode http_rc = 100;
 
       if (http_rc != HTTP_OK)
       {

--- a/src/replicator.cpp
+++ b/src/replicator.cpp
@@ -127,10 +127,10 @@ void Replicator::worker_thread_entry_point()
       if (valid_url)
       {
         std::unique_ptr<HttpRequest> req(new HttpRequest(server,
-                                                        scheme,
-                                                        &_http_client,
-                                                        HttpClient::RequestType::PUT,
-                                                        path));
+                                                         scheme,
+                                                         &_http_client,
+                                                         HttpClient::RequestType::PUT,
+                                                         path));
         req->set_req_body(replication_body);
         HttpResponse resp = req->send();
         HTTPCode http_rc = resp.get_return_code();

--- a/src/ut/test_chronos_internal_connection.cpp
+++ b/src/ut/test_chronos_internal_connection.cpp
@@ -76,7 +76,6 @@ class TestChronosInternalConnection : public ChronosInternalConnection
                             const std::string& path,
                             HttpClient::RequestType method) override
   {
-    TRC_ERROR("sr2sr2 build req with method %d \n server %s \n and parth %s", method, server.c_str(), path.c_str());
     std::unique_ptr<HttpRequest> req(build_request_proxy(server, path, method));
     return req;
   }

--- a/src/ut/test_chronos_internal_connection.cpp
+++ b/src/ut/test_chronos_internal_connection.cpp
@@ -20,11 +20,15 @@
 #include "globals.h"
 #include "fakesnmp.hpp"
 #include "test_interposer.hpp"
+#include "mock_http_request.h"
+#include "constants.h"
+
 
 using namespace std;
 using ::testing::_;
 using ::testing::Return;
 using ::testing::SaveArg;
+using ::testing::Mock;
 
 static SNMP::U32Scalar _fake_scalar("","");
 static SNMP::CounterTable* _fake_counter_table;
@@ -39,8 +43,51 @@ MATCHER(IsNotTombstone, "is not a tombstone")
   return !(arg->is_tombstone());
 }
 
+// We need to subclass ChronosInernalConnection so that we can test it using
+// MockHttpRequests.
+// To do this, we make it a Mock itself, which will allow us to:
+//   * check that build_request_proxy is called with the correct arguments
+//   * return a pointer to a MockHttpRequest from build_request_proxy, which we
+//     can then check has the correct methods called on it
+class TestChronosInternalConnection : public ChronosInternalConnection
+{
+  TestChronosInternalConnection(HttpResolver* resolver,
+                                TimerHandler* handler,
+                                Replicator* replicator,
+                                Alarm* alarm,
+                                SNMP::U32Scalar* _remaining_nodes_scalar,
+                                SNMP::CounterTable* _timers_processed_table,
+                                SNMP::CounterTable* _invalid_timers_processed_table)
+    : ChronosInternalConnection(resolver,
+                                handler,
+                                replicator,
+                                alarm,
+                                _remaining_nodes_scalar,
+                                _timers_processed_table,
+                                _invalid_timers_processed_table,
+                                false)
+  {
+  }
+
+  virtual ~TestChronosInternalConnection() {};
+
+  virtual std::unique_ptr<HttpRequest> build_request(
+                            const std::string& server,
+                            const std::string& path,
+                            HttpClient::RequestType method) override
+  {
+    TRC_ERROR("sr2sr2 build req with method %d \n server %s \n and parth %s", method, server.c_str(), path.c_str());
+    std::unique_ptr<HttpRequest> req(build_request_proxy(server, path, method));
+    return req;
+  }
+
+  MOCK_METHOD3(build_request_proxy, HttpRequest*(const std::string& server,
+                                                 const std::string& path,
+                                                 HttpClient::RequestType method));
+};
+
 /// Fixture for ChronosInternalConnectionTest.
-class TestChronosInternalConnection : public Base
+class ChronosInternalConnectionTest : public Base
 {
 protected:
   void SetUp()
@@ -53,20 +100,37 @@ protected:
     _resolver = new FakeHttpResolver("10.42.42.42");
     _replicator = new MockReplicator();
     _th = new MockTimerHandler();
-    fakecurl_responses["http://10.0.0.1:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"] = "{\"Timers\":[]}";
-    fakecurl_responses["http://10.0.0.2:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"] = "{\"Timers\":[]}";
-    fakecurl_responses["http://10.0.0.3:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"] = "{\"Timers\":[]}";
-    _chronos = new ChronosInternalConnection(_resolver,
-                                             _th,
-                                             _replicator,
-                                             NULL,
-                                             &_fake_scalar,
-                                             _fake_counter_table,
-                                             _fake_counter_table);
+
+    // Because we've inherited from Base, we had a cluster and resync will
+    // happen when we create the ChronosInternalConnection.
+    // We must therefore expect to get HTTP requests, and provide suitable
+    // responses
+    /*HttpResponse resp(HTTP_OK, "{\"Timers\":[]}", {});
+    MockHttpRequest* req1 = new MockHttpRequest();
+    MockHttpRequest* req2 = new MockHttpRequest();
+    MockHttpRequest* req3 = new MockHttpRequest();
+
+    EXPECT_CALL(*_chronos, build_request_proxy(_, _, HttpClient::RequestType::GET))
+      .Times(3)
+      .WillOnce(Return(req1))
+      .WillOnce(Return(req2))
+      .WillOnce(Return(req2));
+
+    EXPECT_CALL(*req1, send()).WillOnce(Return(resp));
+    EXPECT_CALL(*req2, send()).WillOnce(Return(resp));
+    EXPECT_CALL(*req3, send()).WillOnce(Return(resp));*/
+
+    _chronos = new TestChronosInternalConnection(_resolver,
+                                                 _th,
+                                                 _replicator,
+                                                 NULL,
+                                                 &_fake_scalar,
+                                                 _fake_counter_table,
+                                                 _fake_counter_table);
     __globals->get_cluster_staying_addresses(_cluster_addresses);
     __globals->get_cluster_local_ip(_local_ip);
 
-    fakecurl_responses.clear();
+    Mock::VerifyAndClear(_chronos);
   }
 
   void TearDown()
@@ -85,54 +149,141 @@ protected:
   FakeHttpResolver* _resolver;
   MockReplicator* _replicator;
   MockTimerHandler* _th;
-  ChronosInternalConnection* _chronos;
+  TestChronosInternalConnection* _chronos;
   std::vector<std::string> _cluster_addresses;
   std::string _local_ip;
 };
 
-TEST_F(TestChronosInternalConnection, SendDelete)
+TEST_F(ChronosInternalConnectionTest, SendDelete)
 {
-  fakecurl_responses["http://10.42.42.42:80/timers/references"] = CURLE_OK;
+  MockHttpRequest* mock_req = new MockHttpRequest();
+  HttpResponse resp(HTTP_OK, "", {});
+
+  // Expect that we'll build a DELETE request with the correct path and server
+  EXPECT_CALL(*_chronos, build_request_proxy("10.42.42.42:80",
+                                             "/timers/references",
+                                             HttpClient::RequestType::DELETE))
+    .WillOnce(Return(mock_req));
+
+  // Expect that the message is sent
+  EXPECT_CALL(*mock_req, set_req_body("{}")).Times(1);
+  EXPECT_CALL(*mock_req, send()).WillOnce(Return(resp));
+
   HTTPCode status = _chronos->send_delete("10.42.42.42:80", "{}");
-  EXPECT_EQ(status, 200);
+
+  // Check that we get the correct response
+  EXPECT_EQ(200, status);
 }
 
-TEST_F(TestChronosInternalConnection, SendGet)
+TEST_F(ChronosInternalConnectionTest, SendGet)
 {
-  fakecurl_responses["http://10.42.42.42:80/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id;time-from=10000"] = CURLE_OK;
   std::string response;
   bool use_time_from = true;
+
+  MockHttpRequest* mock_req = new MockHttpRequest();
+  HttpResponse resp(HTTP_OK, "response-body", {});
+
+  // Expect that we'll build a GET request with the correct path and server
+  EXPECT_CALL(*_chronos, build_request_proxy("10.42.42.42:80",
+                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id;time-from=10000",
+                                             HttpClient::RequestType::GET))
+    .WillOnce(Return(mock_req));
+
+  std::string range_header = std::string(HEADER_RANGE) + ":" +
+                             std::to_string(MAX_TIMERS_IN_RESPONSE);
+
+  // Expect that we add the correct range header to the request, then send it
+  EXPECT_CALL(*mock_req, add_req_header(range_header)).Times(1);
+  EXPECT_CALL(*mock_req, send()).WillOnce(Return(resp));
+
   std::string path = _chronos->create_path("10.0.0.1:9999", "cluster-view-id", 10000, use_time_from);
   HTTPCode status = _chronos->send_get("10.42.42.42:80", path, 0, response);
-  EXPECT_EQ(status, 200);
+
+  // Check that we got the correct response
+  EXPECT_EQ(200, status);
+  EXPECT_EQ("response-body", response);
 }
 
-TEST_F(TestChronosInternalConnection, SendTriggerNoResults)
+TEST_F(ChronosInternalConnectionTest, SendTriggerNoResults)
 {
-  fakecurl_responses["http://10.0.0.1:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"] = "{\"Timers\":[]}";
+  MockHttpRequest* resync_mock_req = new MockHttpRequest();
+  HttpResponse resp(HTTP_OK, "{\"Timers\":[]}", {});
+
+  // Expect that we'll build the GET request for the resync
+  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
+                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
+                                             HttpClient::RequestType::GET))
+    .WillOnce(Return(resync_mock_req));
+
+  // Expect that we'll add a header and send this request
+  EXPECT_CALL(*resync_mock_req, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req, send()).WillOnce(Return(resp));
+
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
-  EXPECT_EQ(status, 200);
+
+  // Check we got the correct response
+  EXPECT_EQ(200, status);
 }
 
-TEST_F(TestChronosInternalConnection, SendTriggerOneTimer)
+TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimer)
 {
-  fakecurl_responses["http://10.0.0.1:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.3:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}";
-  fakecurl_responses["http://10.0.0.1:9999/timers/references"] = HTTP_ACCEPTED;
-  fakecurl_responses["http://10.0.0.2:9999/timers/references"] = HTTP_ACCEPTED;
-  fakecurl_responses["http://10.0.0.3:9999/timers/references"] = HTTP_ACCEPTED;
   Timer* added_timer;
 
+  MockHttpRequest* resync_mock_req = new MockHttpRequest();
+  MockHttpRequest* delete_mock_req_1 = new MockHttpRequest();
+  MockHttpRequest* delete_mock_req_2 = new MockHttpRequest();
+  MockHttpRequest* delete_mock_req_3 = new MockHttpRequest();
+  HttpResponse resp(HTTP_OK, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.3:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}", {});
+  HttpResponse accepted(HTTP_ACCEPTED, "", {});
+
+  // Expect that we'll build the GET request for the resync, and then three DELETE
+  // requests which we send to each of the cluster nodes
+  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
+                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
+                                             HttpClient::RequestType::GET))
+    .WillOnce(Return(resync_mock_req));
+
+  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
+                                             "/timers/references",
+                                             HttpClient::RequestType::DELETE))
+    .WillOnce(Return(delete_mock_req_1));
+
+  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.2:9999",
+                                             "/timers/references",
+                                             HttpClient::RequestType::DELETE))
+    .WillOnce(Return(delete_mock_req_2));
+
+  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.3:9999",
+                                             "/timers/references",
+                                             HttpClient::RequestType::DELETE))
+    .WillOnce(Return(delete_mock_req_3));
+
+  // Expect that we'll add a header and send the GET request
+  EXPECT_CALL(*resync_mock_req, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req, send()).WillOnce(Return(resp));
+
+  // Expect that we'll add the timer, and save it off
   EXPECT_CALL(*_th, add_timer(_,_)).WillOnce(SaveArg<0>(&added_timer));
 
+  // Expect that the delete requests are sent with the correct body
+  EXPECT_CALL(*delete_mock_req_1, set_req_body("{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":0}]}")).Times(1);
+  EXPECT_CALL(*delete_mock_req_1, send()).WillOnce(Return(accepted));
+  EXPECT_CALL(*delete_mock_req_2, set_req_body("{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":0}]}")).Times(1);
+  EXPECT_CALL(*delete_mock_req_2, send()).WillOnce(Return(accepted));
+  EXPECT_CALL(*delete_mock_req_3, set_req_body("{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":0}]}")).Times(1);
+  EXPECT_CALL(*delete_mock_req_3, send()).WillOnce(Return(accepted));
+
+  // Expect that the timer is replicated
   EXPECT_CALL(*_replicator, replicate_timer_to_node(IsNotTombstone(), "10.0.0.3:9999")); // Update
   EXPECT_CALL(*_replicator, replicate_timer_to_node(IsTombstone(), "10.0.0.2:9999")); // Tombstone
+
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
-  EXPECT_EQ(status, 200);
+  EXPECT_EQ(200, status);
 
   delete added_timer; added_timer = NULL;
 }
 
-TEST_F(TestChronosInternalConnection, SendTriggerOneTimerWithTombstoneAndLeaving)
+TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimerWithTombstoneAndLeaving)
 {
   // Set leaving addresses in globals so that we look there as well.
   std::vector<std::string> leaving_cluster_addresses;
@@ -160,7 +311,7 @@ TEST_F(TestChronosInternalConnection, SendTriggerOneTimerWithTombstoneAndLeaving
 
 // Test that multiple requests are sent when the response indicates there are
 // more timers available. This also checks the time-from parameter.
-TEST_F(TestChronosInternalConnection, RepeatedTimers)
+TEST_F(ChronosInternalConnectionTest, RepeatedTimers)
 {
   // The first request has the time-from set to 0. Respond with a single timer
   // that has a delta of -235ms, and an interval of 100ms. Set the response
@@ -187,7 +338,7 @@ TEST_F(TestChronosInternalConnection, RepeatedTimers)
   delete added_timer; added_timer = NULL;
 }
 
-TEST_F(TestChronosInternalConnection, ResynchronizeWithTimers)
+TEST_F(ChronosInternalConnectionTest, ResynchronizeWithTimers)
 {
   std::vector<std::string> leaving_cluster_addresses;
   leaving_cluster_addresses.push_back("10.0.0.4:9999");
@@ -222,7 +373,7 @@ TEST_F(TestChronosInternalConnection, ResynchronizeWithTimers)
   _chronos->resynchronize();
 }
 
-TEST_F(TestChronosInternalConnection, ResynchronizeWithInvalidGetResponse)
+TEST_F(ChronosInternalConnectionTest, ResynchronizeWithInvalidGetResponse)
 {
   // Response has invalid JSON
   fakecurl_responses["http://10.0.0.1:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"] = "{\"Timers\":}";
@@ -235,7 +386,7 @@ TEST_F(TestChronosInternalConnection, ResynchronizeWithInvalidGetResponse)
   _chronos->resynchronize();
 }
 
-TEST_F(TestChronosInternalConnection, ResynchronizeWithGetRequestFailed)
+TEST_F(ChronosInternalConnectionTest, ResynchronizeWithGetRequestFailed)
 {
   // GET request fails
   fakecurl_responses["http://10.0.0.1:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"] = HTTP_BAD_REQUEST;
@@ -248,42 +399,42 @@ TEST_F(TestChronosInternalConnection, ResynchronizeWithGetRequestFailed)
   _chronos->resynchronize();
 }
 
-TEST_F(TestChronosInternalConnection, SendTriggerInvalidResultsInvalidJSON)
+TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultsInvalidJSON)
 {
   fakecurl_responses["http://10.0.0.1:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"] = "{\"Timers\":]}";
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(status, 400);
 }
 
-TEST_F(TestChronosInternalConnection, SendTriggerInvalidResultsNoTimers)
+TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultsNoTimers)
 {
   fakecurl_responses["http://10.0.0.1:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"] = "{\"Timer\":[]}";
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(status, 400);
 }
 
-TEST_F(TestChronosInternalConnection, SendTriggerInvalidEntryNoTimerObject)
+TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidEntryNoTimerObject)
 {
   fakecurl_responses["http://10.0.0.1:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"] = "{\"Timers\":[\"Timer\"]}";
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(status, 400);
 }
 
-TEST_F(TestChronosInternalConnection, SendTriggerInvalidEntryNoReplicas)
+TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidEntryNoReplicas)
 {
   fakecurl_responses["http://10.0.0.1:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"] = "{\"Timers\":[{\"TimerID\":4}]}";
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(status, 400);
 }
 
-TEST_F(TestChronosInternalConnection, SendTriggerInvalidResultNoTimer)
+TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultNoTimer)
 {
   fakecurl_responses["http://10.0.0.1:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"]}]}";
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(status, 400);
 }
 
-TEST_F(TestChronosInternalConnection, SendTriggerInvalidResultInvalidTimers)
+TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultInvalidTimers)
 {
   fakecurl_responses["http://10.0.0.1:9999/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"] = "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"], \"Timer\": {}}, {\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": {}}}]}";
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);

--- a/src/ut/test_chronos_internal_connection.cpp
+++ b/src/ut/test_chronos_internal_connection.cpp
@@ -19,12 +19,13 @@
 #include "globals.h"
 #include "fakesnmp.hpp"
 #include "test_interposer.hpp"
-#include "mock_http_request.h"
+#include "mock_httpclient.h"
 #include "constants.h"
 
 
 using namespace std;
 using ::testing::_;
+using ::testing::AllOf;
 using ::testing::Return;
 using ::testing::SaveArg;
 using ::testing::Mock;
@@ -43,48 +44,6 @@ MATCHER(IsNotTombstone, "is not a tombstone")
   return !(arg->is_tombstone());
 }
 
-// We need to subclass ChronosInernalConnection so that we can test it using
-// MockHttpRequests.
-// To do this, we make it a Mock itself, which will allow us to:
-//   * check that build_request_proxy is called with the correct arguments
-//   * return a pointer to a MockHttpRequest from build_request_proxy, which we
-//     can then check has the correct methods called on it
-class TestChronosInternalConnection : public ChronosInternalConnection
-{
-  TestChronosInternalConnection(HttpResolver* resolver,
-                                TimerHandler* handler,
-                                Replicator* replicator,
-                                Alarm* alarm,
-                                SNMP::U32Scalar* _remaining_nodes_scalar,
-                                SNMP::CounterTable* _timers_processed_table,
-                                SNMP::CounterTable* _invalid_timers_processed_table)
-    : ChronosInternalConnection(resolver,
-                                handler,
-                                replicator,
-                                alarm,
-                                _remaining_nodes_scalar,
-                                _timers_processed_table,
-                                _invalid_timers_processed_table,
-                                false)
-  {
-  }
-
-  virtual ~TestChronosInternalConnection() {};
-
-  virtual std::unique_ptr<HttpRequest> build_request(
-                            const std::string& server,
-                            const std::string& path,
-                            HttpClient::RequestType method) override
-  {
-    std::unique_ptr<HttpRequest> req(build_request_proxy(server, path, method));
-    return req;
-  }
-
-  MOCK_METHOD3(build_request_proxy, HttpRequest*(const std::string& server,
-                                                 const std::string& path,
-                                                 HttpClient::RequestType method));
-};
-
 /// Fixture for ChronosInternalConnectionTest.
 class ChronosInternalConnectionTest : public Base
 {
@@ -96,29 +55,29 @@ protected:
     cwtest_completely_control_time();
 
     _fake_counter_table = SNMP::CounterTable::create("","");
-    _resolver = new FakeHttpResolver("10.42.42.42");
     _replicator = new MockReplicator();
     _th = new MockTimerHandler();
+    _client = new MockHttpClient();
 
-    _chronos = new TestChronosInternalConnection(_resolver,
-                                                 _th,
-                                                 _replicator,
-                                                 NULL,
-                                                 &_fake_scalar,
-                                                 _fake_counter_table,
-                                                 _fake_counter_table);
+    _chronos = new ChronosInternalConnection(_client,
+                                             _th,
+                                             _replicator,
+                                             NULL,
+                                             &_fake_scalar,
+                                             _fake_counter_table,
+                                             _fake_counter_table,
+                                             false);
+
     __globals->get_cluster_staying_addresses(_cluster_addresses);
     __globals->get_cluster_local_ip(_local_ip);
-
-    Mock::VerifyAndClear(_chronos);
   }
 
   void TearDown()
   {
     delete _chronos;
+    delete _client;
     delete _th;
     delete _replicator;
-    delete _resolver;
     delete _fake_counter_table;
 
     cwtest_reset_time();
@@ -128,37 +87,42 @@ protected:
 
   // Template function for expecting a DELETE request to the specified server
   // for the specified timer
-  void expect_delete(const std::string& server, const std::string& timer)
+  void expect_delete(const std::string& server, const std::string& timer, int times=1)
   {
-    MockHttpRequest* mock_req = new MockHttpRequest();
+    //MockHttpRequest* mock_req = new MockHttpRequest();
+    /*
     EXPECT_CALL(*_chronos, build_request_proxy(server,
                                                "/timers/references",
                                                HttpClient::RequestType::DELETE))
       .WillOnce(Return(mock_req)).RetiresOnSaturation();
     EXPECT_CALL(*mock_req, set_body(timer)).Times(1);
     EXPECT_CALL(*mock_req, send()).WillOnce(Return(resp_accepted));
+    */
+    EXPECT_CALL(*_client, send_request(AllOf(IsDelete(),
+                                             HasServer(server),
+                                             HasBody(timer))))
+      .Times(times)
+      .WillRepeatedly(Return(resp_accepted))
+      .RetiresOnSaturation();
   }
 
-  FakeHttpResolver* _resolver;
   MockReplicator* _replicator;
   MockTimerHandler* _th;
-  TestChronosInternalConnection* _chronos;
+  ChronosInternalConnection* _chronos;
+  MockHttpClient* _client;
   std::vector<std::string> _cluster_addresses;
   std::string _local_ip;
 };
 
 TEST_F(ChronosInternalConnectionTest, SendDelete)
 {
-  MockHttpRequest* mock_req = new MockHttpRequest();
   HttpResponse ok(HTTP_OK, "{}", {});
 
-  EXPECT_CALL(*_chronos, build_request_proxy("10.42.42.42:80",
-                                             "/timers/references",
-                                             HttpClient::RequestType::DELETE))
-    .WillOnce(Return(mock_req));
-
-  EXPECT_CALL(*mock_req, set_body("{}")).Times(1);
-  EXPECT_CALL(*mock_req, send()).WillOnce(Return(ok));
+  EXPECT_CALL(*_client, send_request(AllOf(IsDelete(),
+                                           HasServer("10.42.42.42:80"),
+                                           HasPath("/timers/references"),
+                                           HasBody("{}"))))
+    .WillOnce(Return(ok));
 
   HTTPCode status = _chronos->send_delete("10.42.42.42:80", "{}");
 
@@ -170,22 +134,17 @@ TEST_F(ChronosInternalConnectionTest, SendGet)
 {
   std::string response;
   bool use_time_from = true;
-
-  MockHttpRequest* mock_req = new MockHttpRequest();
   HttpResponse resp(HTTP_OK, "response-body", {});
 
-  // Expect that we'll build a GET request with the correct path and server
-  EXPECT_CALL(*_chronos, build_request_proxy("10.42.42.42:80",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id;time-from=10000",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(mock_req));
-
+  // Expect that the GET request has the right server, path and range header
   std::string range_header = std::string(HEADER_RANGE) + ":" +
                              std::to_string(MAX_TIMERS_IN_RESPONSE);
 
-  // Expect that we add the correct range header to the request, then send it
-  EXPECT_CALL(*mock_req, add_header(range_header)).Times(1);
-  EXPECT_CALL(*mock_req, send()).WillOnce(Return(resp));
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.42.42.42:80"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id;time-from=10000"),
+                                           HasHeader(range_header))))
+    .WillOnce(Return(resp));
 
   std::string path = _chronos->create_path("10.0.0.1:9999", "cluster-view-id", 10000, use_time_from);
   HTTPCode status = _chronos->send_get("10.42.42.42:80", path, 0, response);
@@ -197,18 +156,12 @@ TEST_F(ChronosInternalConnectionTest, SendGet)
 
 TEST_F(ChronosInternalConnectionTest, SendTriggerNoResults)
 {
-  MockHttpRequest* resync_mock_req = new MockHttpRequest();
   HttpResponse resp(HTTP_OK, "{\"Timers\":[]}", {});
 
-  // Expect that we'll build the GET request for the resync
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req));
-
-  // Expect that we'll add a header and send this request
-  EXPECT_CALL(*resync_mock_req, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req, send()).WillOnce(Return(resp));
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.1:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(resp));
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
 
@@ -219,19 +172,14 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerNoResults)
 TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimer)
 {
   Timer* added_timer;
-
-  MockHttpRequest* resync_mock_req = new MockHttpRequest();
   HttpResponse resp(HTTP_OK, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.3:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}", {});
-  // Expect that we'll build the GET request for the resync, and then three DELETE
-  // requests which we send to each of the cluster nodes
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req));
 
-  // Expect that we'll add a header and send the GET request
-  EXPECT_CALL(*resync_mock_req, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req, send()).WillOnce(Return(resp));
+  // Expect that we'll send the GET request for the resync, and then three DELETE
+  // requests which we send to each of the cluster nodes
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.1:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(resp));
 
   // Expect that the delete requests are sent with the correct body
   expect_delete("10.0.0.1:9999", "{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":0}]}");
@@ -254,34 +202,26 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimer)
 TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimerDeleteError)
 {
   Timer* added_timer;
-
-  MockHttpRequest* resync_mock_req = new MockHttpRequest();
   HttpResponse resp(HTTP_OK, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.3:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}", {});
-  // Expect that we'll build the GET request for the resync, and then three DELETE
-  // requests which we send to each of the cluster nodes
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req));
 
-  // Expect that we'll add a header and send the GET request
-  EXPECT_CALL(*resync_mock_req, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req, send()).WillOnce(Return(resp));
+  // Expect that we'll send the GET request for the resync, and then three DELETE
+  // requests which we send to each of the cluster nodes
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.1:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(resp));
 
   // Expect that the delete requests are sent with the correct body, and one of
   // them returns a 503
   expect_delete("10.0.0.1:9999", "{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":0}]}");
   expect_delete("10.0.0.2:9999", "{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":0}]}");
 
-  MockHttpRequest* mock_delete = new MockHttpRequest();
   HttpResponse resp_error(HTTP_SERVER_UNAVAILABLE, "{}", {});
-
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.3:9999",
-                                             "/timers/references",
-                                             HttpClient::RequestType::DELETE))
-    .WillOnce(Return(mock_delete));
-  EXPECT_CALL(*mock_delete, set_body("{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":0}]}")).Times(1);
-  EXPECT_CALL(*mock_delete, send()).WillOnce(Return(resp_error));
+  EXPECT_CALL(*_client, send_request(AllOf(IsDelete(),
+                                           HasServer("10.0.0.3:9999"),
+                                           HasPath("/timers/references"),
+                                           HasBody("{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":0}]}"))))
+    .WillOnce(Return(resp_error));
 
   // Expect that we'll add the timer, and save it off
   EXPECT_CALL(*_th, add_timer(_,_)).WillOnce(SaveArg<0>(&added_timer));
@@ -305,21 +245,16 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimerWithTombstoneAndLeaving
   __globals->set_cluster_leaving_addresses(leaving_cluster_addresses);
   _cluster_addresses.push_back("10.0.0.4:9999");
 
-  MockHttpRequest* resync_mock_req = new MockHttpRequest();
   HttpResponse resp(HTTP_OK, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.4:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}", {});
 
   Timer* added_timer;
 
-  // Expect that we'll build the GET request for the resync, and then four DELETE
+  // Expect that we'll send the GET request for the resync, and then three DELETE
   // requests which we send to each of the cluster nodes
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req));
-
-  // Expect that we'll add a header and send the GET request
-  EXPECT_CALL(*resync_mock_req, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req, send()).WillOnce(Return(resp));
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.1:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(resp));
 
   // Expect that we'll add the timer, and save it off
   EXPECT_CALL(*_th, add_timer(_,_)).WillOnce(SaveArg<0>(&added_timer));
@@ -346,34 +281,26 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimerWithTombstoneAndLeaving
 // more timers available. This also checks the time-from parameter.
 TEST_F(ChronosInternalConnectionTest, RepeatedTimers)
 {
-  MockHttpRequest* resync_mock_req_1 = new MockHttpRequest();
-  MockHttpRequest* resync_mock_req_2 = new MockHttpRequest();
-
   HttpResponse resp_partial(HTTP_PARTIAL_CONTENT, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"], \"Timer\": {\"timing\": { \"start-time-delta\": -235, \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\" ] }}}]}", {});
   HttpResponse resp_ok(HTTP_OK, "{\"Timers\":[]}", {});
-  HttpResponse accepted(HTTP_ACCEPTED, "", {});
 
   // Expect that we'll build and send the first resync request with time-from
   // set to 0.
   // Respond with a single timer that has a delta of -235ms, and an interval of
   // 100ms. Set the response code to 206 so that we'll make another request
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(resp_partial));
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.1:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(resp_partial));
 
   // Expect that we'll build and send the second request with time-from based on
   // the time of the timer we received before.
   // Respond with an empty body as we don't care about any other timers in this
   // test
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id;time-from=" + std::to_string(100000 - 235 + 1),
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_2));
-  EXPECT_CALL(*resync_mock_req_2, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_2, send()).WillOnce(Return(resp_ok));
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.1:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id;time-from=" + std::to_string(100000 - 235 + 1)))))
+    .WillOnce(Return(resp_ok));
 
   // Expect that we'll send deletes to all cluster nodes
   expect_delete("10.0.0.1:9999", "{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":0}]}");
@@ -401,53 +328,40 @@ TEST_F(ChronosInternalConnectionTest, ResynchronizeWithTimers)
   __globals->set_cluster_leaving_addresses(leaving_cluster_addresses);
   _cluster_addresses.push_back("10.0.0.4:9999");
 
-  MockHttpRequest* resync_mock_req_1 = new MockHttpRequest();
-  MockHttpRequest* resync_mock_req_2 = new MockHttpRequest();
-  MockHttpRequest* resync_mock_req_3 = new MockHttpRequest();
-  MockHttpRequest* resync_mock_req_4 = new MockHttpRequest();
-
   // Timers from 10.0.0.2/10.0.0.3/10.0.0.4 - One timer that's having its replica list reordered.
   // This isn't a valid response (as it should be different for .2/.3/.4), but it's sufficient
   HttpResponse response(HTTP_OK, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.1:9999\", \"10.0.0.2:9999\", \"10.0.0.3:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.3:9999\", \"10.0.0.1:9999\", \"10.0.0.2:9999\" ] }}}]}", {});
 
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.1:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.2:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_2));
-  EXPECT_CALL(*resync_mock_req_2, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_2, send()).WillOnce(Return(response));
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.2:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.3:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_3));
-  EXPECT_CALL(*resync_mock_req_3, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_3, send()).WillOnce(Return(response));
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.3:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.4:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_4));
-  EXPECT_CALL(*resync_mock_req_4, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_4, send()).WillOnce(Return(response));
-
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.4:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
   // Delete responses - expect them each 4 times as we have the same response
   // from each of the 4 replicas
-  for (int i = 0; i < 4; i++)
-  {
-    expect_delete("10.0.0.1:9999", "{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":1}]}");
-    expect_delete("10.0.0.2:9999", "{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":1}]}");
-    expect_delete("10.0.0.3:9999", "{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":1}]}");
-    expect_delete("10.0.0.4:9999", "{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":1}]}");
-  }
+  expect_delete("10.0.0.1:9999", "{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":1}]}", 4);
+  expect_delete("10.0.0.2:9999", "{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":1}]}", 4);
+  expect_delete("10.0.0.3:9999", "{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":1}]}", 4);
+  expect_delete("10.0.0.4:9999", "{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":1}]}", 4);
 
   // There should be no calls to add a timer, as the node has moved higher up
   // the replica list
@@ -470,30 +384,23 @@ TEST_F(ChronosInternalConnectionTest, ResynchronizeWithInvalidGetResponse)
   // Responses have invalid JSON
   HttpResponse response(HTTP_OK, "{\"Timers\":}", {});
 
-  MockHttpRequest* resync_mock_req_1 = new MockHttpRequest();
-  MockHttpRequest* resync_mock_req_2 = new MockHttpRequest();
-  MockHttpRequest* resync_mock_req_3 = new MockHttpRequest();
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.1:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.2:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.2:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_2));
-  EXPECT_CALL(*resync_mock_req_2, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_2, send()).WillOnce(Return(response));
-
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.3:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_3));
-  EXPECT_CALL(*resync_mock_req_3, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_3, send()).WillOnce(Return(response));
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.3:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
   // There should be no calls to add/replicate a timer
   EXPECT_CALL(*_th, add_timer(_,_)).Times(0);
@@ -506,30 +413,23 @@ TEST_F(ChronosInternalConnectionTest, ResynchronizeWithGetRequestFailed)
   // GET requests fail
   HttpResponse response(HTTP_BAD_REQUEST, "", {});
 
-  MockHttpRequest* resync_mock_req_1 = new MockHttpRequest();
-  MockHttpRequest* resync_mock_req_2 = new MockHttpRequest();
-  MockHttpRequest* resync_mock_req_3 = new MockHttpRequest();
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.1:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.2:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.2:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_2));
-  EXPECT_CALL(*resync_mock_req_2, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_2, send()).WillOnce(Return(response));
-
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.3:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_3));
-  EXPECT_CALL(*resync_mock_req_3, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_3, send()).WillOnce(Return(response));
+  EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
+                                           HasServer("10.0.0.3:9999"),
+                                           HasPath("/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id"))))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
   // There should be no calls to add/replicate a timer
   EXPECT_CALL(*_th, add_timer(_,_)).Times(0);
@@ -540,14 +440,9 @@ TEST_F(ChronosInternalConnectionTest, ResynchronizeWithGetRequestFailed)
 TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultsInvalidJSON)
 {
   HttpResponse response(HTTP_OK, "{\"Timers\":]}", {});
-  MockHttpRequest* resync_mock_req_1 = new MockHttpRequest();
-
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
+  EXPECT_CALL(*_client, send_request(IsGet()))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(400, status);
@@ -556,14 +451,9 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultsInvalidJSON)
 TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultsNoTimers)
 {
   HttpResponse response(HTTP_OK, "{\"Timer\":[]}", {});
-  MockHttpRequest* resync_mock_req_1 = new MockHttpRequest();
-
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
+  EXPECT_CALL(*_client, send_request(IsGet()))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(400, status);
@@ -572,14 +462,9 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultsNoTimers)
 TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidEntryNoTimerObject)
 {
   HttpResponse response(HTTP_OK, "{\"Timers\":[\"Timer\"]}", {});
-  MockHttpRequest* resync_mock_req_1 = new MockHttpRequest();
-
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
+  EXPECT_CALL(*_client, send_request(IsGet()))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(400, status);
@@ -588,14 +473,9 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidEntryNoTimerObject)
 TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidEntryNoReplicas)
 {
   HttpResponse response(HTTP_OK, "{\"Timers\":[{\"TimerID\":4}]}", {});
-  MockHttpRequest* resync_mock_req_1 = new MockHttpRequest();
-
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
+  EXPECT_CALL(*_client, send_request(IsGet()))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(400, status);
@@ -604,14 +484,9 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidEntryNoReplicas)
 TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultNoTimer)
 {
   HttpResponse response(HTTP_OK, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"]}]}", {});
-  MockHttpRequest* resync_mock_req_1 = new MockHttpRequest();
-
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
+  EXPECT_CALL(*_client, send_request(IsGet()))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(400, status);
@@ -620,14 +495,9 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultNoTimer)
 TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultInvalidTimers)
 {
   HttpResponse response(HTTP_OK, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"], \"Timer\": {}}, {\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": {}}}]}", {});
-  MockHttpRequest* resync_mock_req_1 = new MockHttpRequest();
-
-  EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.1:9999",
-                                             "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
-                                             HttpClient::RequestType::GET))
-    .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
-  EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
+  EXPECT_CALL(*_client, send_request(IsGet()))
+    .WillOnce(Return(response))
+    .RetiresOnSaturation();
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
   EXPECT_EQ(400, status);

--- a/src/ut/test_chronos_internal_connection.cpp
+++ b/src/ut/test_chronos_internal_connection.cpp
@@ -135,7 +135,7 @@ protected:
                                                "/timers/references",
                                                HttpClient::RequestType::DELETE))
       .WillOnce(Return(mock_req)).RetiresOnSaturation();
-    EXPECT_CALL(*mock_req, set_req_body(timer)).Times(1);
+    EXPECT_CALL(*mock_req, set_body(timer)).Times(1);
     EXPECT_CALL(*mock_req, send()).WillOnce(Return(resp_accepted));
   }
 
@@ -157,7 +157,7 @@ TEST_F(ChronosInternalConnectionTest, SendDelete)
                                              HttpClient::RequestType::DELETE))
     .WillOnce(Return(mock_req));
 
-  EXPECT_CALL(*mock_req, set_req_body("{}")).Times(1);
+  EXPECT_CALL(*mock_req, set_body("{}")).Times(1);
   EXPECT_CALL(*mock_req, send()).WillOnce(Return(ok));
 
   HTTPCode status = _chronos->send_delete("10.42.42.42:80", "{}");
@@ -184,7 +184,7 @@ TEST_F(ChronosInternalConnectionTest, SendGet)
                              std::to_string(MAX_TIMERS_IN_RESPONSE);
 
   // Expect that we add the correct range header to the request, then send it
-  EXPECT_CALL(*mock_req, add_req_header(range_header)).Times(1);
+  EXPECT_CALL(*mock_req, add_header(range_header)).Times(1);
   EXPECT_CALL(*mock_req, send()).WillOnce(Return(resp));
 
   std::string path = _chronos->create_path("10.0.0.1:9999", "cluster-view-id", 10000, use_time_from);
@@ -207,7 +207,7 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerNoResults)
     .WillOnce(Return(resync_mock_req));
 
   // Expect that we'll add a header and send this request
-  EXPECT_CALL(*resync_mock_req, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req, send()).WillOnce(Return(resp));
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
@@ -230,7 +230,7 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimer)
     .WillOnce(Return(resync_mock_req));
 
   // Expect that we'll add a header and send the GET request
-  EXPECT_CALL(*resync_mock_req, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req, send()).WillOnce(Return(resp));
 
   // Expect that the delete requests are sent with the correct body
@@ -265,7 +265,7 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimerDeleteError)
     .WillOnce(Return(resync_mock_req));
 
   // Expect that we'll add a header and send the GET request
-  EXPECT_CALL(*resync_mock_req, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req, send()).WillOnce(Return(resp));
 
   // Expect that the delete requests are sent with the correct body, and one of
@@ -280,7 +280,7 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimerDeleteError)
                                              "/timers/references",
                                              HttpClient::RequestType::DELETE))
     .WillOnce(Return(mock_delete));
-  EXPECT_CALL(*mock_delete, set_req_body("{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":0}]}")).Times(1);
+  EXPECT_CALL(*mock_delete, set_body("{\"IDs\":[{\"ID\":4,\"ReplicaIndex\":0}]}")).Times(1);
   EXPECT_CALL(*mock_delete, send()).WillOnce(Return(resp_error));
 
   // Expect that we'll add the timer, and save it off
@@ -318,7 +318,7 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimerWithTombstoneAndLeaving
     .WillOnce(Return(resync_mock_req));
 
   // Expect that we'll add a header and send the GET request
-  EXPECT_CALL(*resync_mock_req, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req, send()).WillOnce(Return(resp));
 
   // Expect that we'll add the timer, and save it off
@@ -361,7 +361,7 @@ TEST_F(ChronosInternalConnectionTest, RepeatedTimers)
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(resp_partial));
 
   // Expect that we'll build and send the second request with time-from based on
@@ -372,7 +372,7 @@ TEST_F(ChronosInternalConnectionTest, RepeatedTimers)
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id;time-from=" + std::to_string(100000 - 235 + 1),
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_2));
-  EXPECT_CALL(*resync_mock_req_2, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_2, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_2, send()).WillOnce(Return(resp_ok));
 
   // Expect that we'll send deletes to all cluster nodes
@@ -414,28 +414,28 @@ TEST_F(ChronosInternalConnectionTest, ResynchronizeWithTimers)
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
 
   EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.2:9999",
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_2));
-  EXPECT_CALL(*resync_mock_req_2, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_2, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_2, send()).WillOnce(Return(response));
 
   EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.3:9999",
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_3));
-  EXPECT_CALL(*resync_mock_req_3, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_3, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_3, send()).WillOnce(Return(response));
 
   EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.4:9999",
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_4));
-  EXPECT_CALL(*resync_mock_req_4, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_4, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_4, send()).WillOnce(Return(response));
 
 
@@ -478,21 +478,21 @@ TEST_F(ChronosInternalConnectionTest, ResynchronizeWithInvalidGetResponse)
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
 
   EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.2:9999",
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_2));
-  EXPECT_CALL(*resync_mock_req_2, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_2, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_2, send()).WillOnce(Return(response));
 
   EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.3:9999",
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_3));
-  EXPECT_CALL(*resync_mock_req_3, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_3, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_3, send()).WillOnce(Return(response));
 
   // There should be no calls to add/replicate a timer
@@ -514,21 +514,21 @@ TEST_F(ChronosInternalConnectionTest, ResynchronizeWithGetRequestFailed)
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
 
   EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.2:9999",
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_2));
-  EXPECT_CALL(*resync_mock_req_2, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_2, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_2, send()).WillOnce(Return(response));
 
   EXPECT_CALL(*_chronos, build_request_proxy("10.0.0.3:9999",
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_3));
-  EXPECT_CALL(*resync_mock_req_3, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_3, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_3, send()).WillOnce(Return(response));
 
   // There should be no calls to add/replicate a timer
@@ -546,7 +546,7 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultsInvalidJSON)
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
@@ -562,7 +562,7 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultsNoTimers)
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
@@ -578,7 +578,7 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidEntryNoTimerObject)
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
@@ -594,7 +594,7 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidEntryNoReplicas)
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
@@ -610,7 +610,7 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultNoTimer)
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);
@@ -626,7 +626,7 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultInvalidTimers)
                                              "/timers?node-for-replicas=10.0.0.1:9999;cluster-view-id=cluster-view-id",
                                              HttpClient::RequestType::GET))
     .WillOnce(Return(resync_mock_req_1));
-  EXPECT_CALL(*resync_mock_req_1, add_req_header(_)).Times(1);
+  EXPECT_CALL(*resync_mock_req_1, add_header(_)).Times(1);
   EXPECT_CALL(*resync_mock_req_1, send()).WillOnce(Return(response));
 
   HTTPCode status = _chronos->resynchronise_with_single_node("10.0.0.1:9999", _cluster_addresses, _local_ip);

--- a/src/ut/test_chronos_internal_connection.cpp
+++ b/src/ut/test_chronos_internal_connection.cpp
@@ -89,15 +89,6 @@ protected:
   // for the specified timer
   void expect_delete(const std::string& server, const std::string& timer, int times=1)
   {
-    //MockHttpRequest* mock_req = new MockHttpRequest();
-    /*
-    EXPECT_CALL(*_chronos, build_request_proxy(server,
-                                               "/timers/references",
-                                               HttpClient::RequestType::DELETE))
-      .WillOnce(Return(mock_req)).RetiresOnSaturation();
-    EXPECT_CALL(*mock_req, set_body(timer)).Times(1);
-    EXPECT_CALL(*mock_req, send()).WillOnce(Return(resp_accepted));
-    */
     EXPECT_CALL(*_client, send_request(AllOf(IsDelete(),
                                              HasServer(server),
                                              HasBody(timer))))
@@ -172,7 +163,13 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerNoResults)
 TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimer)
 {
   Timer* added_timer;
-  HttpResponse resp(HTTP_OK, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.3:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}", {});
+  HttpResponse resp(HTTP_OK,
+                    "{\"Timers\":[{\"TimerID\":4, "
+                                  "\"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.3:9999\"], "
+                                  "\"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, "
+                                              "\"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, "
+                                              "\"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}",
+                    {});
 
   // Expect that we'll send the GET request for the resync, and then three DELETE
   // requests which we send to each of the cluster nodes
@@ -202,7 +199,13 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimer)
 TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimerDeleteError)
 {
   Timer* added_timer;
-  HttpResponse resp(HTTP_OK, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.3:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}", {});
+  HttpResponse resp(HTTP_OK,
+                    "{\"Timers\":[{\"TimerID\":4, "
+                                  "\"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.3:9999\"], "
+                                  "\"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, "
+                                              "\"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, "
+                                              "\"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}",
+                    {});
 
   // Expect that we'll send the GET request for the resync, and then three DELETE
   // requests which we send to each of the cluster nodes
@@ -245,7 +248,13 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimerWithTombstoneAndLeaving
   __globals->set_cluster_leaving_addresses(leaving_cluster_addresses);
   _cluster_addresses.push_back("10.0.0.4:9999");
 
-  HttpResponse resp(HTTP_OK, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.4:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}", {});
+  HttpResponse resp(HTTP_OK,
+                    "{\"Timers\":[{\"TimerID\":4, "
+                                  "\"OldReplicas\":[\"10.0.0.2:9999\", \"10.0.0.4:9999\"], "
+                                  "\"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, "
+                                              "\"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, "
+                                              "\"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}",
+                    {});
 
   Timer* added_timer;
 
@@ -281,7 +290,13 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimerWithTombstoneAndLeaving
 // more timers available. This also checks the time-from parameter.
 TEST_F(ChronosInternalConnectionTest, RepeatedTimers)
 {
-  HttpResponse resp_partial(HTTP_PARTIAL_CONTENT, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"], \"Timer\": {\"timing\": { \"start-time-delta\": -235, \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.1:9999\" ] }}}]}", {});
+  HttpResponse resp_partial(HTTP_PARTIAL_CONTENT,
+                            "{\"Timers\":[{\"TimerID\":4, "
+                                          "\"OldReplicas\":[\"10.0.0.2:9999\"], "
+                                          "\"Timer\": {\"timing\": { \"start-time-delta\": -235, \"interval\": 100, \"repeat-for\": 200 }, "
+                                                      "\"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, "
+                                                      "\"reliability\": { \"replicas\": [ \"10.0.0.1:9999\" ] }}}]}",
+                            {});
   HttpResponse resp_ok(HTTP_OK, "{\"Timers\":[]}", {});
 
   // Expect that we'll build and send the first resync request with time-from
@@ -330,7 +345,13 @@ TEST_F(ChronosInternalConnectionTest, ResynchronizeWithTimers)
 
   // Timers from 10.0.0.2/10.0.0.3/10.0.0.4 - One timer that's having its replica list reordered.
   // This isn't a valid response (as it should be different for .2/.3/.4), but it's sufficient
-  HttpResponse response(HTTP_OK, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.1:9999\", \"10.0.0.2:9999\", \"10.0.0.3:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": { \"replicas\": [ \"10.0.0.3:9999\", \"10.0.0.1:9999\", \"10.0.0.2:9999\" ] }}}]}", {});
+  HttpResponse response(HTTP_OK,
+                        "{\"Timers\":[{\"TimerID\":4, "
+                                      "\"OldReplicas\":[\"10.0.0.1:9999\", \"10.0.0.2:9999\", \"10.0.0.3:9999\"], "
+                                      "\"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, "
+                                                  "\"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, "
+                                                  "\"reliability\": { \"replicas\": [ \"10.0.0.3:9999\", \"10.0.0.1:9999\", \"10.0.0.2:9999\" ] }}}]}",
+                        {});
 
   EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
                                            HasServer("10.0.0.1:9999"),
@@ -494,7 +515,16 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultNoTimer)
 
 TEST_F(ChronosInternalConnectionTest, SendTriggerInvalidResultInvalidTimers)
 {
-  HttpResponse response(HTTP_OK, "{\"Timers\":[{\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"], \"Timer\": {}}, {\"TimerID\":4, \"OldReplicas\":[\"10.0.0.2:9999\"], \"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, \"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, \"reliability\": {}}}]}", {});
+  HttpResponse response(HTTP_OK,
+                        "{\"Timers\":[{\"TimerID\":4, "
+                                      "\"OldReplicas\":[\"10.0.0.2:9999\"], "
+                                      "\"Timer\": {}}, "
+                                     "{\"TimerID\":4, "
+                                      "\"OldReplicas\":[\"10.0.0.2:9999\"], "
+                                      "\"Timer\": {\"timing\": { \"interval\": 100, \"repeat-for\": 200 }, "
+                                                                "\"callback\": { \"http\": { \"uri\": \"localhost\", \"opaque\": \"stuff\" }}, "
+                                                                "\"reliability\": {}}}]}",
+                        {});
   EXPECT_CALL(*_client, send_request(IsGet()))
     .WillOnce(Return(response))
     .RetiresOnSaturation();

--- a/src/ut/test_chronos_internal_connection.cpp
+++ b/src/ut/test_chronos_internal_connection.cpp
@@ -207,7 +207,7 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimerDeleteError)
                                               "\"reliability\": { \"replicas\": [ \"10.0.0.1:9999\", \"10.0.0.3:9999\" ] }}}]}",
                     {});
 
-  // Expect that we'll send the GET request for the resync, and then three DELETE
+  // Expect that we'll send the GET request for the resync, and then 2 DELETE
   // requests which we send to each of the cluster nodes
   EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
                                            HasServer("10.0.0.1:9999"),
@@ -258,7 +258,7 @@ TEST_F(ChronosInternalConnectionTest, SendTriggerOneTimerWithTombstoneAndLeaving
 
   Timer* added_timer;
 
-  // Expect that we'll send the GET request for the resync, and then three DELETE
+  // Expect that we'll send the GET request for the resync, and then 4 DELETE
   // requests which we send to each of the cluster nodes
   EXPECT_CALL(*_client, send_request(AllOf(IsGet(),
                                            HasServer("10.0.0.1:9999"),


### PR DESCRIPTION
This updates Chronos to use the new interfaces in cpp-common for HTTP requests.

Changes to:

* `ChronosInternalConnection`
* `HttpCallback`
* `ChronosGRConnection`
* `Replicator`

There were a couple of places where we have HTTP URLs, but the new interface requires it to be presented as a scheme, server and path. So I spilt the URLs using the function from `Utils`.

For ChronosInternalConnection, I noticed that the UTs weren't checking what HTTP methods we were actually making - they just set up some fake curl responses which apply to any HTTP method. This seemed bad, so I decided to take this opportunity to fix them up to actually check for the correct methods.

To do this, I had to change all of the UTs in that file, which is why there are so many changes. A summary of the changes I made there is:

1. Renamed the tests (as they were called `TestChronosInternalConnection`, when they were actually `ChronosInternalConnectionTest`s)
1. Created a `TestChronosInteralConnection` which we actually test rather than testing the real one directly
    * this allows us to intercept the `build_request` method, and use a Mock to return `MockHttpRequest`s
    * this is turn allows us to `EXPECT` that the correct request is built, and allows us to set expectations on the request (e.g. that it is sent)
1. I added a boolean to the `ChronosInternalConnection`'s constructor which allows you to prevent it from attempting a resync on creation. This is used in the UTs to prevent a resync (which would be making real HTTP requests, as we've only created the real connection at that point, not the subclass)
1. I then went through all the tests and figured out what HTTP requests we should be making, and added the correct expectations for them.
1. I also switch around `EXPECT_EQ` calls to be the right way round so we get better messages if those tests fail

This ended up being fairly time-consuming, and I couldn't convince myself it was worth doing the same for the other Chronos UTs right now (I think we should at some point). So for the other UTs, I left them using fakecurl responses.

I've also removed an existing `TODO` in the code. As part of the move to use the `HttpClient` in Chronos a while back (https://github.com/Metaswitch/chronos/commit/599c2d2b3005d3a89c97ce11b0fcf49375253fcb) we lost the headers we were adding to HTTP callbacks. I've now re-instated those.

#### Testing
`make full_test` and `make fv_test` both pass