### PR TITLE
[Reviewer: Adam] Fix timer store uts

### DIFF
--- a/include/timer_store.h
+++ b/include/timer_store.h
@@ -82,9 +82,17 @@ public:
   static const int SHORT_WHEEL_RESOLUTION_MS = 256;
 #endif
 
+  /// Base class for an iterator over Timers in the TimerStore in order from
+  /// earliest to latest.
   class TSOrderedTimerIterator
   {
   protected:
+    /// Constructor.
+    ///
+    ///
+    /// @param ts        The TimerStore over which to iterate
+    /// @param time_from The time at which to start. Only Timers due to pop
+    ///                  after this time are returned by the iterator.
     TSOrderedTimerIterator(TimerStore* ts, uint32_t time_from);
 
     void iterate_through_ordered_timers();
@@ -95,6 +103,8 @@ public:
     uint32_t _time_from;
   };
 
+  /// Abstract base class for an iterator over timers in either the short wheel
+  /// or the long wheel.
   class TSBaseWheelIterator : public TSOrderedTimerIterator
   {
   public:
@@ -103,15 +113,27 @@ public:
     bool end() const;
 
   protected:
-    // Initialisation of the iterator uses virtual methods, and so happens in
-    // the init() method rather than the constructor.
-    // Subclasses *must* call init() in their constructor to complete
-    // initialization.
+    /// Constructor.
+    ///
+    /// Initialisation of the iterator uses virtual methods, and so happens in
+    /// the init() method rather than the constructor.
+    /// Subclasses *must* call init() in their constructor to complete
+    /// initialization.
+    ///
+    /// @param ts          The TimerStore over which to iterate
+    /// @param time_from   The time at which to start. Only Timers due to pop
+    ///                    after this time are returned by the iterator.
+    /// @param resolution  The resolution in ms of the wheel.
+    /// @param num_buckets The number of buckets in the wheel.
+    /// @param period      The period in ms of the wheel.
     TSBaseWheelIterator(TimerStore* ts,
                         uint32_t time_from,
                         int resolution,
                         int num_buckets,
                         int period);
+
+    /// Performs initialisation of the iterator. Must be called in the
+    /// Constructor of any derived class.
     void init();
 
   private:
@@ -122,13 +144,21 @@ public:
     int _bucket;
     void next_bucket();
 
-    // Kick the timer store to refill this wheel.
+    /// Kick the timer store to refill this wheel.
     virtual void refill_wheel_from_timer_store() = 0;
 
-    // Round down the given time to the resolution of this wheel.
+    /// Round down the given time to the resolution of this wheel.
+    ///
+    /// @param t The time to round down.
+    ///
+    /// @returns The time rounded down to the nearest bucket boundary.
     virtual uint32_t to_wheel_resolution(uint32_t t) = 0;
 
-    // Get the Bucket at the specified index from the TimerStore.
+    /// Get the Bucket at the specified index from the TimerStore.
+    ///
+    /// @param bucket_index The index of the Bucket in the wheel.
+    ///
+    /// @returns The Bucket at the specified index.
     virtual Bucket& get_bucket(int bucket_index) = 0;
   };
 

--- a/include/timer_store.h
+++ b/include/timer_store.h
@@ -123,9 +123,9 @@ public:
     /// @param ts          The TimerStore over which to iterate
     /// @param time_from   The time at which to start. Only Timers due to pop
     ///                    after this time are returned by the iterator.
-    /// @param resolution  The resolution in ms of the wheel.
+    /// @param resolution  The resolution (size of a bucket) in ms of the wheel.
     /// @param num_buckets The number of buckets in the wheel.
-    /// @param period      The period in ms of the wheel.
+    /// @param period      The period (size of the wheel) in ms of the wheel.
     TSBaseWheelIterator(TimerStore* ts,
                         uint32_t time_from,
                         int resolution,
@@ -154,7 +154,7 @@ public:
     /// @returns The time rounded down to the nearest bucket boundary.
     virtual uint32_t to_wheel_resolution(uint32_t t) = 0;
 
-    /// Get the Bucket at the specified index from the TimerStore.
+    /// Get the Bucket at the specified index in the wheel from the TimerStore.
     ///
     /// @param bucket_index The index of the Bucket in the wheel.
     ///

--- a/src/timer_store.cpp
+++ b/src/timer_store.cpp
@@ -525,8 +525,9 @@ bool TimerStore::TSBaseWheelIterator::end() const
           (_bucket == _end_bucket));
 }
 
