### PR TITLE
Do replication requests from the HTTP bind address

### DIFF
--- a/include/replicator.h
+++ b/include/replicator.h
@@ -51,7 +51,7 @@ private:
   struct curl_slist* _headers;
   ExceptionHandler* _exception_handler;
   HttpResolver* _resolver;
-  HttpClient _http_client;
+  HttpClient* _http_client;
 };
 
 #endif


### PR DESCRIPTION
This is the same change as https://github.com/Metaswitch/chronos/pull/373, but applied to the secret 3rd HTTP client that uses. 

I've tested that this works by running the FV tests. 