### PR TITLE
Accept new timer ids

### DIFF
--- a/include/timer.h
+++ b/include/timer.h
@@ -40,7 +40,7 @@ public:
 
   // Returns the next time to pop in ms after epoch
   uint32_t next_pop_time() const;
-  
+
   // Required method for use in a heap
   uint64_t get_pop_time() const;
 
@@ -92,8 +92,8 @@ public:
   // cluster view ID)
   void update_cluster_information();
 
-  // Member variables (mostly public since this is pretty much a struct with utility
-  // functions, rather than a full-blown object).
+  // Member variables (mostly public since this is pretty much a struct with
+  // utility functions, rather than a full-blown object).
   TimerID id;
   uint32_t start_time_mono_ms;
   uint32_t interval_ms;

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -50,7 +50,8 @@ void ControllerTask::run()
     }
   }
   // For a PUT or a DELETE the URL should be of the format
-  // <timer_id>-<replication_factor> or <timer_id><replica_hash>
+  // <timer_id>-<replication_factor><anything>. The <anything> is ignored, but
+  // accepted to make the API extensible.
   else if (boost::regex_match(path, matches, boost::regex("/timers/([[:xdigit:]]{16})([[:xdigit:]]{16})")))
   {
     if ((_req.method() != htp_method_PUT) && (_req.method() != htp_method_DELETE))
@@ -65,7 +66,9 @@ void ControllerTask::run()
       add_or_update_timer(timer_id, 0, replica_hash);
     }
   }
-  else if (boost::regex_match(path, matches, boost::regex("/timers/([[:xdigit:]]{16})-([[:digit:]]+)")))
+  else if (boost::regex_match(path,
+                              matches,
+                              boost::regex("/timers/([[:xdigit:]]{16})-([[:digit:]]+)(.*)")))
   {
     if ((_req.method() != htp_method_PUT) && (_req.method() != htp_method_DELETE))
     {

--- a/src/handlers.cpp
+++ b/src/handlers.cpp
@@ -40,7 +40,9 @@ void ControllerTask::run()
   // For a PUT or a DELETE the URL should be of the format
   // <timer_id>-<replication_factor><anything>. The <anything> is ignored, but
   // accepted to make the API extensible.
-  else if (boost::regex_match(path, matches, boost::regex("/timers/([[:xdigit:]]{16})-([[:digit:]]+)")))
+  else if (boost::regex_match(path,
+                              matches,
+                              boost::regex("/timers/([[:xdigit:]]{16})-([[:digit:]]+)(.*)")))
   {
     if ((_req.method() != htp_method_PUT) && (_req.method() != htp_method_DELETE))
     {

--- a/src/ut/test_handler.cpp
+++ b/src/ut/test_handler.cpp
@@ -151,6 +151,11 @@ TYPED_TEST(TestHandler, ValidJSONDeleteTimerWithExtendedTimerID)
   EXPECT_CALL(*TestFixture::_httpstack, send_reply(_, 200, _));
   TestFixture::_task->run();
 
+  // Check that the timer ID and replication factor have been parsed correctly.
+  EXPECT_EQ(added_timer->_replication_factor, 2);
+  // The ID is the passed in ID converted to base 10.
+  EXPECT_EQ(added_timer->id, 1311693406324658740);
+
   delete added_timer; added_timer = NULL;
 }
 

--- a/src/ut/test_handler.cpp
+++ b/src/ut/test_handler.cpp
@@ -148,10 +148,10 @@ TYPED_TEST(TestHandler, ValidJSONDeleteTimerWithReplicas)
   delete added_timer; added_timer = NULL;
 }
 
-// Tests a valid request to delete an existing timer, where the timer ID follows
-// the form <timer_id>-<replication_factor><random>. This tests that the URL
-// parsing is flexible, so the URL can be extended in the future if necessary.
-// Currently this random content is ignored.
+// Tests that requests containing a URL of the form
+// /timers/<timer_id>-<replication_factor><random> are accepted. This tests that
+// the URL parsing is flexible, so the URL can be extended in the future if
+// necessary. Currently this random content is ignored.
 TYPED_TEST(TestHandler, ValidJSONDeleteTimerWithExtendedTimerID)
 {
   Timer* added_timer;


### PR DESCRIPTION
In the future we may want to extend the URLs on our PUT/DELETE requests.
This PR changes the way we parse this URL to accept URLs that contain content that isn't understood by chronos. This extra content will be ignored, and the request will still be accepted.
This means a two-step upgrade won't be required in the future if the URL is changed.

`make test`, `make full_test`, and `make fv_test` all pass.

(My death test change also ended up in here, sorry.)
(I'm aware my comment changes here will clash with PR #380, I'll fix this up when merging.)