-// Fill _ordered_timers with the timers from the next bucket, if we're not at
-// the end of the wheel.
+// Fill _ordered_timers with the timers from the next bucket containing any
+// timers, if we're not at the end of the wheel, and leave _iterator pointing
+// to the next timer.
 void TimerStore::TSBaseWheelIterator::next_bucket()
 {
   _ordered_timers.clear();

--- a/src/timer_store.cpp
+++ b/src/timer_store.cpp
@@ -545,14 +545,12 @@ void TimerStore::TSBaseWheelIterator::next_bucket()
     {
       iterate_through_ordered_timers();
 
-      // LCOV_EXCL_START
       if (_iterator == _ordered_timers.end())
       {
         _ordered_timers.clear();
         _iterator = _ordered_timers.end();
         ++_bucket;
       }
-      // LCOV_EXCL_STOP
     }
     else
     {

--- a/src/ut/test_timer_store.cpp
+++ b/src/ut/test_timer_store.cpp
@@ -609,7 +609,7 @@ TYPED_TEST(TestTimerStore, IterateOverShortWheelTimersTimeFrom)
 {
   // We want to add 2 timers to the short wheel, which are both in the same
   // bucket and have some time between them. To do this, we insert the first
-  // timer at the start of the next bucket. We then add the 2nd timer half
+  // timer at the start of the next bucket. We then add the second timer half
   // of the SHORT_WHEEL_RESOLUTION_MS after the first, ensuring they're both in
   // the next short wheel bucket.
   uint32_t next_bucket_time_ms = TestFixture::ts->to_short_wheel_resolution(get_time_ms()) +
@@ -650,7 +650,7 @@ TYPED_TEST(TestTimerStore, IterateOverLongWheelTimersTimeFrom)
   // We want to add 2 timers to the long wheel, which are both in the same
   // bucket, but not the first bucket (as we don't want them to be moved into
   // the short wheel) and have some time between them. To do this, we insert the
-  // first timer at the start of the next but one bucket. We then add the 2nd
+  // first timer at the start of the next but one bucket. We then add the second
   // timer half of the LONG_WHEEL_RESOLUTION_MS after the first, ensuring they're
   // both in the next but one long wheel bucket.
   uint32_t next_bucket_time_ms = TestFixture::ts->to_long_wheel_resolution(get_time_ms()) +
@@ -731,7 +731,7 @@ TYPED_TEST(TestTimerStore, IterateOverShortWheelTimersTimeFromInPast)
 TYPED_TEST(TestTimerStore, IterateOverTimersSkipEarlier)
 {
   // We want to add one timer to the next short wheel bucket, and one to the
-  // one after that, to test that we correct skip over the timer in the next
+  // one after that, to test that we correctly skip over the timer in the next
   // bucket when iterating over the timers.
   uint32_t next_bucket_time_ms = TestFixture::ts->to_short_wheel_resolution(get_time_ms()) +
                                  TimerStore::SHORT_WHEEL_RESOLUTION_MS;
@@ -768,14 +768,14 @@ TYPED_TEST(TestTimerStore, IterateOverTimersSkipEarlier)
 TYPED_TEST(TestTimerStore, IterateOverTimersInPreviousBuckets)
 {
   // If the current time is pointing to a time in the first long wheel bucket,
-  // advance time by LONG_WHEEL_RESOLUTION_MS to move into the 2nd bucket
+  // advance time by LONG_WHEEL_RESOLUTION_MS to move into the second bucket
   if (TestFixture::ts->long_wheel_bucket(get_time_ms()) == &(TestFixture::ts->_long_wheel[0]))
   {
     cwtest_advance_time_ms(TimerStore::LONG_WHEEL_RESOLUTION_MS);
   }
 
   // If the current time is pointing to a time in the first short wheel bucket,
-  // advance time by SHORT_WHEEL_RESOLUTION_MS to move into the 2nd bucket
+  // advance time by SHORT_WHEEL_RESOLUTION_MS to move into the second bucket
   if (TestFixture::ts->short_wheel_bucket(get_time_ms()) == &(TestFixture::ts->_short_wheel[0]))
   {
     cwtest_advance_time_ms(TimerStore::SHORT_WHEEL_RESOLUTION_MS);

--- a/src/ut/test_timer_store.cpp
+++ b/src/ut/test_timer_store.cpp
@@ -627,7 +627,7 @@ TYPED_TEST(TestTimerStore, IterateOverShortWheelTimersTimeFrom)
   timer5->repeat_for = timer5->interval_ms;
   TestFixture::ts->insert(timer5);
 
-  // Ask for timer from 1ms after the first timer, and check that only the
+  // Ask for timers from 1ms after the first timer, and check that only the
   // second is returned
   int count = 0;
   for (TimerStore::TSIterator it = TestFixture::ts->begin(next_bucket_time_ms + 1);
@@ -668,7 +668,7 @@ TYPED_TEST(TestTimerStore, IterateOverLongWheelTimersTimeFrom)
   timer5->repeat_for = timer5->interval_ms;
   TestFixture::ts->insert(timer5);
 
-  // Ask for timer from 1ms after the first timer, and check that only the
+  // Ask for timers from 1ms after the first timer, and check that only the
   // second is returned
   int count = 0;
   for (TimerStore::TSIterator it = TestFixture::ts->begin(next_bucket_time_ms + 1);
@@ -706,7 +706,7 @@ TYPED_TEST(TestTimerStore, IterateOverTimersSkipEarlier)
   timer5->repeat_for = timer5->interval_ms;
   TestFixture::ts->insert(timer5);
 
-  // Ask for timer from now, and check that only the second is returned
+  // Ask for timers from now, and check that only the second is returned
   int count = 0;
   for (TimerStore::TSIterator it = TestFixture::ts->begin(next_bucket_time_ms + 1);
        !(it.end());

--- a/src/ut/test_timer_store.cpp
+++ b/src/ut/test_timer_store.cpp
@@ -609,7 +609,7 @@ TYPED_TEST(TestTimerStore, IterateOverShortWheelTimersTimeFrom)
 {
   // We want to add 2 timers to the short wheel, which are both in the same
   // bucket and have some time between them. To do this, we insert the first
-  // first timer at the start of the next bucket. We then add the 2nd timer half
+  // timer at the start of the next bucket. We then add the 2nd timer half
   // of the SHORT_WHEEL_RESOLUTION_MS after the first, ensuring they're both in
   // the next short wheel bucket.
   uint32_t next_bucket_time_ms = TestFixture::ts->to_short_wheel_resolution(get_time_ms()) +
@@ -624,6 +624,47 @@ TYPED_TEST(TestTimerStore, IterateOverShortWheelTimersTimeFrom)
   // Create a timer that will pop halfway through the next short wheel bucket
   Timer* timer5 = default_timer(5);
   timer5->interval_ms = next_bucket_time_ms - get_time_ms() + (TimerStore::SHORT_WHEEL_RESOLUTION_MS / 2);
+  timer5->repeat_for = timer5->interval_ms;
+  TestFixture::ts->insert(timer5);
+
+  // Ask for timer from 1ms after the first timer, and check that only the
+  // second is returned
+  int count = 0;
+  for (TimerStore::TSIterator it = TestFixture::ts->begin(next_bucket_time_ms + 1);
+       !(it.end());
+       ++it)
+  {
+    count++;
+  }
+
+  ASSERT_EQ(1, count);
+
+  delete timer4;
+  delete timer5;
+}
+
+// Test that the LongWheelIterator correctly skips over a timer due to pop
+// before the time_from when it's in the long wheel
+TYPED_TEST(TestTimerStore, IterateOverLongWheelTimersTimeFrom)
+{
+  // We want to add 2 timers to the long wheel, which are both in the same
+  // bucket, but not the first bucket (as we don't want them to be moved into
+  // the short wheel) and have some time between them. To do this, we insert the
+  // first timer at the start of the next but one bucket. We then add the 2nd
+  // timer half of the LONG_WHEEL_RESOLUTION_MS after the first, ensuring they're
+  // both in the next but one long wheel bucket.
+  uint32_t next_bucket_time_ms = TestFixture::ts->to_long_wheel_resolution(get_time_ms()) +
+                                 2 * TimerStore::LONG_WHEEL_RESOLUTION_MS;
+
+  // Create a timer that will pop at the start of the next long wheel bucket
+  Timer* timer4 = default_timer(4);
+  timer4->interval_ms = next_bucket_time_ms - get_time_ms();
+  timer4->repeat_for = timer4->interval_ms;
+  TestFixture::ts->insert(timer4);
+
+  // Create a timer that will pop halfway through the next long wheel bucket
+  Timer* timer5 = default_timer(5);
+  timer5->interval_ms = next_bucket_time_ms - get_time_ms() + (TimerStore::LONG_WHEEL_RESOLUTION_MS / 2);
   timer5->repeat_for = timer5->interval_ms;
   TestFixture::ts->insert(timer5);
 


### PR DESCRIPTION
As discussed, I'm probably going to get Ellie to review this too, but wanted someone in our team to review it first to build up expertise etc.

This change was motivated by https://github.com/Metaswitch/clearwater-issues/issues/2489, where we occasionally missed coverage depending on when the UTs were run.

However, it expanded a bit (sticking to our "make things a bit better" philosophy) to include some tidy up of the `TimerStore` and other minor tweaks.

`make`, `make full_test` and `make fv_test` all pass. I haven't yet run the live tests over it, but I waned to get eyes on it first. I'm probably just looking to merge this into master, so there's no huge rush on it.

### Changes
I made a few changes in sections, so I'd recommend reviewing the commits I've pulled out here separately, as it'll all make more sense that way.

1. Fix up the unreliable UT
    * It turns out that we didn't always hit this line in the UTs: https://github.com/Metaswitch/chronos/blob/db26d04bc8bfdafa7686d847884c05fa38e1c483/src/timer_store.cpp#L432. Having looked at the test sometimes hit it, it was the `TestTimerHandlerRealStore` `TimeFromShortWheelTimers` test in `test_timer_store.cpp`. That tests adds 2 timers to the short wheel, 10ms apart. We missed coverage if we happened to control time at a point such that these 2 timers went into different buckets in the short wheel, and the time_from fell into the 2nd of the buckets. In that case, when we retreived the timers, we started from the second bucket so we never had to skip over the first one. I verified this was the case by editing the test to advance time to one such time, and it failed each time.
    * To fix this, I wanted to ste timers carefully such that they were always in the same bucket. However, this sort of test requires knowledge of the internals of the `TimerStore`, so I added this test in `test_timer_store.cpp` not `test_timer_handler.cpp` (The handler tests should not care about how the store organises its data).
    * I added this UT in the first commit (https://github.com/Metaswitch/chronos/commit/a855ba5ed373f5c5b7c2b3a359b4229c2b5a17df). It basically ensures that it puts both timers into the same bucket in the short wheel.

1. In adding this UT, I found another bug, which caused my new UT to fail.
    * The bug was that if the `time_from` fell into a bucket which was "earlier" that the current time, we didn't set the `_end_bucket` correctly. e.g. if a wheel had 4 buckets, and the current time was in bucket 3 and `time_from` was in bucket 0, then we'd end up starting at bucket 0 and iterating until we hit bucket 7. Since the bucket indices are modulo 4, this meant we'd go through buckets 0, 1 and 2 twice.
    * I fixed this in the second commit (https://github.com/Metaswitch/chronos/commit/ec40c8fafd752854df6e8a6ed4b450937ebc574c). There's a fairly detailed comment in that commit, so I won't reproduce it here.
    * The UT I added in the first commit was testing this, so I didn't add any others for it.

1. Because we had separate long and short wheel iterators, it followed that the long wheel had the same bug. So I added a UT to verify that it did (https://github.com/Metaswitch/chronos/commit/4241a8b17d26be0aaaa3478f1f9837fa9c4d8ef5) which failed until I also fixed the bug for the long wheel (https://github.com/Metaswitch/chronos/commit/a284346ffd02fae6b147830300492e8de575c16d)

1. You'll have noticed that the short and long wheel iterators now have a whole load of duplicated code, so I wanted to refactor them. I wanted to do this after I had put in place all the UTs and got them passing, so I could verify that the small refactor didn't break things, which is why I did this separately.
    * I created a new `TSBaseWheelIterator` which both the `TSShortWheelIterator` and the `TSLongWheelIterator` inherit from.
    * I then commonalised all the methods from the two previous iterators into the base one, because they're fundamentally doing the same thing
    * I added virtual methods for the few things that are different (refilling the wheel, getting a bucket and rouding to the wheel resolution)
    * the last 4 commits (https://github.com/Metaswitch/chronos/pull/382/files/a284346ffd02fae6b147830300492e8de575c16d..7a2c799f84796d2da9fc385188e1b2c294da56d1) are this refactor