### PR TITLE
Make chronos DNS port configurable

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -50,6 +50,7 @@ The shared configuration file has the following format:
     [dns]
     servers = 127.0.0.1                      # DNS servers to use (up to three allowed)
     timeout = 200                            # Amount of time to wait for a DNS response
+    port = 5353                              # Port to use when contacting the DNS server
 
     [sites]
     local_site = local-site-name             # The name of the local site

--- a/include/globals.h
+++ b/include/globals.h
@@ -72,6 +72,7 @@ public:
   GLOBAL(max_ttl, int);
   GLOBAL(dns_servers, std::vector<std::string>);
   GLOBAL(dns_timeout, int);
+  GLOBAL(dns_port, int);
   GLOBAL(target_latency, int);
   GLOBAL(max_tokens, int);
   GLOBAL(initial_token_rate, int);

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -59,6 +59,7 @@ Globals::Globals(std::string local_config_file,
     ("throttling.max_token_rate", po::value<int>()->default_value(0), "Maximum token bucket refill rate for HTTP overload control")
     ("dns.servers", po::value<std::vector<std::string>>()->multitoken()->default_value(std::vector<std::string>(1, "127.0.0.1"), "HOST"), "The addresses of the DNS servers used by the Chronos process")
     ("dns.timeout", po::value<int>()->default_value(200), "The amount of time to wait for a DNS response")
+    ("dns.port", po::value<int>()->default_value(53), "The port on which to contact the DNS servers")
     ;
 
 #ifndef UNIT_TEST
@@ -174,6 +175,9 @@ void Globals::update_config()
 
   int dns_timeout = conf_map["dns.timeout"].as<int>();
   set_dns_timeout(dns_timeout);
+
+  int dns_port = conf_map["dns.port"].as<int>();
+  set_dns_port(dns_port);
 
   uint32_t instance_id = conf_map["identity.instance_id"].as<uint32_t>();
   uint32_t deployment_id = conf_map["identity.deployment_id"].as<uint32_t>();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -329,9 +329,12 @@ int main(int argc, char** argv)
   __globals->get_dns_servers(dns_servers);
   int dns_timeout;
   __globals->get_dns_timeout(dns_timeout);
+  int dns_port;
+  __globals->get_dns_port(dns_port);
   DnsCachedResolver* dns_resolver = new DnsCachedResolver(dns_servers,
                                                           dns_timeout,
-                                                          options.dns_config_file);
+                                                          options.dns_config_file,
+                                                          dns_port);
 
 
   // Create an Updater that listens for SIGUSR2 and, in response, reloads the

--- a/src/ut/chronos_shared.conf
+++ b/src/ut/chronos_shared.conf
@@ -6,6 +6,7 @@ servers = 1.1.1.1
 servers = 2.2.2.2
 servers = 3.3.3.3
 timeout = 500
+port = 5353
 
 [sites]
 local_site=mysite

--- a/src/ut/test_globals.cpp
+++ b/src/ut/test_globals.cpp
@@ -64,6 +64,10 @@ TEST_F(TestGlobals, ParseGlobalsDefaults)
   test_global->get_dns_timeout(dns_timeout);
   EXPECT_EQ(dns_timeout, 200);
 
+  int dns_port;
+  test_global->get_dns_port(dns_port);
+  EXPECT_EQ(dns_port, 53);
+
   std::string cluster_local_address;
   test_global->get_cluster_local_ip(cluster_local_address);
   EXPECT_EQ(cluster_local_address, "127.0.0.1:7253");
@@ -146,6 +150,10 @@ TEST_F(TestGlobals, ParseGlobalsNotDefaults)
   int dns_timeout;
   test_global->get_dns_timeout(dns_timeout);
   EXPECT_EQ(dns_timeout, 500);
+
+  int dns_port;
+  test_global->get_dns_port(dns_port);
+  EXPECT_EQ(dns_port, 5353);
 
   std::string cluster_local_address;
   test_global->get_cluster_local_ip(cluster_local_address);


### PR DESCRIPTION
This PR enhances chronos so that you can specify what DNS port to use. This is needed so that the FV tests can run their own DNS server on a non-default port.

I've tested this by:

* Running chronos in the FV tests and confirming that DNS queries were working (by checking the logs). 
* Running the chronos UTs. 